### PR TITLE
Add alerting feature

### DIFF
--- a/.test-defs/Conformance.yaml
+++ b/.test-defs/Conformance.yaml
@@ -16,7 +16,8 @@ kind: TestDefinition
 metadata:
   name: conformance
 spec:
-  owner: OutputQualification-Team
+  owner: oleg.loewen@sap.com
+  recipientsOnFailure: oleg.loewen@sap.com
 
   description: Run kubernetes conformance tests.
 

--- a/.test-defs/ItConfigSecret.yaml
+++ b/.test-defs/ItConfigSecret.yaml
@@ -16,7 +16,7 @@ kind: TestDefinition
 metadata:
   name: secret-config-testdef
 spec:
-  owner: OutputQualification-Team
+  owner: dummy@mail.com
 
   description: Tests mounting of configurations from secrets.
 

--- a/.test-defs/ItConfigValue.yaml
+++ b/.test-defs/ItConfigValue.yaml
@@ -16,7 +16,7 @@ kind: TestDefinition
 metadata:
   name: value-config-testdef
 spec:
-  owner: OutputQualification-Team
+  owner: dummy@mail.com
 
   description: Tests mounting of configurations from secrets.
 

--- a/.test-defs/ItExitHandlerTestDef.yaml
+++ b/.test-defs/ItExitHandlerTestDef.yaml
@@ -16,7 +16,7 @@ kind: TestDefinition
 metadata:
   name: exit-handler-testdef
 spec:
-  owner: OutputQualification-Team
+  owner: dummy@mail.com
 
   description: Tests the deployment of a guestbook app with redis.
 

--- a/.test-defs/ItFailingIntegrationTestDef.yaml
+++ b/.test-defs/ItFailingIntegrationTestDef.yaml
@@ -16,7 +16,7 @@ kind: TestDefinition
 metadata:
   name: failing-integration-testdef
 spec:
-  owner: OutputQualification-Team
+  owner: dummy@mail.com
 
   description: Tests the deployment of a guestbook app with redis.
 

--- a/.test-defs/ItIntegrationTestDef.yaml
+++ b/.test-defs/ItIntegrationTestDef.yaml
@@ -16,7 +16,8 @@ kind: TestDefinition
 metadata:
   name: integration-testdef
 spec:
-  owner: OutputQualification-Team
+  owner: dummy@mail.com
+
   description: Tests the deployment of a guestbook app with redis.
 
   labels: ["tm-integration"]

--- a/.test-defs/ItNameWithDotTestDef.yaml
+++ b/.test-defs/ItNameWithDotTestDef.yaml
@@ -16,7 +16,7 @@ kind: TestDefinition
 metadata:
   name: integration.testdef
 spec:
-  owner: OutputQualification-Team
+  owner: dummy@mail.com
 
   description: Tests the deployment of a guestbook app with redis.
 

--- a/.test-defs/ItSerialTestDef.yaml
+++ b/.test-defs/ItSerialTestDef.yaml
@@ -16,7 +16,7 @@ kind: TestDefinition
 metadata:
   name: serial-testdef
 spec:
-  owner: OutputQualification-Team
+  owner: dummy@mail.com
 
   description: Serial test step
 

--- a/cmd/testmachinery-run/main.go
+++ b/cmd/testmachinery-run/main.go
@@ -42,6 +42,7 @@ var (
 	outputFilePath          string
 	elasticSearchConfigName string
 	s3Endpoint              string
+	concourseOnErrorDir     string
 )
 
 func main() {
@@ -59,6 +60,7 @@ func main() {
 		OutputFile:           outputFilePath,
 		ESConfigName:         elasticSearchConfigName,
 		S3Endpoint:           s3Endpoint,
+		ConcourseOnErrorDir:  concourseOnErrorDir,
 	}
 
 	parameters := &testrunner.TestrunParameters{
@@ -112,5 +114,6 @@ func init() {
 	flag.StringVar(&outputFilePath, "output-file-path", "", "The filepath where the summary should be written to.")
 	flag.StringVar(&elasticSearchConfigName, "es-config-name", "", "The elasticsearch secret-server config name.")
 	flag.StringVar(&s3Endpoint, "s3-endpoint", os.Getenv("S3_ENDPOINT"), "S3 endpoint of the testmachinery cluster.")
+	flag.StringVar(&concourseOnErrorDir, "concourseOnErrorDir", os.Getenv("ON_ERROR_DIR"), "On error dir which is used by Concourse.")
 
 }

--- a/cmd/testmachinery-run/testrunner/testrunner.go
+++ b/cmd/testmachinery-run/testrunner/testrunner.go
@@ -49,11 +49,11 @@ var (
 func Run(config *TestrunConfig, parameters *TestrunParameters) {
 	log.Info("Get Testmachinery clients")
 
-	if config.ESConfigName != "" {
-		esCfgName = config.ESConfigName
+	if config.ESConfigName == "" {
+		config.ESConfigName = esCfgName
 	}
-	if config.OutputFile != "" {
-		outputFilePath = config.OutputFile
+	if config.OutputFile == "" {
+		config.OutputFile = outputFilePath
 	}
 	if config.Timeout != nil && *config.Timeout > -1 {
 		maxWaitTimeSeconds = *config.Timeout
@@ -137,7 +137,7 @@ func Run(config *TestrunConfig, parameters *TestrunParameters) {
 		time.Sleep(time.Duration(pollIntervalSeconds) * time.Second)
 	}
 
-	err = Output(config.TmKubeconfigPath, config.S3Endpoint, outputFilePath, tr, metadata)
+	err = Output(config, tr, metadata)
 	if err != nil {
 		log.Fatal(err.Error())
 	}

--- a/cmd/testmachinery-run/testrunner/types.go
+++ b/cmd/testmachinery-run/testrunner/types.go
@@ -48,6 +48,7 @@ type TestrunConfig struct {
 	OutputFile           string
 	ESConfigName         string
 	S3Endpoint           string
+	ConcourseOnErrorDir  string
 }
 
 // Metadata is the common metadata of all ouputs and summaries.

--- a/docs/GetStarted.md
+++ b/docs/GetStarted.md
@@ -16,7 +16,7 @@ The repository does not necessarily need to be public.
 But if it is private you need to grant the TestMachinery read access to this repository.
 
 Tests in the TestMachinery are configuration files called TestDefinitions which are located in the `repoRoot/.test-defs` folder.
-The TestMachinery automatically searches for testDefinitions files in all specified testlocations (see [testrun description](#create-a-testrun) for more information).
+The TestMachinery automatically searches for TestDefinitions files in all specified testlocations (see [testrun description](#create-a-testrun) for more information).
 A TestDefinition consists of a name and a description of how the test should be executed by the TestMachinery.
 Therefore, a basic test consists of a command which will be executed inside the specified container image.
 
@@ -24,7 +24,8 @@ Therefore, a basic test consists of a command which will be executed inside the 
 metadata:
   name: TestDefName
 spec:
-  owner: Gardener-Team # optional
+  owner: gardener@team.de # test owner and contact person in case of a test failure 
+  recipientsOnFailure: developer1@team.de, developer2@team.de # optional, list of emails to be notified if a step fails 
   description: test # optional; description of the test.
 
   activeDeadlineSeconds: 600 # optional; maximum seconds to wait for the test to finish.

--- a/examples/GuestbookTestDef.yaml
+++ b/examples/GuestbookTestDef.yaml
@@ -14,7 +14,8 @@
 
 kind: TestDefinition
 metadata:
-  name: GuestbookTestDef
+  name: owner@company.com
+  recipientsOnFailure: developer1@company.com, developer2@company.com
 spec:
   owner: OutputQualification-Team
 

--- a/pkg/apis/testmachinery/v1beta1/types.go
+++ b/pkg/apis/testmachinery/v1beta1/types.go
@@ -126,8 +126,10 @@ type TestflowStepStatus struct {
 
 // TestflowStepStatusTestDefinition holds information about the used testdefinition and its location.
 type TestflowStepStatusTestDefinition struct {
-	Name     string       `json:"name,omitempty"`
-	Location TestLocation `json:"location,omitempty"`
+	Name                string       `json:"name,omitempty"`
+	Location            TestLocation `json:"location,omitempty"`
+	Owner               string       `json:"owner,omitempty"`
+	RecipientsOnFailure string       `json:"recipientsOnFailure"`
 }
 
 // TestLocation describes a location to search for TestDefinitions.
@@ -198,6 +200,7 @@ type TestDefMetadata struct {
 // TestDefSpec is the actual description of the test.
 type TestDefSpec struct {
 	Owner                 string          `json:"owner" yaml:"owner"`
+	RecipientsOnFailure   string          `json:"recipientsOnFailure" yaml:"recipientsOnFailure"`
 	Description           string          `json:"description" yaml:"description"`
 	Labels                []string        `json:"labels" yaml:"labels"`
 	Behavior              []string        `json:"behavior" yaml:"behavior"`

--- a/pkg/controller/testrun_control_complete.go
+++ b/pkg/controller/testrun_control_complete.go
@@ -73,8 +73,10 @@ func (r *TestrunReconciler) completeTestrun(ctx context.Context, tr *tmv1beta1.T
 				Duration:          int64(d.Seconds()),
 				ExportArtifactKey: getNodeExportKey(status.Outputs),
 				TestDefinition: tmv1beta1.TestflowStepStatusTestDefinition{
-					Name:     node.TestDefinition.Info.Metadata.Name,
-					Location: *node.TestDefinition.Location.GetLocation(),
+					Name:                node.TestDefinition.Info.Metadata.Name,
+					Location:            *node.TestDefinition.Location.GetLocation(),
+					Owner:               node.TestDefinition.Info.Spec.Owner,
+					RecipientsOnFailure: node.TestDefinition.Info.Spec.RecipientsOnFailure,
 				},
 			})
 		}

--- a/pkg/testmachinery/testdefinition/validation_test.go
+++ b/pkg/testmachinery/testdefinition/validation_test.go
@@ -43,15 +43,16 @@ var _ = Describe("TestDefinition Validation", func() {
 				},
 				Spec: tmv1beta1.TestDefSpec{
 					Command: []string{"bash"},
+					Owner:   "test@corp.com",
 				},
 			}
 		})
 
-		It("should succed when a name and a command is defined", func() {
+		It("should succeed when a name and a command is defined", func() {
 			Expect(testdefinition.Validate("identifier", testdef)).ToNot(HaveOccurred())
 		})
 
-		It("should succed when a name contains '-'", func() {
+		It("should succeed when a name contains '-'", func() {
 			testdef.Metadata.Name = "test-name"
 			Expect(testdefinition.Validate("identifier", testdef)).ToNot(HaveOccurred())
 		})
@@ -73,6 +74,31 @@ var _ = Describe("TestDefinition Validation", func() {
 
 		It("should fail when no command is defined", func() {
 			testdef.Spec.Command = []string{}
+			Expect(testdefinition.Validate("identifier", testdef)).To(HaveOccurred())
+		})
+
+		It("should fail if no Owner is defined", func() {
+			testdef.Spec.Owner = ""
+			Expect(testdefinition.Validate("identifier", testdef)).To(HaveOccurred())
+		})
+
+		It("should succeed when valid recipient is defined", func() {
+			testdef.Spec.RecipientsOnFailure = "test@corp.com"
+			Expect(testdefinition.Validate("identifier", testdef)).ToNot(HaveOccurred())
+		})
+
+		It("should succeed when valid recipient list is defined", func() {
+			testdef.Spec.RecipientsOnFailure = "test@corp.com, test2@corp.com"
+			Expect(testdefinition.Validate("identifier", testdef)).ToNot(HaveOccurred())
+		})
+
+		It("should fail if any of recipient emails is invalid email", func() {
+			testdef.Spec.RecipientsOnFailure = "test@corp.com, test2corp.com"
+			Expect(testdefinition.Validate("identifier", testdef)).To(HaveOccurred())
+		})
+
+		It("should fail when the recipient email is not a valid email", func() {
+			testdef.Spec.RecipientsOnFailure = "testcorp.com"
 			Expect(testdefinition.Validate("identifier", testdef)).To(HaveOccurred())
 		})
 	})

--- a/pkg/testmachinery/testflow/testflow_suite_test.go
+++ b/pkg/testmachinery/testflow/testflow_suite_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Testflow", func() {
 							FileName: "file.name",
 							Info: &tmv1beta1.TestDefinition{
 								Metadata: tmv1beta1.TestDefMetadata{Name: "testdefname"},
-								Spec:     tmv1beta1.TestDefSpec{Command: []string{"bash"}},
+								Spec:     tmv1beta1.TestDefSpec{Command: []string{"bash"}, Owner: "user@company.com"},
 							},
 						},
 					}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds alerting to the testrunner so that test `recipientsOnFailure` of failing tests get notified.

**Release note**:
```improvement user
Add alerting