### PR TITLE
Add support for components descriptors

### DIFF
--- a/charts/testmachinery/values.yaml
+++ b/charts/testmachinery/values.yaml
@@ -23,7 +23,7 @@ controller:
 
   steps:
     baseImage: eu.gcr.io/gardener-project/gardener/testmachinery/base-step:0.28.0
-    prepareImage: eu.gcr.io/gardener-project/gardener/testmachinery/prepare-step:0.28.0
+    prepareImage: eu.gcr.io/gardener-project/gardener/testmachinery/prepare-step:0.29.0
 
   serviceAccountName: testmachinery-controller
   webhook:

--- a/cmd/testmachinery-run/main.go
+++ b/cmd/testmachinery-run/main.go
@@ -28,20 +28,20 @@ import (
 )
 
 var (
-	gardenKubeconfigPath string
-	tmKubeconfigPath     string
-	testrunChartPath     string
-	projectName          string
-	shootName            string
-	landscape            string
-	cloudprovider        string
-	cloudprofile         string
-	secretBinding        string
-	region               string
-	zone                 string
-	k8sVersion           string
-	bom                  string
-	timeout              int64
+	gardenKubeconfigPath     string
+	tmKubeconfigPath         string
+	testrunChartPath         string
+	projectName              string
+	shootName                string
+	landscape                string
+	cloudprovider            string
+	cloudprofile             string
+	secretBinding            string
+	region                   string
+	zone                     string
+	k8sVersion               string
+	componenetDescriptorPath string
+	timeout                  int64
 
 	outputFilePath          string
 	elasticSearchConfigName string
@@ -71,16 +71,16 @@ func main() {
 		TestrunName:      testrunName,
 		TestrunChartPath: testrunChartPath,
 
-		ProjectName:   projectName,
-		ShootName:     shootName,
-		Landscape:     landscape,
-		Cloudprovider: cloudprovider,
-		Cloudprofile:  cloudprofile,
-		SecretBinding: secretBinding,
-		Region:        region,
-		Zone:          zone,
-		K8sVersion:    k8sVersion,
-		BOM:           bom,
+		ProjectName:             projectName,
+		ShootName:               shootName,
+		Landscape:               landscape,
+		Cloudprovider:           cloudprovider,
+		Cloudprofile:            cloudprofile,
+		SecretBinding:           secretBinding,
+		Region:                  region,
+		Zone:                    zone,
+		K8sVersion:              k8sVersion,
+		ComponentDescriptorPath: componenetDescriptorPath,
 	}
 
 	testrunner.Run(config, parameters)
@@ -121,7 +121,7 @@ func init() {
 	flag.StringVar(&region, "region", "", "Region where the shoot is created.")
 	flag.StringVar(&zone, "zone", "", "Zone of the shoot worker nodes. Not required for azure shoots.")
 	flag.StringVar(&k8sVersion, "k8s-version", "", "Kubernetes version of the shoot.")
-	flag.StringVar(&bom, "bom", "", "Component versions of the currently deployed landscape.")
+	flag.StringVar(&componenetDescriptorPath, "component-descriptor-path", "", "Path to the component descriptor (BOM) of the current landscape.")
 
 	flag.StringVar(&outputFilePath, "output-file-path", "", "The filepath where the summary should be written to.")
 	flag.StringVar(&elasticSearchConfigName, "es-config-name", "", "The elasticsearch secret-server config name.")

--- a/cmd/testmachinery-run/testrunner/componentdescriptor/componentdescriptor.go
+++ b/cmd/testmachinery-run/testrunner/componentdescriptor/componentdescriptor.go
@@ -1,0 +1,62 @@
+// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package componentdescriptor
+
+import (
+	yaml "gopkg.in/yaml.v2"
+)
+
+// GetComponents returns a list of all git/component dependencies.
+func GetComponents(content []byte) ([]*Component, error) {
+
+	components := components{
+		components:   make([]*Component, 0, 0),
+		componentSet: make(map[Component]bool),
+	}
+
+	componentDescriptor, err := parse(content)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, component := range componentDescriptor.Components {
+		components.add(component.Dependencies.Components)
+	}
+
+	return components.components, nil
+}
+
+func (c *components) add(newComponents []Component) {
+	for _, item := range newComponents {
+		component := item
+		if !c.has(component) {
+			c.components = append(c.components, &component)
+			c.componentSet[component] = true
+		}
+	}
+}
+
+func (c *components) has(newComponent Component) bool {
+	_, ok := c.componentSet[newComponent]
+	return ok
+}
+
+func parse(content []byte) (*descriptor, error) {
+	var d = &descriptor{}
+	err := yaml.Unmarshal(content, d)
+	if err != nil {
+		return nil, err
+	}
+	return d, nil
+}

--- a/cmd/testmachinery-run/testrunner/componentdescriptor/componentdescriptor_test.go
+++ b/cmd/testmachinery-run/testrunner/componentdescriptor/componentdescriptor_test.go
@@ -1,0 +1,62 @@
+// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package componentdescriptor
+
+import (
+	"io/ioutil"
+	"reflect"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ComponentDescriptor Suite")
+}
+
+var _ = Describe("componentdescriptor test", func() {
+	It("Should parse a component descriptor and return 2 dependencies", func() {
+		input, err := ioutil.ReadFile("./testdata/component_descriptor_1")
+		Expect(err).ToNot(HaveOccurred(), "Cannot read json file from ./testdata/component_descriptor_1")
+
+		dependencies, err := GetComponents(input)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(len(dependencies)).To(Equal(2))
+	})
+
+	It("Should parse a component descriptor and ignore duplicates", func() {
+		input, err := ioutil.ReadFile("./testdata/component_descriptor_2")
+		Expect(err).ToNot(HaveOccurred(), "Cannot read json file from ./testdata/component_descriptor_2")
+
+		result := []*Component{
+			&Component{
+				Name:    "repo1",
+				Version: "0.17.0",
+			},
+			&Component{
+				Name:    "repo2",
+				Version: "1.27.0",
+			},
+		}
+
+		dependencies, err := GetComponents(input)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(len(dependencies)).To(Equal(2), "There should be 2 dependencies")
+		Expect(reflect.DeepEqual(dependencies, result)).To(BeTrue())
+	})
+})

--- a/cmd/testmachinery-run/testrunner/componentdescriptor/testdata/component_descriptor_1
+++ b/cmd/testmachinery-run/testrunner/componentdescriptor/testdata/component_descriptor_1
@@ -1,0 +1,5 @@
+components:
+- dependencies:
+    components:
+    - {name: github.com/gardener/gardener, version: 0.17.0}
+    - {name: github.com/gardener/dashboard, version: 1.27.0}

--- a/cmd/testmachinery-run/testrunner/componentdescriptor/testdata/component_descriptor_2
+++ b/cmd/testmachinery-run/testrunner/componentdescriptor/testdata/component_descriptor_2
@@ -1,0 +1,8 @@
+components:
+- dependencies:
+    components:
+    - {name: repo1, version: 0.17.0}
+    - {name: repo2, version: 1.27.0}
+- dependencies:
+    components:
+    - {name: repo1, version: 0.17.0}

--- a/cmd/testmachinery-run/testrunner/componentdescriptor/types.go
+++ b/cmd/testmachinery-run/testrunner/componentdescriptor/types.go
@@ -1,0 +1,38 @@
+// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package componentdescriptor
+
+// Component describes a component consisting of the git repository url and a version.
+type Component struct {
+	Name    string `yaml:"name"`
+	Version string `yaml:"version"`
+}
+
+type components struct {
+	components   []*Component
+	componentSet map[Component]bool
+}
+
+type descriptor struct {
+	Components []dependencies `yaml:"components"`
+}
+
+type dependencies struct {
+	Dependencies dependency `yaml:"dependencies"`
+}
+
+type dependency struct {
+	Name       string      `yaml:"name"`
+	Components []Component `yaml:"components"`
+}

--- a/cmd/testmachinery-run/testrunner/elasticsearch/elasticsearch_suite_test.go
+++ b/cmd/testmachinery-run/testrunner/elasticsearch/elasticsearch_suite_test.go
@@ -39,9 +39,6 @@ var (
 )
 
 var _ = Describe("elasticsearch test", func() {
-	BeforeSuite(func() {
-
-	})
 
 	Context("Parse default json format", func() {
 		It("should parse default json and add testmachinery index", func() {

--- a/cmd/testmachinery-run/testrunner/output.go
+++ b/cmd/testmachinery-run/testrunner/output.go
@@ -199,6 +199,7 @@ func getExportedDocuments(cfg *testmachinery.ObjectStoreConfig, status tmv1beta1
 					Metadata:    *metadata,
 					TestDefName: step.TestDefinition.Name,
 					Phase:       step.Phase,
+					StartTime:   step.StartTime,
 					Duration:    step.Duration,
 				}
 				reader, err := minioClient.GetObject(cfg.BucketName, step.ExportArtifactKey, minio.GetObjectOptions{})

--- a/cmd/testmachinery-run/testrunner/testrunner.go
+++ b/cmd/testmachinery-run/testrunner/testrunner.go
@@ -15,11 +15,12 @@
 package testrunner
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"time"
+
+	"github.com/gardener/test-infra/cmd/testmachinery-run/testrunner/componentdescriptor"
 
 	tmv1beta1 "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
 	"github.com/gardener/test-infra/pkg/util"
@@ -64,13 +65,16 @@ func Run(config *TestrunConfig, parameters *TestrunParameters) {
 		CloudProvider:     parameters.Cloudprovider,
 		KubernetesVersion: parameters.K8sVersion,
 	}
-	if parameters.BOM != "" {
-		var jsonBody interface{}
-		err := json.Unmarshal([]byte(parameters.BOM), &jsonBody)
+	if parameters.ComponentDescriptorPath != "" {
+		data, err := ioutil.ReadFile(parameters.ComponentDescriptorPath)
 		if err != nil {
-			log.Warnf("Cannot decode BOM %s", err.Error())
+			log.Warnf("Cannot read component descriptor file %s: %s", parameters.ComponentDescriptorPath, err.Error())
+		}
+		components, err := componentdescriptor.GetComponents(data)
+		if err != nil {
+			log.Warnf("Cannot decode and parse BOM %s", err.Error())
 		} else {
-			metadata.BOM = jsonBody
+			metadata.BOM = components
 		}
 	}
 

--- a/cmd/testmachinery-run/testrunner/types.go
+++ b/cmd/testmachinery-run/testrunner/types.go
@@ -71,6 +71,7 @@ type StepExportMetadata struct {
 	Metadata
 	TestDefName string           `json:"testdefinition"`
 	Phase       argov1.NodePhase `json:"phase,omitempty"`
+	StartTime   *metav1.Time     `json:"startTime,omitempty"`
 	Duration    int64            `json:"duration,omitempty"`
 }
 

--- a/cmd/testmachinery-run/testrunner/types.go
+++ b/cmd/testmachinery-run/testrunner/types.go
@@ -31,16 +31,16 @@ type TestrunParameters struct {
 	TestrunName      string
 	TestrunChartPath string
 
-	ProjectName   string
-	ShootName     string
-	Landscape     string
-	Cloudprovider string
-	Cloudprofile  string
-	SecretBinding string
-	Region        string
-	Zone          string
-	K8sVersion    string
-	BOM           string
+	ProjectName             string
+	ShootName               string
+	Landscape               string
+	Cloudprovider           string
+	Cloudprofile            string
+	SecretBinding           string
+	Region                  string
+	Zone                    string
+	K8sVersion              string
+	ComponentDescriptorPath string
 }
 
 // TestrunConfig are configuration of the evironment like the testmachinery cluster or S3 store


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support for component descriptors.
For now a component_descriptor file can be parsed and will be added to the tm metadata.
In the future, the testrunner should also dynamically add the github repositories to the testrun locations.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement
- target_group:   user
-->
```improvement user
Add parsing of component_descriptor files (BOM)
