### PR TITLE
Add support for all input parameters of create-shoot

### DIFF
--- a/cmd/testmachinery-run/main.go
+++ b/cmd/testmachinery-run/main.go
@@ -35,6 +35,10 @@ var (
 	shootName            string
 	landscape            string
 	cloudprovider        string
+	cloudprofile         string
+	secretBinding        string
+	region               string
+	zone                 string
 	k8sVersion           string
 	bom                  string
 	timeout              int64
@@ -106,6 +110,10 @@ func init() {
 
 	flag.StringVar(&landscape, "landscape", "", "Current gardener landscape.")
 	flag.StringVar(&cloudprovider, "cloudprovider", "", "Cloudprovider where the shoot is created.")
+	flag.StringVar(&cloudprofile, "cloudprofile", "", "Cloudprofile of shoot.")
+	flag.StringVar(&secretBinding, "secret-binding", "", "SecretBinding that should be used to create the shoot.")
+	flag.StringVar(&region, "region", "", "Region where the shoot is created.")
+	flag.StringVar(&zone, "zone", "", "Zone of the shoot worker nodes. Not required for azure shoots.")
 	flag.StringVar(&k8sVersion, "k8s-version", "", "Kubernetes version of the shoot.")
 	flag.StringVar(&bom, "bom", "", "Component versions of the currently deployed landscape.")
 

--- a/cmd/testmachinery-run/testrunner/testrunner.go
+++ b/cmd/testmachinery-run/testrunner/testrunner.go
@@ -104,6 +104,10 @@ func Run(config *TestrunConfig, parameters *TestrunParameters) {
 			"name":             parameters.ShootName,
 			"projectNamespace": fmt.Sprintf("garden-%s", parameters.ProjectName),
 			"cloudprovider":    parameters.Cloudprovider,
+			"cloudprofile":     parameters.Cloudprofile,
+			"secretBinding":    parameters.SecretBinding,
+			"region":           parameters.Region,
+			"zone":             parameters.Zone,
 			"k8sVersion":       parameters.K8sVersion,
 		},
 		"kubeconfigs": map[string]interface{}{

--- a/cmd/testmachinery-run/testrunner/types.go
+++ b/cmd/testmachinery-run/testrunner/types.go
@@ -35,6 +35,10 @@ type TestrunParameters struct {
 	ShootName     string
 	Landscape     string
 	Cloudprovider string
+	Cloudprofile  string
+	SecretBinding string
+	Region        string
+	Zone          string
 	K8sVersion    string
 	BOM           string
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support for all new values needed by create-shoot.
https://github.com/gardener/gardener/pull/712

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
