### PR TITLE
Remove pods when workflow is finished

### DIFF
--- a/docs/Testmachinery.md
+++ b/docs/Testmachinery.md
@@ -1,0 +1,16 @@
+# Testmachinery
+
+
+## Controller
+
+| Name                | default                                                                 | Description                                                                                               |
+| ------------------- | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| TM_NAMESPACE        | "default"                                                               | Namespace where the testmachinery-controller runs                                                         |
+| PREPARE_IMAGE       | "eu.gcr.io/gardener-project/gardener/testmachinery/prepare-step:0.28.0" | Image that is used in the prepare step.                                                                   |
+| BASE_IMAGE          | "default"                                                               | Default image for test defintion with no explicit image.                                                  |
+| CLEAN_WORKFLOW_PODS | "false"                                                                 | Deletes all pods when a workflow is finished. Logs are still accessible.                                  |
+| S3_ENDPOINT         | ""                                                                      | Endpoint url of the minio/s3 instance where argo stores it's artifacts (e.g. minio-service.deafult:9000). |
+| S3_ACCESS_KEY       | ""                                                                      | Minio/S3 access key                                                                                       |
+| S3_SECRET_KEY       | ""                                                                      | Minio/S3 secret key                                                                                       |
+| S3_BUCKET_NAME      | ""                                                                      | Minio/S3 bucket name, where argo stores it's artifacts.                                                   |
+| GIT_SECRETS         | ""                                                                      | Github configuration with technical users and endpoint information.                                       |

--- a/pkg/testmachinery/garbagecollection/workflow.go
+++ b/pkg/testmachinery/garbagecollection/workflow.go
@@ -1,0 +1,38 @@
+package garbagecollection
+
+import (
+	"context"
+
+	log "github.com/sirupsen/logrus"
+
+	argov1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
+	"github.com/gardener/test-infra/pkg/testmachinery"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// CleanWorkflowPods deletes all pods of a completed workflow.
+// cleanup pods to remove workload from the api server adn etcd.
+// logs are still accessible through "archiveLogs" option in argo
+func CleanWorkflowPods(c client.Client, wf *argov1.Workflow) {
+	if testmachinery.GetConfig().CleanWorkflowPods {
+		for nodeName, node := range wf.Status.Nodes {
+			if node.Type == argov1.NodeTypePod {
+				if err := deletePod(c, testmachinery.GetConfig().Namespace, nodeName); err != nil {
+					log.Debugf("Cannot delete pod %s: %s", nodeName, err.Error())
+				}
+			}
+		}
+	}
+}
+
+func deletePod(c client.Client, namesapce, name string) error {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namesapce,
+		},
+	}
+	return c.Delete(context.TODO(), pod)
+}

--- a/pkg/testmachinery/testdefinition/prepare.go
+++ b/pkg/testmachinery/testdefinition/prepare.go
@@ -42,6 +42,7 @@ func NewPrepare(name string, kubeconfigs tmv1beta1.TestrunKubeconfigs) *PrepareD
 				"testmachinery.sapcloud.io/TestDefinition": "Prepare",
 			},
 		},
+		ActiveDeadlineSeconds: &activeDeadlineSeconds,
 		Container: &apiv1.Container{
 			Image:   testmachinery.PREPARE_IMAGE,
 			Command: []string{"/tm/prepare", "/tm/repos.json"},

--- a/pkg/testmachinery/testmachinery.go
+++ b/pkg/testmachinery/testmachinery.go
@@ -38,9 +38,10 @@ func Setup() {
 	}
 
 	tmConfig = &TmConfiguration{
-		Namespace:  util.Getenv("TM_NAMESPACE", "default"),
-		Insecure:   false,
-		GitSecrets: gitSecrets.Secrets,
+		Namespace:         util.Getenv("TM_NAMESPACE", "default"),
+		Insecure:          false,
+		CleanWorkflowPods: util.GetenvBool("CLEAN_WORKFLOW_PODS", false),
+		GitSecrets:        gitSecrets.Secrets,
 		ObjectStore: &ObjectStoreConfig{
 			Endpoint:   os.Getenv("S3_ENDPOINT"),
 			AccessKey:  os.Getenv("S3_ACCESS_KEY"),

--- a/pkg/testmachinery/types.go
+++ b/pkg/testmachinery/types.go
@@ -46,10 +46,11 @@ var (
 
 // TmConfiguration is an object containing the actual configuration of the Testmachinery
 type TmConfiguration struct {
-	Namespace   string
-	Insecure    bool
-	GitSecrets  []*GitConfig
-	ObjectStore *ObjectStoreConfig
+	Namespace         string
+	Insecure          bool
+	CleanWorkflowPods bool
+	GitSecrets        []*GitConfig
+	ObjectStore       *ObjectStoreConfig
 }
 
 // ObjectStoreConfig is an object containing the ObjectStore specific configuration

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"os"
 	"regexp"
+	"strconv"
 	"time"
 
 	argov1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
@@ -105,11 +106,23 @@ func DownloadFile(client *http.Client, url string) ([]byte, error) {
 	return data, nil
 }
 
-// Getenv returns the value of the environment varibale with the key if the env var exists.
+// Getenv returns the string value of the environment varibale with the provided key if the env var exists.
 // Otherwise the default value is returned
 func Getenv(key, defaultValue string) string {
 	if os.Getenv(key) != "" {
 		return os.Getenv(key)
+	}
+	return defaultValue
+}
+
+// GetenvBool returns the boolean value of the environment varibale with the provided key if the env var exists and can be parsed.
+// Otherwise the default value is returned
+func GetenvBool(key string, defaultValue bool) bool {
+	env := os.Getenv(key)
+	if env != "" {
+		if b, err := strconv.ParseBool(env); err == nil {
+			return b
+		}
 	}
 	return defaultValue
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the feature to configure if all pods of a workflow should be deleted when the workflow itself has finished.

This feature can be toggled by setting the environment variable "CLEAN_WORKFLOW_PODS"


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Adds configurable cleanup of pods when workflow has finished
```
