### PR TITLE
Refactor notifications to use go struct instead of string concatination

### DIFF
--- a/cmd/testmachinery-run/testrunner/types.go
+++ b/cmd/testmachinery-run/testrunner/types.go
@@ -94,3 +94,14 @@ type StepSummary struct {
 	StartTime *metav1.Time     `json:"startTime,omitempty"`
 	Duration  int64            `json:"duration,omitempty"`
 }
+
+// notificationConfig is the configuration that is used by concourse to send notifications.
+type notificationCfg struct {
+	Email email `yaml:"email"`
+}
+
+type email struct {
+	Subject    string   `yaml:"subject"`
+	Recipients []string `yaml:"recipients"`
+	MailBody   string   `yaml:"mail_body"`
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Refactor notifications to use go struct instead of strings concatination.

** Note for Reviewers**:
@OlegLoewen can you please check if the body can be encoded like this?
```
email_body: "test \n test"
```

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
