### PR TITLE
Add machine type and autoscaler to testrunner

### DIFF
--- a/cmd/testmachinery-run/main.go
+++ b/cmd/testmachinery-run/main.go
@@ -41,6 +41,9 @@ var (
 	region                   string
 	zone                     string
 	k8sVersion               string
+	machineType              string
+	autoscalerMin            string
+	autoscalerMax            string
 	componenetDescriptorPath string
 	timeout                  int64
 
@@ -55,7 +58,7 @@ func main() {
 
 	flag.Parse()
 
-	shootName = fmt.Sprintf("%s-%s-%s", shootName, cloudprovider, util.RandomString(5))
+	shootName = fmt.Sprintf("%s-%s", shootName, util.RandomString(5))
 	testrunName := fmt.Sprintf("%s%s", testrunNamePrefix, util.RandomString(5))
 
 	config := &testrunner.TestrunConfig{
@@ -81,6 +84,9 @@ func main() {
 		Region:                  region,
 		Zone:                    zone,
 		K8sVersion:              k8sVersion,
+		MachineType:             machineType,
+		AutoscalerMin:           autoscalerMin,
+		AutoscalerMax:           autoscalerMax,
 		ComponentDescriptorPath: componenetDescriptorPath,
 	}
 
@@ -123,6 +129,9 @@ func init() {
 	flag.StringVar(&region, "region", "", "Region where the shoot is created.")
 	flag.StringVar(&zone, "zone", "", "Zone of the shoot worker nodes. Not required for azure shoots.")
 	flag.StringVar(&k8sVersion, "k8s-version", "", "Kubernetes version of the shoot.")
+	flag.StringVar(&machineType, "machinetype", "", "Machinetype of the shoot's worker nodes.")
+	flag.StringVar(&autoscalerMin, "autoscaler-min", "", "Min number of worker nodes.")
+	flag.StringVar(&autoscalerMax, "autoscaler-max", "", "Max number of worker nodes.")
 	flag.StringVar(&componenetDescriptorPath, "component-descriptor-path", "", "Path to the component descriptor (BOM) of the current landscape.")
 
 	flag.StringVar(&outputFilePath, "output-file-path", "", "The filepath where the summary should be written to.")

--- a/cmd/testmachinery-run/testrunner/testrunner.go
+++ b/cmd/testmachinery-run/testrunner/testrunner.go
@@ -113,6 +113,9 @@ func Run(config *TestrunConfig, parameters *TestrunParameters) {
 			"region":           parameters.Region,
 			"zone":             parameters.Zone,
 			"k8sVersion":       parameters.K8sVersion,
+			"machinetype":      parameters.MachineType,
+			"autoscalerMin":    parameters.AutoscalerMin,
+			"autoscalerMax":    parameters.AutoscalerMax,
 		},
 		"kubeconfigs": map[string]interface{}{
 			"gardener": string(gardenKubeconfig),

--- a/cmd/testmachinery-run/testrunner/types.go
+++ b/cmd/testmachinery-run/testrunner/types.go
@@ -19,8 +19,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// SummaryType defines the type of a test result or summary
 type SummaryType string
 
+// Summary types can be testrun or teststep
 const (
 	SummaryTypeTestrun  SummaryType = "testrun"
 	SummaryTypeTeststep SummaryType = "teststep"
@@ -40,6 +42,9 @@ type TestrunParameters struct {
 	Region                  string
 	Zone                    string
 	K8sVersion              string
+	MachineType             string
+	AutoscalerMin           string
+	AutoscalerMax           string
 	ComponentDescriptorPath string
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds shoot machine type and autoscaler configuration to the testrunner.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
Add machinetype and autoscaler configuration to testrunner
```
