### PR TITLE
Refactor testrunner polling

### DIFF
--- a/pkg/testrunner/run.go
+++ b/pkg/testrunner/run.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gardener/test-infra/pkg/util"
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 func addBOMLocationsToTestrun(tr *tmv1beta1.Testrun, componenets []*componentdescriptor.Component) {
@@ -41,14 +42,9 @@ func runTestrun(tmClient *tmclientset.Clientset, tr *tmv1beta1.Testrun, paramete
 	log.Infof("Testrun %s deployed", tr.Name)
 
 	testrunPhase := tmv1beta1.PhaseStatusInit
-	startTime := time.Now()
-	for !util.Completed(testrunPhase) {
-		var err error
-
-		if util.MaxTimeExceeded(startTime, maxWaitTimeSeconds) {
-			log.Fatalf("Maximum wait time of %d is exceeded by Testrun %s", maxWaitTimeSeconds, parameters.TestrunName)
-		}
-
+	interval := time.Duration(pollIntervalSeconds) * time.Second
+	timeout := time.Duration(maxWaitTimeSeconds) * time.Second
+	err = wait.PollImmediate(interval, timeout, func() (bool, error) {
 		tr, err = tmClient.Testmachinery().Testruns(namespace).Get(tr.Name, metav1.GetOptions{})
 		if err != nil {
 			log.Errorf("Cannot get testrun: %s", err.Error())
@@ -62,8 +58,10 @@ func runTestrun(tmClient *tmclientset.Clientset, tr *tmv1beta1.Testrun, paramete
 		} else {
 			log.Infof("Testrun %s is in %s phase. Waiting ...", tr.Name, testrunPhase)
 		}
-
-		time.Sleep(time.Duration(pollIntervalSeconds) * time.Second)
+		return util.Completed(testrunPhase), nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("Maximum wait time of %d is exceeded by Testrun %s", maxWaitTimeSeconds, parameters.TestrunName)
 	}
 
 	return tr, nil

--- a/pkg/testrunner/testrunner.go
+++ b/pkg/testrunner/testrunner.go
@@ -129,6 +129,7 @@ func runChart(tmClient *tmclientset.Clientset, chart *chartrenderer.RenderedChar
 			tr, err := runTestrun(tmClient, tr, parameters)
 			if err != nil {
 				log.Error(err.Error())
+				tr.Status.Phase = argov1.NodeFailed
 			}
 			mutex.Lock()
 			finishedTestruns = append(finishedTestruns, tr)


### PR DESCRIPTION
**What this PR does / why we need it**:
Use more stable apimachinery polling function to wait for the testrun to finish.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
