### PR TITLE
Update golang to 1.12.0

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -29,9 +29,9 @@ test-infra:
               tag_as_latest: true
     ti_test_steps: &ti_test_steps
       check:
-        image: 'golang:1.11.1'
+        image: 'golang:1.12.0'
       test:
-        image: 'golang:1.11.1'
+        image: 'golang:1.12.0'
 
   jobs:
     head-update:

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 #############      builder       #############
-FROM golang:1.11.1 AS builder
+FROM golang:1.12.0 AS builder
 
 WORKDIR /go/src/github.com/gardener/test-infra
 COPY . .

--- a/hack/images/golang/Dockerfile
+++ b/hack/images/golang/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.1 AS ginkgo
+FROM golang:1.12.0 AS ginkgo
 
 RUN go get -u github.com/onsi/ginkgo/ginkgo
 


### PR DESCRIPTION
**What this PR does / why we need it**:
https://golang.org/doc/go1.12

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
The golang version has been upgraded to `v1.12.0`.
```
