### PR TITLE
Upgrade to alpine 3.9 and kubectl 1.13.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go install \
   ./cmd/...
 
 ############# tm-controller #############
-FROM alpine:3.8 AS tm-controller
+FROM alpine:3.9 AS tm-controller
 
 RUN apk add --update bash curl
 
@@ -35,10 +35,9 @@ WORKDIR /
 ENTRYPOINT ["/testmachinery-controller"]
 
 ############# tm-run #############
-FROM eu.gcr.io/gardener-project/cc/job-image:1.101.0 AS tm-run
+FROM eu.gcr.io/gardener-project/gardener/testmachinery/base-step:0.32.0 AS tm-run
 
 COPY --from=builder /go/bin/testrunner /testrunner
-COPY ./.env /
 
 WORKDIR /
 

--- a/hack/images/base/Dockerfile
+++ b/hack/images/base/Dockerfile
@@ -1,7 +1,7 @@
-FROM golang:1.11.5-alpine3.8
+FROM golang:1.12-alpine3.9
 
-ENV HELM_TILLER_VERSION=v2.12.1
-ENV KUBECTL_VERSION=v1.12.3
+ENV HELM_TILLER_VERSION=v2.13.0
+ENV KUBECTL_VERSION=v1.13.4
 
 RUN  \
   echo '@edge http://nl.alpinelinux.org/alpine/edge/main' >> /etc/apk/repositories \

--- a/hack/images/prepare/Dockerfile
+++ b/hack/images/prepare/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/gardener-project/gardener/testmachinery/base-step:0.28.0 AS tm-prepare
+FROM eu.gcr.io/gardener-project/gardener/testmachinery/base-step:0.32.0 AS tm-prepare
 
 COPY ./prepare /tm/prepare
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrades various images to alpine 3.9.
Upgrade kubectl and helm version of base image.
Use base image for testrunner.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Upgrade alpine to 3.9
```
```improvement operator
Upgrade kubectl to 1.13.45 and helm to 2.13.0
```
```improvement operator
Use Test Machinery base image for Testrunner
```
