### PR TITLE
Add "ingested" status to a testruns status

### DIFF
--- a/cmd/testrunner/cmd/runtestrun/run_testrun.go
+++ b/cmd/testrunner/cmd/runtestrun/run_testrun.go
@@ -96,7 +96,7 @@ func init() {
 	runTestrunCmd.Flags().StringVar(&tmKubeconfigPath, "tm-kubeconfig-path", "", "Path to the testmachinery cluster kubeconfig")
 	runTestrunCmd.MarkFlagRequired("tm-kubeconfig-path")
 	runTestrunCmd.MarkFlagFilename("tm-kubeconfig-path")
-	runTestrunCmd.Flags().StringVarP(&namespace, "namespace", "n", "default", "Namesapce where the testrun should be deployed.")
+	runTestrunCmd.Flags().StringVarP(&namespace, "namespace", "n", "default", "Namespace where the testrun should be deployed.")
 
 	runTestrunCmd.Flags().Int64Var(&timeout, "timeout", 3600, "Timout in seconds of the testrunner to wait for the complete testrun to finish.")
 	runTestrunCmd.Flags().Int64Var(&interval, "interval", 20, "Poll interval in seconds of the testrunner to poll for the testrun status.")

--- a/docs/testrunner/testrunner_run-testrun.md
+++ b/docs/testrunner/testrunner_run-testrun.md
@@ -17,7 +17,7 @@ testrunner run-testrun [flags]
   -h, --help                        help for run-testrun
       --interval int                Poll interval in seconds of the testrunner to poll for the testrun status. (default 20)
       --name-prefix string          Name prefix of the testrun (default "testrunner-")
-  -n, --namespace string            Namesapce where the testrun should be deployed. (default "default")
+  -n, --namespace string            Namespace where the testrun should be deployed. (default "default")
       --timeout int                 Timout in seconds of the testrunner to wait for the complete testrun to finish. (default 3600)
       --tm-kubeconfig-path string   Path to the testmachinery cluster kubeconfig
 ```

--- a/pkg/apis/testmachinery/v1beta1/types.go
+++ b/pkg/apis/testmachinery/v1beta1/types.go
@@ -132,6 +132,9 @@ type TestrunStatus struct {
 	// Steps is the detailed summary of every step.
 	// It also shows all specific executed tests.
 	Steps [][]*TestflowStepStatus `json:"steps,omitempty"`
+
+	// Ingested states whether the result of a testrun is already ingested into a persistant storage (db).
+	Ingested bool `json:"ingested"`
 }
 
 // TestflowStepStatus is the status of Testflow step

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -775,7 +775,15 @@ func schema_pkg_apis_testmachinery_v1beta1_TestrunStatus(ref common.ReferenceCal
 							},
 						},
 					},
+					"ingested": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Ingested states whether the result of a testrun is already ingested into a persistant storage (db).",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
+				Required: []string{"ingested"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/testrunner/result/collect.go
+++ b/pkg/testrunner/result/collect.go
@@ -35,6 +35,11 @@ func Collect(config *Config, tmKubeconfigPath, namespace string, testruns []*tmv
 		err = IngestFile(config.OutputFile, config.ESConfigName)
 		if err != nil {
 			log.Errorf("Cannot persist file %s: %s", config.OutputFile, err.Error())
+		} else {
+			err := MarkTestrunsAsIngested(tmKubeconfigPath, testruns)
+			if err != nil {
+				log.Warn(err.Error())
+			}
 		}
 
 		if tr.Status.Phase == tmv1beta1.PhaseStatusSuccess {

--- a/pkg/testrunner/testrunner.go
+++ b/pkg/testrunner/testrunner.go
@@ -43,7 +43,10 @@ func Run(config *Config, testruns []*tmv1beta1.Testrun, testrunNamePrefix string
 	if err != nil {
 		return nil, fmt.Errorf("Cannot build kubernetes client from %s: %s", config.TmKubeconfigPath, err.Error())
 	}
-	tmClient := tmclientset.NewForConfigOrDie(tmConfig)
+	tmClient, err := tmclientset.NewForConfig(tmConfig)
+	if err != nil {
+		return nil, err
+	}
 
 	finishedTestruns := runChart(tmClient, testruns, config.Namespace, testrunNamePrefix)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds an attribute to a testruns status which indicates if the testrun is already processed and the  results are ingested.
This status will be also updated by testrunner when it's finished ingesting the results to elasticsearch.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
