### PR TITLE
Add support for version matrix execution of testruns

### DIFF
--- a/cmd/testrunner/cmd/runtemplate/run_template.go
+++ b/cmd/testrunner/cmd/runtemplate/run_template.go
@@ -28,17 +28,19 @@ import (
 )
 
 var (
-	tmKubeconfigPath        string
-	namespace               string
+	tmKubeconfigPath string
+	namespace        string
+	timeout          int64
+	interval         int64
+
 	outputFilePath          string
 	elasticSearchConfigName string
 	s3Endpoint              string
 	concourseOnErrorDir     string
-	timeout                 int64
-	interval                int64
 
 	testrunChartPath         string
 	gardenKubeconfigPath     string
+	allK8sVersions           bool
 	testrunNamePrefix        string
 	projectName              string
 	shootName                string
@@ -102,6 +104,7 @@ var runCmd = &cobra.Command{
 		parameters := &testrunnerTemplate.TestrunParameters{
 			GardenKubeconfigPath: gardenKubeconfigPath,
 			TestrunChartPath:     testrunChartPath,
+			MakeVersionMatrix:    allK8sVersions,
 
 			ProjectName:             projectName,
 			ShootName:               shootName,
@@ -149,24 +152,25 @@ func init() {
 	runCmd.Flags().StringVar(&tmKubeconfigPath, "tm-kubeconfig-path", "", "Path to the testmachinery cluster kubeconfig")
 	runCmd.MarkFlagRequired("tm-kubeconfig-path")
 	runCmd.MarkFlagFilename("tm-kubeconfig-path")
-	runCmd.Flags().StringVar(&testrunChartPath, "testruns-chart-path", "", "Path to the testruns chart.")
-	runCmd.MarkFlagRequired("testruns-chart-path")
-	runCmd.MarkFlagFilename("testruns-chart-path")
 	runCmd.Flags().StringVar(&testrunNamePrefix, "testrun-prefix", "default-", "Testrun name prefix which is used to generate a unique testrun name.")
 	runCmd.MarkFlagRequired("testrun-prefix")
 	runCmd.Flags().StringVarP(&namespace, "namespace", "n", "default", "Namesapce where the testrun should be deployed.")
-
 	runCmd.Flags().Int64Var(&timeout, "timeout", 3600, "Timout in seconds of the testrunner to wait for the complete testrun to finish.")
 	runCmd.Flags().Int64Var(&interval, "interval", 20, "Poll interval in seconds of the testrunner to poll for the testrun status.")
+
 	runCmd.Flags().StringVar(&outputFilePath, "output-file-path", "./testout", "The filepath where the summary should be written to.")
 	runCmd.Flags().StringVar(&elasticSearchConfigName, "es-config-name", "sap_internal", "The elasticsearch secret-server config name.")
 	runCmd.Flags().StringVar(&s3Endpoint, "s3-endpoint", os.Getenv("S3_ENDPOINT"), "S3 endpoint of the testmachinery cluster.")
 	runCmd.Flags().StringVar(&concourseOnErrorDir, "concourse-onError-dir", os.Getenv("ON_ERROR_DIR"), "On error dir which is used by Concourse.")
 
 	// parameter flags
+	runCmd.Flags().StringVar(&testrunChartPath, "testruns-chart-path", "", "Path to the testruns chart.")
+	runCmd.MarkFlagRequired("testruns-chart-path")
+	runCmd.MarkFlagFilename("testruns-chart-path")
 	runCmd.Flags().StringVar(&gardenKubeconfigPath, "gardener-kubeconfig-path", "", "Path to the gardener kubeconfig.")
 	runCmd.MarkFlagRequired("gardener-kubeconfig-path")
 	runCmd.MarkFlagFilename("gardener-kubeconfig-path")
+	runCmd.Flags().BoolVar(&allK8sVersions, "all-k8s-versions", false, "Run the testrun with all available versions specified by the cloudprovider.")
 	runCmd.Flags().StringVar(&projectName, "project-name", "", "Gardener project name of the shoot")
 	runCmd.MarkFlagRequired("gardener-kubeconfig-path")
 	runCmd.Flags().StringVar(&shootName, "shoot-name", "", "Shoot name which is used to run tests.")

--- a/docs/Testrunner.md
+++ b/docs/Testrunner.md
@@ -45,6 +45,7 @@ testrunner run|run-tmpl [flags]
 | testrun-prefix | | Prefix of the deployed Testrun. This prefix is used for the `metadata.generateName` of Testruns in the helm template. | x |
 | namespace | default | Namespace where the testrun is deployed. |  |
 | timeout | 3600 | Max seconds to wait for all Testruns to finish. | |
+| version-matrix | false | Run the testrun with all available versions of the specified cloudprovider. :warning: The `k8s-version` is ingored if this parameter is set to true.| |
 | output-file-path | "./testout" | The filepath where the test summary and results should be written to. | |
 | s3-endpoint | EnvVar ("S3_ENDPOINT") | Accessible S3 endpoint of the s3 storage used by argo. This parameter is needed when tests export test results and the testrunner needs to fetch them and add them to the summary. | |
 | es-config-name | | Elasticsearch server config name that is used with the cc-utils cli | |

--- a/docs/testrunner/testrunner_run-template.md
+++ b/docs/testrunner/testrunner_run-template.md
@@ -13,6 +13,7 @@ testrunner run-template [flags]
 ### Options
 
 ```
+      --all-k8s-versions                   Run the testrun with all available versions specified by the cloudprovider.
       --autoscaler-max string              Max number of worker nodes.
       --autoscaler-min string              Min number of worker nodes.
       --cloudprofile string                Cloudprofile of shoot.

--- a/pkg/testrunner/template/render.go
+++ b/pkg/testrunner/template/render.go
@@ -1,0 +1,75 @@
+package template
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/gardener/gardener/pkg/chartrenderer"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/test-infra/pkg/util"
+	log "github.com/sirupsen/logrus"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// RenderChart renders the provided helm chart with testruns, adds the testrun parameters and returns the templated files.
+func RenderChart(tmKubeconfigPath string, parameters *TestrunParameters, versions []string) ([]string, error) {
+	log.Debugf("Parameters: %+v", util.PrettyPrintStruct(parameters))
+	log.Debugf("Render chart from %s", parameters.TestrunChartPath)
+
+	tmClusterClient, err := kubernetes.NewClientFromFile(tmKubeconfigPath, nil, client.Options{})
+	if err != nil {
+		return nil, fmt.Errorf("couldn't create k8s client from kubeconfig filepath %s: %v", tmKubeconfigPath, err)
+	}
+	tmChartRenderer, err := chartrenderer.New(tmClusterClient)
+	if err != nil {
+		return nil, fmt.Errorf("Cannot create chartrenderer for gardener: %s", err.Error())
+	}
+
+	gardenKubeconfig, err := ioutil.ReadFile(parameters.GardenKubeconfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("Cannot read gardener kubeconfig %s, Error: %s", parameters.GardenKubeconfigPath, err.Error())
+	}
+
+	renderedFiles := []string{}
+	for _, version := range versions {
+		files, err := renderSingleChart(tmChartRenderer, parameters, gardenKubeconfig, version)
+		if err != nil {
+			return nil, err
+		}
+		renderedFiles = append(renderedFiles, files...)
+	}
+	return renderedFiles, nil
+}
+
+func renderSingleChart(renderer chartrenderer.ChartRenderer, parameters *TestrunParameters, gardenKubeconfig []byte, version string) ([]string, error) {
+	chart, err := renderer.Render(parameters.TestrunChartPath, "", parameters.Namespace, map[string]interface{}{
+		"shoot": map[string]interface{}{
+			"name":             fmt.Sprintf("%s-%s", parameters.ShootName, util.RandomString(5)),
+			"projectNamespace": fmt.Sprintf("garden-%s", parameters.ProjectName),
+			"cloudprovider":    parameters.Cloudprovider,
+			"cloudprofile":     parameters.Cloudprofile,
+			"secretBinding":    parameters.SecretBinding,
+			"region":           parameters.Region,
+			"zone":             parameters.Zone,
+			"k8sVersion":       version,
+			"machinetype":      parameters.MachineType,
+			"autoscalerMin":    parameters.AutoscalerMin,
+			"autoscalerMax":    parameters.AutoscalerMax,
+			"floatingPoolName": parameters.FloatingPoolName,
+		},
+		"kubeconfigs": map[string]interface{}{
+			"gardener": string(gardenKubeconfig),
+		},
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	files := []string{}
+	for _, file := range chart.Files {
+		files = append(files, file)
+	}
+
+	return files, nil
+}

--- a/pkg/testrunner/template/template.go
+++ b/pkg/testrunner/template/template.go
@@ -18,26 +18,18 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"github.com/gardener/gardener/pkg/chartrenderer"
-	"github.com/gardener/gardener/pkg/client/kubernetes"
 	tmv1beta1 "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
 	"github.com/gardener/test-infra/pkg/testrunner/componentdescriptor"
 	"github.com/gardener/test-infra/pkg/testrunner/result"
 	"github.com/gardener/test-infra/pkg/util"
 	log "github.com/sirupsen/logrus"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Render renders a helm chart with containing testruns, adds the provided parameters and values, and returns the parsed and modified testruns.
 func Render(tmKubeconfigPath string, parameters *TestrunParameters, metadata *result.Metadata) ([]*tmv1beta1.Testrun, error) {
-
-	// if the kubernetes version is not set, get the latest version defined by the cloudprofile
-	if parameters.K8sVersion == "" {
-		var err error
-		parameters.K8sVersion, err = getLatestK8sVersion(parameters.GardenKubeconfigPath, parameters.Cloudprofile, parameters.Cloudprovider)
-		if err != nil {
-			log.Fatalf("Kubernetes is not defined nor can it be read from the cloudprofile: %s", err.Error())
-		}
+	versions, err := getK8sVersions(parameters)
+	if err != nil {
+		log.Fatal(err.Error())
 	}
 
 	if parameters.ComponentDescriptorPath != "" {
@@ -53,22 +45,23 @@ func Render(tmKubeconfigPath string, parameters *TestrunParameters, metadata *re
 		}
 	}
 
-	chart, err := RenderChart(tmKubeconfigPath, parameters)
+	files, err := RenderChart(tmKubeconfigPath, parameters, versions)
 	if err != nil {
 		return nil, err
 	}
 
 	// parse the rendered testruns and add locations from BOM of a bom was provided.
 	testruns := []*tmv1beta1.Testrun{}
-	for fileName, fileContent := range chart.Files {
+	for _, fileContent := range files {
 		tr, err := util.ParseTestrun([]byte(fileContent))
 		if err != nil {
-			log.Warnf("Cannot parse %s: %s", fileName, err.Error())
+			log.Warnf("Cannot parse rendered file: %s", err.Error())
 		}
 
 		// Add current dependency repositories to the testrun location.
 		// This gives us all dependent repositories as well as there deployed version.
 		addBOMLocationsToTestrun(&tr, metadata.BOM)
+
 		testruns = append(testruns, &tr)
 	}
 
@@ -77,44 +70,4 @@ func Render(tmKubeconfigPath string, parameters *TestrunParameters, metadata *re
 	}
 
 	return testruns, nil
-}
-
-// RenderChart renders the provided helm chart with testruns and adds the testrun parameters.
-func RenderChart(tmKubeconfigPath string, parameters *TestrunParameters) (*chartrenderer.RenderedChart, error) {
-	log.Debugf("Parameters: %+v", util.PrettyPrintStruct(parameters))
-	log.Debugf("Render chart from %s", parameters.TestrunChartPath)
-
-	tmClusterClient, err := kubernetes.NewClientFromFile(tmKubeconfigPath, nil, client.Options{})
-	if err != nil {
-		return nil, fmt.Errorf("couldn't create k8s client from kubeconfig filepath %s: %v", tmKubeconfigPath, err)
-	}
-	tmChartRenderer, err := chartrenderer.New(tmClusterClient)
-	if err != nil {
-		return nil, fmt.Errorf("Cannot create chartrenderer for gardener  %s", err.Error())
-	}
-
-	gardenKubeconfig, err := ioutil.ReadFile(parameters.GardenKubeconfigPath)
-	if err != nil {
-		return nil, fmt.Errorf("Cannot read gardener kubeconfig %s, Error: %s", parameters.GardenKubeconfigPath, err.Error())
-	}
-
-	return tmChartRenderer.Render(parameters.TestrunChartPath, "", parameters.Namespace, map[string]interface{}{
-		"shoot": map[string]interface{}{
-			"name":             fmt.Sprintf("%s-%s", parameters.ShootName, util.RandomString(5)),
-			"projectNamespace": fmt.Sprintf("garden-%s", parameters.ProjectName),
-			"cloudprovider":    parameters.Cloudprovider,
-			"cloudprofile":     parameters.Cloudprofile,
-			"secretBinding":    parameters.SecretBinding,
-			"region":           parameters.Region,
-			"zone":             parameters.Zone,
-			"k8sVersion":       parameters.K8sVersion,
-			"machinetype":      parameters.MachineType,
-			"autoscalerMin":    parameters.AutoscalerMin,
-			"autoscalerMax":    parameters.AutoscalerMax,
-			"floatingPoolName": parameters.FloatingPoolName,
-		},
-		"kubeconfigs": map[string]interface{}{
-			"gardener": string(gardenKubeconfig),
-		},
-	})
 }

--- a/pkg/testrunner/template/types.go
+++ b/pkg/testrunner/template/types.go
@@ -20,6 +20,8 @@ type TestrunParameters struct {
 	GardenKubeconfigPath string
 	Namespace            string
 	TestrunChartPath     string
+	// Ignore K8sVersion and generate a testrun for every valid version that is defined in the cloudprofile
+	MakeVersionMatrix bool
 
 	ProjectName             string
 	ShootName               string


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables the testrunner to duplicate testruns for multiple k8s versions.
Therefore, it is know possible to specify a boolean flag called `--version-matrix` which triggers the testrunner to duplicate all found testruns by all supported versions of the corresponding cloudprofile.


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
Add support for kubernetes version matrix build of templated testruns in testrunner
```
