### PR TITLE
Add ssl support for s3 instances

### DIFF
--- a/charts/testmachinery/templates/deployment-tm-controller.yaml
+++ b/charts/testmachinery/templates/deployment-tm-controller.yaml
@@ -37,6 +37,7 @@ spec:
       containers:
       - name: testmachinery-controller
         image: "{{ .Values.controller.image }}:{{ .Values.controller.tag }}"
+        imagePullPolicy: Always
 {{ if .Values.local.enabled }}
         command: ["/testmachinery-controller", "-insecure=true"]
 {{end}}

--- a/cmd/testrunner/cmd/runtemplate/run_template.go
+++ b/cmd/testrunner/cmd/runtemplate/run_template.go
@@ -36,6 +36,7 @@ var (
 	outputFilePath          string
 	elasticSearchConfigName string
 	s3Endpoint              string
+	s3SSL                   bool
 	concourseOnErrorDir     string
 
 	testrunChartPath         string
@@ -98,6 +99,7 @@ var runCmd = &cobra.Command{
 			OutputFile:          outputFilePath,
 			ESConfigName:        elasticSearchConfigName,
 			S3Endpoint:          s3Endpoint,
+			S3SSL:               s3SSL,
 			ConcourseOnErrorDir: concourseOnErrorDir,
 		}
 
@@ -161,6 +163,7 @@ func init() {
 	runCmd.Flags().StringVar(&outputFilePath, "output-file-path", "./testout", "The filepath where the summary should be written to.")
 	runCmd.Flags().StringVar(&elasticSearchConfigName, "es-config-name", "sap_internal", "The elasticsearch secret-server config name.")
 	runCmd.Flags().StringVar(&s3Endpoint, "s3-endpoint", os.Getenv("S3_ENDPOINT"), "S3 endpoint of the testmachinery cluster.")
+	runCmd.Flags().BoolVar(&s3SSL, "s3-ssl", false, "S3 has SSL enabled.")
 	runCmd.Flags().StringVar(&concourseOnErrorDir, "concourse-onError-dir", os.Getenv("ON_ERROR_DIR"), "On error dir which is used by Concourse.")
 
 	// parameter flags

--- a/pkg/testmachinery/garbagecollection/minio.go
+++ b/pkg/testmachinery/garbagecollection/minio.go
@@ -32,7 +32,7 @@ func NewObjectStore() (*ObjectStore, error) {
 
 	cfg := testmachinery.GetConfig().ObjectStore
 
-	minioClient, err := minio.New(cfg.Endpoint, cfg.AccessKey, cfg.SecretKey, false)
+	minioClient, err := minio.New(cfg.Endpoint, cfg.AccessKey, cfg.SecretKey, cfg.SSL)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/testmachinery/types.go
+++ b/pkg/testmachinery/types.go
@@ -56,6 +56,7 @@ type TmConfiguration struct {
 // ObjectStoreConfig is an object containing the ObjectStore specific configuration
 type ObjectStoreConfig struct {
 	Endpoint   string
+	SSL        bool
 	AccessKey  string
 	SecretKey  string
 	BucketName string

--- a/pkg/testrunner/result/types.go
+++ b/pkg/testrunner/result/types.go
@@ -22,14 +22,17 @@ import (
 
 // Config represents the configuration for collecting and storing results from a testrun.
 type Config struct {
-	// outputFilePath is the path where the testresult is written to.
+	// OutputFilePath is the path where the testresult is written to.
 	OutputFile string
 
-	// config name of the elastic search to store the test results.
+	// Config name of the elasticsearch instance to store the test results.
 	ESConfigName string
 
-	// Endpint of the s3 storage of the testmachinery.
+	// Endpoint of the s3 storage of the testmachinery.
 	S3Endpoint string
+
+	// S3SSL indicates whether the S3 instance is SSL secured or not.
+	S3SSL bool
 
 	// Path to the error directory of concourse to put the notify.cfg in.
 	ConcourseOnErrorDir string


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support for ssl secured s3 instances.
Also a new flag is introduced `s3-ssl` to specify ssl usage of the corresponding endpoint.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Add ssl support for s3 instances
```
