### PR TITLE
Stabilize testrunner polling

### DIFF
--- a/pkg/testrunner/run.go
+++ b/pkg/testrunner/run.go
@@ -46,10 +46,13 @@ func runTestrun(tmClient kubernetes.Interface, tr *tmv1beta1.Testrun, namespace,
 	interval := time.Duration(pollIntervalSeconds) * time.Second
 	timeout := time.Duration(maxWaitTimeSeconds) * time.Second
 	err = wait.PollImmediate(interval, timeout, func() (bool, error) {
-		err := tmClient.Client().Get(ctx, client.ObjectKey{Namespace: namespace, Name: tr.Name}, tr)
+		testrun := &tmv1beta1.Testrun{}
+		err := tmClient.Client().Get(ctx, client.ObjectKey{Namespace: namespace, Name: tr.Name}, testrun)
 		if err != nil {
 			log.Errorf("Cannot get testrun: %s", err.Error())
+			return false, nil
 		}
+		tr = testrun
 
 		if tr.Status.State != "" {
 			testrunPhase = tr.Status.Phase

--- a/pkg/testrunner/testrunner.go
+++ b/pkg/testrunner/testrunner.go
@@ -61,6 +61,9 @@ func runChart(tmClient kubernetes.Interface, testruns []*tmv1beta1.Testrun, name
 			tr, err := runTestrun(tmClient, tr, namespace, testrunNamePrefix)
 			if err != nil {
 				log.Error(err.Error())
+				if tr == nil {
+					return
+				}
 				tr.Status.Phase = tmv1beta1.PhaseStatusFailed
 			}
 			mutex.Lock()


### PR DESCRIPTION
**What this PR does / why we need it**:
Testrunner currently cannot recover from not found testruns.
Therefore this PR introduces a fix that checks if the testrun can be fetched from the server and overwrites the original testrun only in case of success.
 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
Fixed issue where the Testrunner cannot recover from unavailable Testruns.
```
