### PR TITLE
Rename result output attribute names and update Docs

### DIFF
--- a/docs/Testrunner.md
+++ b/docs/Testrunner.md
@@ -52,6 +52,7 @@ testrunner run|run-tmpl [flags]
 | version-matrix | false | Run the testrun with all available versions of the specified cloudprovider. :warning: The `k8s-version` is ingored if this parameter is set to true.| |
 | output-file-path | "./testout" | The filepath where the test summary and results should be written to. | |
 | s3-endpoint | EnvVar ("S3_ENDPOINT") | Accessible S3 endpoint of the s3 storage used by argo. This parameter is needed when tests export test results and the testrunner needs to fetch them and add them to the summary. | |
+| s3-ssl | false | Enables ssl support for the corresponding s3 storage. | |
 | es-config-name | | Elasticsearch server config name that is used with the cc-utils cli | |
 | concourse-onError-dir | EnvVar ("ON_ERROR_DIR") | Directory where the `notify.cfg` should be written to. | |
 

--- a/docs/testrunner/testrunner_run-template.md
+++ b/docs/testrunner/testrunner_run-template.md
@@ -33,6 +33,7 @@ testrunner run-template [flags]
       --project-name string                Gardener project name of the shoot
       --region string                      Region where the shoot is created.
       --s3-endpoint string                 S3 endpoint of the testmachinery cluster.
+      --s3-ssl                             S3 has SSL enabled.
       --secret-binding string              SecretBinding that should be used to create the shoot.
       --shoot-name string                  Shoot name which is used to run tests.
       --testrun-prefix string              Testrun name prefix which is used to generate a unique testrun name. (default "default-")

--- a/pkg/testrunner/elasticsearch/elasticsearchbulk.go
+++ b/pkg/testrunner/elasticsearch/elasticsearchbulk.go
@@ -51,7 +51,7 @@ func ParseExportedFiles(name string, stepMeta interface{}, docs []byte) []byte {
 	var jsonBody map[string]interface{}
 	err := json.Unmarshal(docs, &jsonBody)
 	if err == nil {
-		jsonBody["tm_meta"] = stepMeta
+		jsonBody["tm"] = stepMeta
 		patchedDoc, err := json.Marshal(jsonBody)
 		if err != nil {
 			log.Warnf("Cannot mashal exported json with metadata from %s", name)
@@ -99,7 +99,7 @@ func parseExportedBulkFormat(name string, stepMeta interface{}, docs []byte) []b
 			continue
 		}
 
-		jsonBody["tm_meta"] = stepMeta
+		jsonBody["tm"] = stepMeta
 		patchedDoc, err := json.Marshal(jsonBody)
 		if err != nil {
 			log.Errorf("Cannot mashal artifact %s", err.Error())

--- a/pkg/testrunner/elasticsearch/testdata/bulk_no_meta_output
+++ b/pkg/testrunner/elasticsearch/testdata/bulk_no_meta_output
@@ -1,4 +1,4 @@
 {"index":{"_index":"TestDef","_type":"_doc"}}
-{"tm_meta":{"tm_id":"testId"},"test": "bulk_no_1"}
+{"tm":{"tm_id":"testId"},"test": "bulk_no_1"}
 {"index":{"_index":"TestDef","_type":"_doc"}}
-{"tm_meta":{"tm_id":"testId"},"test": 2}
+{"tm":{"tm_id":"testId"},"test": 2}

--- a/pkg/testrunner/elasticsearch/testdata/bulk_with_meta_output
+++ b/pkg/testrunner/elasticsearch/testdata/bulk_with_meta_output
@@ -1,4 +1,4 @@
 {"index":{"_index":"tm-test-index1","_type":"_doc"}}
-{"tm_meta":{"tm_id":"testId"},"test": "bulk_no_1"}
+{"tm":{"tm_id":"testId"},"test": "bulk_no_1"}
 {"index":{"_index":"tm-test-index2","_type":"_doc"}}
-{"tm_meta":{"tm_id":"testId"},"test": 2}
+{"tm":{"tm_id":"testId"},"test": 2}

--- a/pkg/testrunner/elasticsearch/testdata/json_output
+++ b/pkg/testrunner/elasticsearch/testdata/json_output
@@ -1,2 +1,2 @@
 {"index":{"_index":"TestDef","_type":"_doc"}}
-{"tm_meta":{"tm_id":"testId"},"test":"json"}
+{"tm":{"tm_id":"testId"},"test":"json"}

--- a/pkg/testrunner/result/types.go
+++ b/pkg/testrunner/result/types.go
@@ -52,11 +52,12 @@ type Metadata struct {
 	// Landscape describes the current dev,staging,canary,office or live.
 	Landscape         string `json:"landscape"`
 	CloudProvider     string `json:"cloudprovider"`
-	KubernetesVersion string `json:"kubernetes_version"`
+	KubernetesVersion string `json:"k8s_version"`
 
-	// BOM describes the current component_descriptor of the direct landscape-setup components.
-	BOM       []*componentdescriptor.Component `json:"bom"`
-	TestrunID string                           `json:"testrun_id"`
+	// ComponentDescriptor describes the current component_descriptor of the direct landscape-setup components.
+	// It is formated as an array of components: { name: "my_component", version: "0.0.1" }
+	ComponentDescriptor []*componentdescriptor.Component `json:"bom"`
+	TestrunID           string                           `json:"testrun_id"`
 }
 
 // StepExportMetadata is the metadata of one step of a testrun.
@@ -70,7 +71,7 @@ type StepExportMetadata struct {
 
 // TestrunSummary is the result of the overall testrun.
 type TestrunSummary struct {
-	Metadata  *Metadata        `json:"tm_meta"`
+	Metadata  *Metadata        `json:"tm"`
 	Type      SummaryType      `json:"type"`
 	Phase     argov1.NodePhase `json:"phase,omitempty"`
 	StartTime *metav1.Time     `json:"startTime,omitempty"`
@@ -80,7 +81,7 @@ type TestrunSummary struct {
 
 // StepSummary is the result of a specific step.
 type StepSummary struct {
-	Metadata  *Metadata        `json:"tm_meta"`
+	Metadata  *Metadata        `json:"tm"`
 	Type      SummaryType      `json:"type"`
 	Name      string           `json:"name,omitempty"`
 	Phase     argov1.NodePhase `json:"phase,omitempty"`

--- a/pkg/testrunner/template/template.go
+++ b/pkg/testrunner/template/template.go
@@ -40,9 +40,9 @@ func Render(tmClient kubernetes.Interface, parameters *TestrunParameters, metada
 		}
 		components, err := componentdescriptor.GetComponents(data)
 		if err != nil {
-			return nil, fmt.Errorf("Cannot decode and parse BOM %s", err.Error())
+			return nil, fmt.Errorf("Cannot decode and parse the component descriptor: %s", err.Error())
 		}
-		metadata.BOM = components
+		metadata.ComponentDescriptor = components
 	}
 
 	files, err := RenderChart(tmClient, parameters, versions)
@@ -60,7 +60,7 @@ func Render(tmClient kubernetes.Interface, parameters *TestrunParameters, metada
 
 		// Add all repositories defined in the component descriptor to the testrun locations.
 		// This gives us all dependent repositories as well as there deployed version.
-		addBOMLocationsToTestrun(&tr, metadata.BOM)
+		addBOMLocationsToTestrun(&tr, metadata.ComponentDescriptor)
 
 		testruns = append(testruns, &tr)
 	}

--- a/test/testrunner/output/testrunner_output_execution_test.go
+++ b/test/testrunner/output/testrunner_output_execution_test.go
@@ -88,10 +88,8 @@ var _ = Describe("Testrunner execution tests", func() {
 		testrunConfig.OutputFile = outputFilePath + util.RandomString(3)
 		tr := resources.GetBasicTestrun(namespace, commitSha)
 		tr, _, err := utils.RunTestrun(ctx, tmClient, tr, argov1.NodeSucceeded, namespace, maxWaitTime)
+		defer utils.DeleteTestrun(tmClient, tr)
 		Expect(err).ToNot(HaveOccurred())
-		if err == nil {
-			defer utils.DeleteTestrun(tmClient, tr)
-		}
 
 		err = result.Output(&testrunConfig, tmClient, namespace, tr, &result.Metadata{})
 		Expect(err).ToNot(HaveOccurred())
@@ -114,7 +112,9 @@ var _ = Describe("Testrunner execution tests", func() {
 			// every data document should have of a testrun metadata information
 			if line%2 == 0 {
 				Expect(jsonBody["index"]).To(BeNil())
-				Expect(jsonBody["testrun_id"] != nil || jsonBody["tm_meta"] != nil).To(BeTrue())
+				Expect(jsonBody["tm"]).ToNot(BeEmpty())
+				Expect(jsonBody["tm"].(map[string]interface{})["testrun_id"]).ToNot(BeEmpty())
+
 			}
 			line++
 		}
@@ -127,10 +127,8 @@ var _ = Describe("Testrunner execution tests", func() {
 		testrunConfig.OutputFile = outputFilePath + util.RandomString(3)
 		tr := resources.GetBasicTestrun(namespace, commitSha)
 		tr, _, err := utils.RunTestrun(ctx, tmClient, tr, argov1.NodeSucceeded, namespace, maxWaitTime)
+		defer utils.DeleteTestrun(tmClient, tr)
 		Expect(err).ToNot(HaveOccurred())
-		if err == nil {
-			defer utils.DeleteTestrun(tmClient, tr)
-		}
 
 		err = result.Output(&testrunConfig, tmClient, namespace, tr, &result.Metadata{})
 		Expect(err).ToNot(HaveOccurred())
@@ -150,8 +148,8 @@ var _ = Describe("Testrunner execution tests", func() {
 		}
 		Expect(scanner.Err()).ToNot(HaveOccurred())
 
-		Expect(jsonBody["tm_meta"]).ToNot(BeNil())
-		Expect(jsonBody["tm_meta"].(map[string]interface{})["testrun_id"]).To(Equal(tr.Name))
+		Expect(jsonBody["tm"]).ToNot(BeNil())
+		Expect(jsonBody["tm"].(map[string]interface{})["testrun_id"]).To(Equal(tr.Name))
 
 		Expect(documents[len(documents)-2]["index"].(map[string]interface{})["_index"]).To(Equal("integration-testdef"))
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
Rename multiple metadata fields:
-  `tm_meta` to `tm`
- `kubernetes_version` to `k8s_version`
- `bom` to `component_descriptor` (only updated in internal structure, json output stays `bom`)

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```action user
Renamed metadata fields: `tm_meta` to `tm` and `kubernetes_version` to `k8s_version`.
```
