### PR TITLE
Add argoui link to metadata output

### DIFF
--- a/cmd/testrunner/cmd/runtemplate/run_template.go
+++ b/cmd/testrunner/cmd/runtemplate/run_template.go
@@ -41,6 +41,7 @@ var (
 	elasticSearchConfigName string
 	s3Endpoint              string
 	s3SSL                   bool
+	argouiEndpoint          string
 	concourseOnErrorDir     string
 
 	testrunChartPath         string
@@ -111,6 +112,7 @@ var runCmd = &cobra.Command{
 			ESConfigName:        elasticSearchConfigName,
 			S3Endpoint:          s3Endpoint,
 			S3SSL:               s3SSL,
+			ArgoUIEndpoint:      argouiEndpoint,
 			ConcourseOnErrorDir: concourseOnErrorDir,
 		}
 
@@ -175,6 +177,7 @@ func init() {
 	runCmd.Flags().StringVar(&elasticSearchConfigName, "es-config-name", "sap_internal", "The elasticsearch secret-server config name.")
 	runCmd.Flags().StringVar(&s3Endpoint, "s3-endpoint", os.Getenv("S3_ENDPOINT"), "S3 endpoint of the testmachinery cluster.")
 	runCmd.Flags().BoolVar(&s3SSL, "s3-ssl", false, "S3 has SSL enabled.")
+	runCmd.Flags().StringVar(&argouiEndpoint, "argoui-endpoint", "", "ArgoUI endpoint of the testmachinery cluster.")
 	runCmd.Flags().StringVar(&concourseOnErrorDir, "concourse-onError-dir", os.Getenv("ON_ERROR_DIR"), "On error dir which is used by Concourse.")
 
 	// parameter flags

--- a/docs/Testrunner.md
+++ b/docs/Testrunner.md
@@ -53,6 +53,7 @@ testrunner run|run-tmpl [flags]
 | output-file-path | "./testout" | The filepath where the test summary and results should be written to. | |
 | s3-endpoint | EnvVar ("S3_ENDPOINT") | Accessible S3 endpoint of the s3 storage used by argo. This parameter is needed when tests export test results and the testrunner needs to fetch them and add them to the summary. | |
 | s3-ssl | false | Enables ssl support for the corresponding s3 storage. | |
+| argoui-endpoint | | Endpoint of the ArgoUI watching the Testmachinery cluster. | |
 | es-config-name | | Elasticsearch server config name that is used with the cc-utils cli | |
 | concourse-onError-dir | EnvVar ("ON_ERROR_DIR") | Directory where the `notify.cfg` should be written to. | |
 

--- a/docs/testrunner/testrunner_run-template.md
+++ b/docs/testrunner/testrunner_run-template.md
@@ -14,6 +14,7 @@ testrunner run-template [flags]
 
 ```
       --all-k8s-versions                   Run the testrun with all available versions specified by the cloudprovider.
+      --argoui-endpoint string             ArgoUI endpoint of the testmachinery cluster.
       --autoscaler-max string              Max number of worker nodes.
       --autoscaler-min string              Min number of worker nodes.
       --cloudprofile string                Cloudprofile of shoot.

--- a/pkg/testrunner/result/output.go
+++ b/pkg/testrunner/result/output.go
@@ -23,6 +23,8 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net/url"
+	"path"
 	"strings"
 
 	"github.com/gardener/test-infra/pkg/testmachinery"
@@ -44,6 +46,10 @@ func Output(config *Config, tmClient kubernetes.Interface, namespace string, tr 
 	}
 
 	metadata.TestrunID = tr.Name
+
+	if _, err := url.ParseRequestURI(config.ArgoUIEndpoint); err != nil {
+		metadata.ArgoUIExternalURL = path.Join(config.ArgoUIEndpoint, "workflows", namespace, tr.Name)
+	}
 
 	trSummary, err := getTestrunSummary(tr, metadata)
 	if err != nil {

--- a/pkg/testrunner/result/output.go
+++ b/pkg/testrunner/result/output.go
@@ -47,8 +47,12 @@ func Output(config *Config, tmClient kubernetes.Interface, namespace string, tr 
 
 	metadata.TestrunID = tr.Name
 
-	if _, err := url.ParseRequestURI(config.ArgoUIEndpoint); err != nil {
-		metadata.ArgoUIExternalURL = path.Join(config.ArgoUIEndpoint, "workflows", namespace, tr.Name)
+	if config.ArgoUIEndpoint != "" {
+		if _, err := url.ParseRequestURI(config.ArgoUIEndpoint); err == nil {
+			metadata.ArgoUIExternalURL = path.Join(config.ArgoUIEndpoint, "workflows", namespace, tr.Name)
+		} else {
+			log.Debugf("Cannot parse Url %s: %s", config.ArgoUIEndpoint, err.Error())
+		}
 	}
 
 	trSummary, err := getTestrunSummary(tr, metadata)

--- a/pkg/testrunner/result/types.go
+++ b/pkg/testrunner/result/types.go
@@ -34,6 +34,9 @@ type Config struct {
 	// S3SSL indicates whether the S3 instance is SSL secured or not.
 	S3SSL bool
 
+	// Endpoint of the argo ui of the testmachinery.
+	ArgoUIEndpoint string
+
 	// Path to the error directory of concourse to put the notify.cfg in.
 	ConcourseOnErrorDir string
 }
@@ -57,7 +60,14 @@ type Metadata struct {
 	// ComponentDescriptor describes the current component_descriptor of the direct landscape-setup components.
 	// It is formated as an array of components: { name: "my_component", version: "0.0.1" }
 	ComponentDescriptor []*componentdescriptor.Component `json:"bom"`
-	TestrunID           string                           `json:"testrun_id"`
+
+	// Name of the testrun crd object.
+	TestrunID string `json:"testrun_id"`
+
+	// Link to the workflow in the argo ui
+	// Only set if an ingress with the name "argo-ui" for the argoui is set.
+	// Argo URL is in format: https://argo-endpoint.com/workflows/namespace/wf-name
+	ArgoUIExternalURL string `json:"argo_external_url"`
 }
 
 // StepExportMetadata is the metadata of one step of a testrun.

--- a/pkg/testrunner/result/types.go
+++ b/pkg/testrunner/result/types.go
@@ -67,7 +67,7 @@ type Metadata struct {
 	// Link to the workflow in the argo ui
 	// Only set if an ingress with the name "argo-ui" for the argoui is set.
 	// Argo URL is in format: https://argo-endpoint.com/workflows/namespace/wf-name
-	ArgoUIExternalURL string `json:"argo_external_url"`
+	ArgoUIExternalURL string `json:"argo_url"`
 }
 
 // StepExportMetadata is the metadata of one step of a testrun.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds another optional metadata field which is a link that points to the wf in an argo ui.
Therefore another flag `argoui-endpoint` is introduced where the argoui endpoint can be specified which is then used to generate the URL for the specific workflow.


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
Add ArgoUI link to metadata.
```
