### PR TITLE
Add context metadata to testruns executed by the testrunner

### DIFF
--- a/cmd/testrunner/cmd/runtemplate/run_template.go
+++ b/cmd/testrunner/cmd/runtemplate/run_template.go
@@ -137,23 +137,23 @@ var runCmd = &cobra.Command{
 			ComponentDescriptorPath: componenetDescriptorPath,
 		}
 
-		metadata := &result.Metadata{
+		metadata := &testrunner.Metadata{
 			Landscape:         parameters.Landscape,
 			CloudProvider:     parameters.Cloudprovider,
 			KubernetesVersion: parameters.K8sVersion,
 		}
-		testruns, err := testrunnerTemplate.Render(tmClient, parameters, metadata)
+		runs, err := testrunnerTemplate.Render(tmClient, parameters, metadata)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		finishedTestruns, err := testrunner.Run(config, testruns, testrunName)
-		failed, err := result.Collect(rsConfig, tmClient, config.Namespace, finishedTestruns, metadata)
+		finishedRuns, err := testrunner.ExecuteTestrun(config, runs, testrunName)
+		failed, err := result.Collect(rsConfig, tmClient, config.Namespace, finishedRuns)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		result.GenerateNotificationConfigForAlerting(finishedTestruns, rsConfig.ConcourseOnErrorDir)
+		result.GenerateNotificationConfigForAlerting(finishedRuns.GetTestruns(), rsConfig.ConcourseOnErrorDir)
 
 		log.Info("Testrunner finished.")
 		if failed {

--- a/cmd/testrunner/cmd/runtestrun/run_testrun.go
+++ b/cmd/testrunner/cmd/runtestrun/run_testrun.go
@@ -87,18 +87,24 @@ var runTestrunCmd = &cobra.Command{
 			log.Fatalf("Testrunner execution disrupted: %s", err.Error())
 		}
 
-		finishedTestruns, err := testrunner.Run(config, []*tmv1beta1.Testrun{&tr}, testrunNamePrefix)
+		run := []*testrunner.Run{
+			{
+				Testrun: &tr,
+			},
+		}
+
+		finishedRuns, err := testrunner.ExecuteTestrun(config, run, testrunNamePrefix)
 		if err != nil {
 			log.Fatalf("Testrunner execution disrupted: %s", err.Error())
 		}
 
-		if finishedTestruns[0].Status.Phase == tmv1beta1.PhaseStatusSuccess {
+		if finishedRuns[0].Testrun.Status.Phase == tmv1beta1.PhaseStatusSuccess {
 			log.Info("Testrunner successfully finished.")
 		} else {
-			log.Errorf("Testrunner finished with phase %s", finishedTestruns[0].Status.Phase)
+			log.Errorf("Testrunner finished with phase %s", finishedRuns[0].Testrun.Status.Phase)
 		}
 
-		fmt.Print(util.PrettyPrintStruct(finishedTestruns[0].Status))
+		fmt.Print(util.PrettyPrintStruct(finishedRuns[0].Testrun.Status))
 	},
 }
 

--- a/pkg/testrunner/result/ingest.go
+++ b/pkg/testrunner/result/ingest.go
@@ -16,6 +16,7 @@ package result
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 
@@ -46,18 +47,16 @@ func IngestFile(file, esCfgName string) error {
 }
 
 // MarkTestrunsAsIngested sets the ingest status of testruns to true
-func MarkTestrunsAsIngested(tmClient kubernetes.Interface, testruns []*tmv1beta1.Testrun) error {
+func MarkTestrunsAsIngested(tmClient kubernetes.Interface, tr *tmv1beta1.Testrun) error {
 	ctx := context.Background()
 	defer ctx.Done()
-	for _, tr := range testruns {
-		tr.Status.Ingested = true
-		err := tmClient.Client().Update(ctx, tr)
-		if err != nil {
-			log.Errorf("Cannot update status off testrun %s in namespace %s: %s", tr.Name, tr.Namespace, err.Error())
-			continue
-		}
-		log.Debugf("Successfully updated status of testrun %s in namespace %s", tr.Name, tr.Namespace)
+
+	tr.Status.Ingested = true
+	err := tmClient.Client().Update(ctx, tr)
+	if err != nil {
+		return fmt.Errorf("Cannot update status off testrun %s in namespace %s: %s", tr.Name, tr.Namespace, err.Error())
 	}
+	log.Debugf("Successfully updated status of testrun %s in namespace %s", tr.Name, tr.Namespace)
 
 	return nil
 }

--- a/pkg/testrunner/result/types.go
+++ b/pkg/testrunner/result/types.go
@@ -14,12 +14,6 @@
 
 package result
 
-import (
-	argov1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
-	"github.com/gardener/test-infra/pkg/testrunner/componentdescriptor"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-)
-
 // Config represents the configuration for collecting and storing results from a testrun.
 type Config struct {
 	// OutputFilePath is the path where the testresult is written to.
@@ -39,64 +33,6 @@ type Config struct {
 
 	// Path to the error directory of concourse to put the notify.cfg in.
 	ConcourseOnErrorDir string
-}
-
-// SummaryType defines the type of a test result or summary
-type SummaryType string
-
-// Summary types can be testrun or teststep
-const (
-	SummaryTypeTestrun  SummaryType = "testrun"
-	SummaryTypeTeststep SummaryType = "teststep"
-)
-
-// Metadata is the common metadata of all ouputs and summaries.
-type Metadata struct {
-	// Landscape describes the current dev,staging,canary,office or live.
-	Landscape         string `json:"landscape"`
-	CloudProvider     string `json:"cloudprovider"`
-	KubernetesVersion string `json:"k8s_version"`
-
-	// ComponentDescriptor describes the current component_descriptor of the direct landscape-setup components.
-	// It is formated as an array of components: { name: "my_component", version: "0.0.1" }
-	ComponentDescriptor []*componentdescriptor.Component `json:"bom"`
-
-	// Name of the testrun crd object.
-	TestrunID string `json:"testrun_id"`
-
-	// Link to the workflow in the argo ui
-	// Only set if an ingress with the name "argo-ui" for the argoui is set.
-	// Argo URL is in format: https://argo-endpoint.com/workflows/namespace/wf-name
-	ArgoUIExternalURL string `json:"argo_url"`
-}
-
-// StepExportMetadata is the metadata of one step of a testrun.
-type StepExportMetadata struct {
-	Metadata
-	TestDefName string           `json:"testdefinition"`
-	Phase       argov1.NodePhase `json:"phase,omitempty"`
-	StartTime   *metav1.Time     `json:"startTime,omitempty"`
-	Duration    int64            `json:"duration,omitempty"`
-}
-
-// TestrunSummary is the result of the overall testrun.
-type TestrunSummary struct {
-	Metadata  *Metadata        `json:"tm"`
-	Type      SummaryType      `json:"type"`
-	Phase     argov1.NodePhase `json:"phase,omitempty"`
-	StartTime *metav1.Time     `json:"startTime,omitempty"`
-	Duration  int64            `json:"duration,omitempty"`
-	TestsRun  int              `json:"testsRun,omitempty"`
-}
-
-// StepSummary is the result of a specific step.
-type StepSummary struct {
-	Metadata  *Metadata        `json:"tm"`
-	Type      SummaryType      `json:"type"`
-	Name      string           `json:"name,omitempty"`
-	Phase     argov1.NodePhase `json:"phase,omitempty"`
-	StartTime *metav1.Time     `json:"startTime,omitempty"`
-	Duration  int64            `json:"duration,omitempty"`
 }
 
 // notificationConfig is the configuration that is used by concourse to send notifications.

--- a/pkg/testrunner/run.go
+++ b/pkg/testrunner/run.go
@@ -29,6 +29,15 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
+// GetTestruns returns all testruns of a RunList as testrun array
+func (r RunList) GetTestruns() []*tmv1beta1.Testrun {
+	testruns := []*tmv1beta1.Testrun{}
+	for _, run := range r {
+		testruns = append(testruns, run.Testrun)
+	}
+	return testruns
+}
+
 func runTestrun(tmClient kubernetes.Interface, tr *tmv1beta1.Testrun, namespace, name string) (*tmv1beta1.Testrun, error) {
 	ctx := context.Background()
 	defer ctx.Done()

--- a/pkg/testrunner/template/types.go
+++ b/pkg/testrunner/template/types.go
@@ -38,3 +38,14 @@ type TestrunParameters struct {
 	FloatingPoolName        string
 	ComponentDescriptorPath string
 }
+
+// TestrunFile is the internal representation of a rendered testrun chart with metadata information
+type TestrunFile struct {
+	File     string
+	Metadata TestrunFileMetadata
+}
+
+// TestrunFileMetadata represents the metadata of a rendered testrun.
+type TestrunFileMetadata struct {
+	KubernetesVersion string
+}

--- a/test/testrunner/output/testrunner_output_execution_test.go
+++ b/test/testrunner/output/testrunner_output_execution_test.go
@@ -21,6 +21,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/gardener/test-infra/pkg/testrunner"
+
 	"github.com/gardener/test-infra/pkg/testmachinery"
 	"github.com/gardener/test-infra/pkg/testrunner/result"
 
@@ -91,7 +93,7 @@ var _ = Describe("Testrunner execution tests", func() {
 		defer utils.DeleteTestrun(tmClient, tr)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = result.Output(&testrunConfig, tmClient, namespace, tr, &result.Metadata{})
+		err = result.Output(&testrunConfig, tmClient, namespace, tr, &testrunner.Metadata{TestrunID: tr.Name})
 		Expect(err).ToNot(HaveOccurred())
 
 		file, err := os.Open(testrunConfig.OutputFile)
@@ -130,7 +132,7 @@ var _ = Describe("Testrunner execution tests", func() {
 		defer utils.DeleteTestrun(tmClient, tr)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = result.Output(&testrunConfig, tmClient, namespace, tr, &result.Metadata{})
+		err = result.Output(&testrunConfig, tmClient, namespace, tr, &testrunner.Metadata{TestrunID: tr.Name})
 		Expect(err).ToNot(HaveOccurred())
 
 		file, err := os.Open(testrunConfig.OutputFile)

--- a/test/testrunner/run/testrunner_run_test.go
+++ b/test/testrunner/run/testrunner_run_test.go
@@ -80,25 +80,41 @@ var _ = Describe("Testrunner execution tests", func() {
 	Context("testrun", func() {
 		It("should run a single testrun", func() {
 			tr := resources.GetBasicTestrun(namespace, commitSha)
-			finishedTr, err := testrunner.Run(&testrunConfig, []*tmv1beta1.Testrun{tr}, "test-")
-			defer utils.DeleteTestrun(tmClient, finishedTr[0])
+			run := []*testrunner.Run{
+				{
+					Testrun:  tr,
+					Metadata: &testrunner.Metadata{},
+				},
+			}
+			finishedTr, err := testrunner.ExecuteTestrun(&testrunConfig, run, "test-")
+			defer utils.DeleteTestrun(tmClient, finishedTr[0].Testrun)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(len(finishedTr)).To(Equal(1))
-			Expect(finishedTr[0].Status.Phase).To(Equal(tmv1beta1.PhaseStatusSuccess))
+			Expect(finishedTr[0].Testrun.Status.Phase).To(Equal(tmv1beta1.PhaseStatusSuccess))
 		})
 
 		It("should run 2 testruns", func() {
 			tr := resources.GetBasicTestrun(namespace, commitSha)
 			tr2 := resources.GetBasicTestrun(namespace, commitSha)
-			finishedTr, err := testrunner.Run(&testrunConfig, []*tmv1beta1.Testrun{tr, tr2}, "test-")
-			defer utils.DeleteTestrun(tmClient, finishedTr[0])
-			defer utils.DeleteTestrun(tmClient, finishedTr[1])
+			run := []*testrunner.Run{
+				{
+					Testrun:  tr,
+					Metadata: &testrunner.Metadata{},
+				},
+				{
+					Testrun:  tr2,
+					Metadata: &testrunner.Metadata{},
+				},
+			}
+			finishedTr, err := testrunner.ExecuteTestrun(&testrunConfig, run, "test-")
+			defer utils.DeleteTestrun(tmClient, finishedTr[0].Testrun)
+			defer utils.DeleteTestrun(tmClient, finishedTr[1].Testrun)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(len(finishedTr)).To(Equal(2))
-			Expect(finishedTr[0].Status.Phase).To(Equal(tmv1beta1.PhaseStatusSuccess))
-			Expect(finishedTr[1].Status.Phase).To(Equal(tmv1beta1.PhaseStatusSuccess))
+			Expect(finishedTr[0].Testrun.Status.Phase).To(Equal(tmv1beta1.PhaseStatusSuccess))
+			Expect(finishedTr[1].Testrun.Status.Phase).To(Equal(tmv1beta1.PhaseStatusSuccess))
 		})
 
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a new type called `Run` which represents a testrun with specific metadata.
This makes it possible to have specific metadata information like the k8s version, for a testrun executed by the testrunner. 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
Add context metadata to testruns executed by the Testrunner.
```
