### PR TITLE
Add shared folder to artifacts

### DIFF
--- a/docs/GetStarted.md
+++ b/docs/GetStarted.md
@@ -4,6 +4,7 @@
   - [Create a Test](#create-a-test)
     - [Input Contract](#input-contract)
     - [Export Contract](#export-contract)
+    - [Shared Folder](#shared-folder)
     - [Images](#images)
   - [Create a Testrun](#create-a-testrun)
   - [Configuration](#configuration)
@@ -116,6 +117,10 @@ It then automatically uploads these documents to an index named like the TestDef
       { "index": { "_index": "mySecondSpecificIndex", "_type": "_doc" } }
       { "key3": 5 }
     ```
+
+### Shared Folder
+
+Data that is stored in `TM_SHARED_PATH` location, can be accessed from within any testflow step of a the workflow. This is essential if e.g. a test flow step needs to evaluate the output of the previously finished test flow step. This folder is also available as an artifact in the Argo UI.
 
 ### Images
 

--- a/pkg/testmachinery/testdefinition/testdefinition.go
+++ b/pkg/testmachinery/testdefinition/testdefinition.go
@@ -91,6 +91,10 @@ func New(def *tmv1beta1.TestDefinition, loc Location, fileName string) *TestDefi
 					Name: "kubeconfigs",
 					Path: testmachinery.TM_KUBECONFIG_PATH,
 				},
+				{
+					Name: "sharedFolder",
+					Path: testmachinery.TM_SHARED_PATH,
+				},
 			},
 		},
 		Outputs: argov1.Outputs{
@@ -198,6 +202,11 @@ func (td *TestDefinition) AddSerialStdOutput() {
 		Path: testmachinery.TM_KUBECONFIG_PATH,
 	}
 	td.AddOutputArtifacts(kubeconfigArtifact)
+	sharedFolderArtifact := argov1.Artifact{
+		Name: "sharedFolder",
+		Path: testmachinery.TM_SHARED_PATH,
+	}
+	td.AddOutputArtifacts(sharedFolderArtifact)
 }
 
 // AddConfig adds the config elements of different types (environment variable) to the TestDefinitions's template.

--- a/pkg/testmachinery/testflow/node.go
+++ b/pkg/testmachinery/testflow/node.go
@@ -82,6 +82,10 @@ func (n *Node) addTask(lastSerialNode, rootNode *Node) {
 			Name: "kubeconfigs",
 			From: fmt.Sprintf("{{tasks.%s.outputs.artifacts.kubeconfigs}}", lastSerialNode.Task.Name),
 		},
+		{
+			Name: "sharedFolder",
+			From: fmt.Sprintf("{{tasks.%s.outputs.artifacts.sharedFolder}}", lastSerialNode.Task.Name),
+		},
 	}
 
 	if n.TestDefinition.Location.Type() != tmv1beta1.LocationTypeLocal {

--- a/pkg/testmachinery/types.go
+++ b/pkg/testmachinery/types.go
@@ -24,7 +24,10 @@ import (
 
 const (
 	// TM_KUBECONFIG_PATH is the path where kubeconfigs are mounted to tests.
-	TM_KUBECONFIG_PATH = "/tmp/env/kubeconfig"
+	TM_KUBECONFIG_PATH = "/tmp/tm/kubeconfig"
+
+	// TM_SHARED_PATH is the path to a shared folder, where content is shared among the workflow steps
+	TM_SHARED_PATH = "/tmp/tm/shared"
 
 	// TM_REPO_PATH is the path where the repo/location is mounted to the tests.
 	TM_REPO_PATH = "/src"


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds shared folder which can be used across the flow steps.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Add shared folder for testflow steps.
```
