### PR TITLE
Update structure of BOM output

### DIFF
--- a/pkg/testrunner/componentdescriptor/componentdescriptor.go
+++ b/pkg/testrunner/componentdescriptor/componentdescriptor.go
@@ -18,7 +18,7 @@ import (
 )
 
 // GetComponents returns a list of all git/component dependencies.
-func GetComponents(content []byte) ([]*Component, error) {
+func GetComponents(content []byte) (ComponentList, error) {
 
 	components := components{
 		components:   make([]*Component, 0, 0),
@@ -35,6 +35,23 @@ func GetComponents(content []byte) ([]*Component, error) {
 	}
 
 	return components.components, nil
+}
+
+// JSON returns the json output for a list of components
+// The list is converted into the format:
+// {
+//	"component_name": {
+//	 	"version": "0.0.0"
+//	}
+// }
+func (c ComponentList) JSON() map[string]ComponentJSON {
+	components := make(map[string]ComponentJSON)
+	for _, component := range c {
+		components[component.Name] = ComponentJSON{
+			Version: component.Version,
+		}
+	}
+	return components
 }
 
 func (c *components) add(newComponents []Component) {

--- a/pkg/testrunner/componentdescriptor/componentdescriptor_test.go
+++ b/pkg/testrunner/componentdescriptor/componentdescriptor_test.go
@@ -57,6 +57,6 @@ var _ = Describe("componentdescriptor test", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(len(dependencies)).To(Equal(2), "There should be 2 dependencies")
-		Expect(reflect.DeepEqual(dependencies, result)).To(BeTrue())
+		Expect(reflect.DeepEqual(dependencies, ComponentList(result))).To(BeTrue())
 	})
 })

--- a/pkg/testrunner/componentdescriptor/types.go
+++ b/pkg/testrunner/componentdescriptor/types.go
@@ -19,6 +19,13 @@ type Component struct {
 	Version string `yaml:"version"`
 }
 
+// ComponentList is a set of multiple components.
+type ComponentList []*Component
+
+// ComponentJSON is the object that is written to the elastic search metadata.
+type ComponentJSON struct {
+	Version string `json:"version"`
+}
 type components struct {
 	components   []*Component
 	componentSet map[Component]bool

--- a/pkg/testrunner/result/output.go
+++ b/pkg/testrunner/result/output.go
@@ -47,6 +47,8 @@ func Output(config *Config, tmClient kubernetes.Interface, namespace string, tr 
 		return nil
 	}
 
+	metadata.Testrun.StartTime = tr.Status.StartTime
+
 	if config.ArgoUIEndpoint != "" && tr.Status.Workflow != "" {
 		if u, err := url.ParseRequestURI(config.ArgoUIEndpoint); err == nil {
 			u.Path = path.Join(u.Path, "workflows", namespace, tr.Status.Workflow)

--- a/pkg/testrunner/testrunner.go
+++ b/pkg/testrunner/testrunner.go
@@ -66,7 +66,7 @@ func runChart(tmClient kubernetes.Interface, runs RunList, namespace, testrunNam
 				tr.Status.Phase = tmv1beta1.PhaseStatusFailed
 			}
 			r.Testrun = tr
-			r.Metadata.TestrunID = tr.Name
+			r.Metadata.Testrun.ID = tr.Name
 			mutex.Lock()
 			finishedTestruns = append(finishedTestruns, r)
 			mutex.Unlock()

--- a/pkg/testrunner/types.go
+++ b/pkg/testrunner/types.go
@@ -18,7 +18,6 @@ import (
 	argov1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	tmv1beta1 "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
-	"github.com/gardener/test-infra/pkg/testrunner/componentdescriptor"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -66,10 +65,10 @@ type Metadata struct {
 
 	// ComponentDescriptor describes the current component_descriptor of the direct landscape-setup components.
 	// It is formated as an array of components: { name: "my_component", version: "0.0.1" }
-	ComponentDescriptor []*componentdescriptor.Component `json:"bom"`
+	ComponentDescriptor interface{} `json:"bom"`
 
 	// Name of the testrun crd object.
-	TestrunID string `json:"testrun_id"`
+	Testrun TestrunMetadata `json:"tr"`
 
 	// Link to the workflow in the argo ui
 	// Only set if an ingress with the name "argo-ui" for the argoui is set.
@@ -77,10 +76,19 @@ type Metadata struct {
 	ArgoUIExternalURL string `json:"argo_url"`
 }
 
+// TestrunMetadata represents the metadata of a testrun
+type TestrunMetadata struct {
+	// Name of the testrun crd object.
+	ID string `json:"id"`
+
+	// Startime of the testrun.
+	StartTime *metav1.Time `json:"startTime"`
+}
+
 // StepExportMetadata is the metadata of one step of a testrun.
 type StepExportMetadata struct {
 	Metadata
-	TestDefName string           `json:"testdefinition"`
+	TestDefName string           `json:"testdefinition,omitempty"`
 	Phase       argov1.NodePhase `json:"phase,omitempty"`
 	StartTime   *metav1.Time     `json:"startTime,omitempty"`
 	Duration    int64            `json:"duration,omitempty"`
@@ -88,8 +96,8 @@ type StepExportMetadata struct {
 
 // TestrunSummary is the result of the overall testrun.
 type TestrunSummary struct {
-	Metadata  *Metadata        `json:"tm"`
-	Type      SummaryType      `json:"type"`
+	Metadata  *Metadata        `json:"tm,omitempty"`
+	Type      SummaryType      `json:"type,omitempty"`
 	Phase     argov1.NodePhase `json:"phase,omitempty"`
 	StartTime *metav1.Time     `json:"startTime,omitempty"`
 	Duration  int64            `json:"duration,omitempty"`
@@ -98,8 +106,8 @@ type TestrunSummary struct {
 
 // StepSummary is the result of a specific step.
 type StepSummary struct {
-	Metadata  *Metadata        `json:"tm"`
-	Type      SummaryType      `json:"type"`
+	Metadata  *Metadata        `json:"tm,omitempty"`
+	Type      SummaryType      `json:"type,omitempty"`
 	Name      string           `json:"name,omitempty"`
 	Phase     argov1.NodePhase `json:"phase,omitempty"`
 	StartTime *metav1.Time     `json:"startTime,omitempty"`

--- a/test/testrunner/output/testrunner_output_execution_test.go
+++ b/test/testrunner/output/testrunner_output_execution_test.go
@@ -93,7 +93,7 @@ var _ = Describe("Testrunner execution tests", func() {
 		defer utils.DeleteTestrun(tmClient, tr)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = result.Output(&testrunConfig, tmClient, namespace, tr, &testrunner.Metadata{TestrunID: tr.Name})
+		err = result.Output(&testrunConfig, tmClient, namespace, tr, &testrunner.Metadata{Testrun: testrunner.TestrunMetadata{ID: tr.Name}})
 		Expect(err).ToNot(HaveOccurred())
 
 		file, err := os.Open(testrunConfig.OutputFile)
@@ -115,7 +115,7 @@ var _ = Describe("Testrunner execution tests", func() {
 			if line%2 == 0 {
 				Expect(jsonBody["index"]).To(BeNil())
 				Expect(jsonBody["tm"]).ToNot(BeEmpty())
-				Expect(jsonBody["tm"].(map[string]interface{})["testrun_id"]).ToNot(BeEmpty())
+				Expect(jsonBody["tm"].(map[string]interface{})["tr"]).ToNot(BeEmpty())
 
 			}
 			line++
@@ -132,7 +132,7 @@ var _ = Describe("Testrunner execution tests", func() {
 		defer utils.DeleteTestrun(tmClient, tr)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = result.Output(&testrunConfig, tmClient, namespace, tr, &testrunner.Metadata{TestrunID: tr.Name})
+		err = result.Output(&testrunConfig, tmClient, namespace, tr, &testrunner.Metadata{Testrun: testrunner.TestrunMetadata{ID: tr.Name}})
 		Expect(err).ToNot(HaveOccurred())
 
 		file, err := os.Open(testrunConfig.OutputFile)
@@ -151,7 +151,7 @@ var _ = Describe("Testrunner execution tests", func() {
 		Expect(scanner.Err()).ToNot(HaveOccurred())
 
 		Expect(jsonBody["tm"]).ToNot(BeNil())
-		Expect(jsonBody["tm"].(map[string]interface{})["testrun_id"]).To(Equal(tr.Name))
+		Expect(jsonBody["tm"].(map[string]interface{})["tr"].(map[string]interface{})["id"]).To(Equal(tr.Name))
 
 		Expect(documents[len(documents)-2]["index"].(map[string]interface{})["_index"]).To(Equal("integration-testdef"))
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the output for the component descriptor to use this format:
```json
{
  "<component_name>": {
    "version": "<version>"
  }
}
```
Also, changed the testrun metadata to:
```json
{
  "tm": {
    "tr": {
      "id": "<testrun_id>",
      "startTime": "<startTime>"
    }
  }
}
```
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Changed the result format of the testrunner.
```
