### PR TITLE
Make testdef path configurable

### DIFF
--- a/.ci/deploy
+++ b/.ci/deploy
@@ -39,8 +39,9 @@ mv ./kubectl /usr/local/bin/kubectl
 if ! which helm 1>/dev/null; then
   echo -n "Installing helm... "
   install_helm_path="./get_helm.sh"
-  curl https://raw.githubusercontent.com/helm/helm/v2.9.1/scripts/get > "${install_helm_path}"
+  curl https://raw.githubusercontent.com/helm/helm/v2.13.0/scripts/get > "${install_helm_path}"
   chmod 700 "${install_helm_path}"
+  export DESIRED_VERSION=v2.13.0
   bash "${install_helm_path}"
   rm ./"${install_helm_path}"
   echo "done."

--- a/pkg/testmachinery/testmachinery.go
+++ b/pkg/testmachinery/testmachinery.go
@@ -27,7 +27,7 @@ var tmConfig *TmConfiguration
 
 // Setup fetches all configuration values and creates the TmConfiguration.
 func Setup() {
-
+	TESTDEF_PATH = util.Getenv("TESTDEF_PATH", ".test-defs")
 	PREPARE_IMAGE = util.Getenv("PREPARE_IMAGE", "eu.gcr.io/gardener-project/gardener/testmachinery/prepare-step:latest")
 	BASE_IMAGE = util.Getenv("BASE_IMAGE", "eu.gcr.io/gardener-project/gardener/testmachinery/base-step:0.28.0")
 

--- a/pkg/testmachinery/types.go
+++ b/pkg/testmachinery/types.go
@@ -29,9 +29,6 @@ const (
 	// TM_REPO_PATH is the path where the repo/location is mounted to the tests.
 	TM_REPO_PATH = "/src"
 
-	// TESTDEF_PATH is the path to TestDefinition inside repositories (scripts/integration-tests/argo/tm)
-	TESTDEF_PATH = ".test-defs"
-
 	// PHASE_RUNNING is the name of the running phase.
 	PHASE_RUNNING = "Running"
 
@@ -45,6 +42,9 @@ const (
 )
 
 var (
+	// TESTDEF_PATH is the path to TestDefinition inside repositories (scripts/integration-tests/argo/tm)
+	TESTDEF_PATH string
+
 	// PREPARE_IMAGE is image of the prepare step.
 	PREPARE_IMAGE string
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes the path where the testmachinery looks for TestDefinition Files in the repository.

Mainly needed for the it tests to be moved to different directory.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Make the TestDefinition path configurable
```
