### PR TITLE
Add collect command to testrunner

### DIFF
--- a/cmd/testrunner/cmd/cmd.go
+++ b/cmd/testrunner/cmd/cmd.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"github.com/gardener/test-infra/cmd/testrunner/cmd/collect"
 	"os"
 
 	"github.com/gardener/test-infra/cmd/testrunner/cmd/docs"
@@ -48,5 +49,6 @@ func init() {
 
 	runtemplate.AddCommand(rootCmd)
 	runtestrun.AddCommand(rootCmd)
+	collect.AddCommand(rootCmd)
 	docs.AddCommand(rootCmd)
 }

--- a/cmd/testrunner/cmd/collect/collect.go
+++ b/cmd/testrunner/cmd/collect/collect.go
@@ -1,0 +1,123 @@
+// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collect
+
+import (
+	"context"
+	"github.com/gardener/test-infra/pkg/testrunner/result"
+	"os"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/test-infra/pkg/testmachinery"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/test-infra/pkg/testrunner"
+	"github.com/gardener/test-infra/pkg/util"
+	"github.com/spf13/cobra"
+
+	log "github.com/sirupsen/logrus"
+
+	tmv1beta1 "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
+)
+
+var (
+	tmKubeconfigPath string
+	namespace        string
+
+	testrunName string
+
+	outputFilePath          string
+	elasticSearchConfigName string
+	s3Endpoint              string
+	s3SSL                   bool
+	argouiEndpoint          string
+	concourseOnErrorDir     string
+)
+
+// AddCommand adds run-testrun to a command.
+func AddCommand(cmd *cobra.Command) {
+	cmd.AddCommand(collectCmd)
+}
+
+var collectCmd = &cobra.Command{
+	Use:   "collect",
+	Short: "Collects results from a completed testrun.",
+	Run: func(cmd *cobra.Command, args []string) {
+		if debug, _ := cmd.Flags().GetBool("debug"); debug {
+			log.SetLevel(log.DebugLevel)
+			log.Warn("Set debug log level")
+
+			cmd.DebugFlags()
+		}
+		ctx := context.Background()
+		defer ctx.Done()
+		log.Info("Start testmachinery testrunner")
+
+		collectConfig := &result.Config{
+			OutputFile:          outputFilePath,
+			ESConfigName:        elasticSearchConfigName,
+			S3Endpoint:          s3Endpoint,
+			S3SSL:               s3SSL,
+			ArgoUIEndpoint:      argouiEndpoint,
+			ConcourseOnErrorDir: concourseOnErrorDir,
+		}
+		log.Debugln(util.PrettyPrintStruct(collectConfig))
+
+		tmClient, err := kubernetes.NewClientFromFile("", tmKubeconfigPath, client.Options{
+			Scheme: testmachinery.TestMachineryScheme,
+		})
+		if err != nil {
+			log.Fatalf("Cannot build kubernetes client from %s: %s", tmKubeconfigPath, err.Error())
+		}
+
+		tr := &tmv1beta1.Testrun{}
+		err = tmClient.Client().Get(ctx, client.ObjectKey{Namespace: namespace, Name: testrunName}, tr)
+		if err != nil {
+			log.Fatalf("Cannot fetch testrun %s from cluster", testrunName)
+		}
+
+		run := &testrunner.Run{
+			Testrun:  tr,
+			Metadata: &testrunner.Metadata{},
+		}
+
+		_, err = result.Collect(collectConfig, tmClient, namespace, []*testrunner.Run{run})
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+
+		log.Info("Finished collecting testrun results.")
+	},
+}
+
+func init() {
+	// configuration flags
+	collectCmd.Flags().StringVar(&tmKubeconfigPath, "tm-kubeconfig-path", "", "Path to the testmachinery cluster kubeconfig")
+	collectCmd.MarkFlagRequired("tm-kubeconfig-path")
+	collectCmd.MarkFlagFilename("tm-kubeconfig-path")
+	collectCmd.Flags().StringVarP(&namespace, "namespace", "n", "default", "Namespace where the testrun should be deployed.")
+
+	collectCmd.Flags().StringVarP(&testrunName, "tr-name", "t", "", "Name of the testrun to collect results.")
+	collectCmd.MarkFlagRequired("testruns-chart-path")
+
+	// parameter flags
+	collectCmd.Flags().StringVar(&outputFilePath, "output-file-path", "./testout", "The filepath where the summary should be written to.")
+	collectCmd.Flags().StringVar(&elasticSearchConfigName, "es-config-name", "sap_internal", "The elasticsearch secret-server config name.")
+	collectCmd.Flags().StringVar(&s3Endpoint, "s3-endpoint", os.Getenv("S3_ENDPOINT"), "S3 endpoint of the testmachinery cluster.")
+	collectCmd.Flags().BoolVar(&s3SSL, "s3-ssl", false, "S3 has SSL enabled.")
+	collectCmd.Flags().StringVar(&argouiEndpoint, "argoui-endpoint", "", "ArgoUI endpoint of the testmachinery cluster.")
+	collectCmd.Flags().StringVar(&concourseOnErrorDir, "concourse-onError-dir", os.Getenv("ON_ERROR_DIR"), "On error dir which is used by Concourse.")
+
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the command `collect` to the testrunner cli which collects the results of completed testruns and optionally stores them into elastic search.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Add `testrunner collect` command to collect results of completed Testruns.
```
