### PR TITLE
added kibana log url

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ See [docs/GetStarted](docs/GetStarted.md)
 1. Setup a k8s cluster (min. Version 1.10.x, preferred Version: 1.12.x, minikube is also suitable)
 2. Install prerequisites ([argo](https://github.com/argoproj/argo), [minio](https://www.minio.io/) and the Testrun CRD) with `make install`
     * The default namespace is `default`; another namespace can be defined with `make install NS=namespace-name`
-3. Install the TestMachinery with `make install_controller`. Then the controller alongside to a service, validation webhooks and needed rbac permissions is installed.
+3. Install the TestMachinery with `make install-controller`. Then the controller alongside to a service, validation webhooks and needed rbac permissions is installed.
 4. `TestRun`s can be executed by creating them with `kubectl create -f path/to/testrun.yaml` (examples can be found in the [examples folder](examples))
 
 **Prerequisite**: the TestMachinery and the `TestRun`s have to reside in the same namespace due to cross-namespace issues of the argo workflow engine.

--- a/cmd/testrunner/cmd/collect/collect.go
+++ b/cmd/testrunner/cmd/collect/collect.go
@@ -43,6 +43,7 @@ var (
 	s3Endpoint              string
 	s3SSL                   bool
 	argouiEndpoint          string
+	kibanaEndpoint          string
 	concourseOnErrorDir     string
 )
 
@@ -71,6 +72,7 @@ var collectCmd = &cobra.Command{
 			S3Endpoint:          s3Endpoint,
 			S3SSL:               s3SSL,
 			ArgoUIEndpoint:      argouiEndpoint,
+			KibanaEndpoint:      kibanaEndpoint,
 			ConcourseOnErrorDir: concourseOnErrorDir,
 		}
 		log.Debugln(util.PrettyPrintStruct(collectConfig))
@@ -118,6 +120,7 @@ func init() {
 	collectCmd.Flags().StringVar(&s3Endpoint, "s3-endpoint", os.Getenv("S3_ENDPOINT"), "S3 endpoint of the testmachinery cluster.")
 	collectCmd.Flags().BoolVar(&s3SSL, "s3-ssl", false, "S3 has SSL enabled.")
 	collectCmd.Flags().StringVar(&argouiEndpoint, "argoui-endpoint", "", "ArgoUI endpoint of the testmachinery cluster.")
+	collectCmd.Flags().StringVar(&kibanaEndpoint, "kibana-logging-endpoint", "", "Kibana endpoint used for logging of the testmachinery cluster.")
 	collectCmd.Flags().StringVar(&concourseOnErrorDir, "concourse-onError-dir", os.Getenv("ON_ERROR_DIR"), "On error dir which is used by Concourse.")
 
 }

--- a/cmd/testrunner/cmd/runtemplate/run_template.go
+++ b/cmd/testrunner/cmd/runtemplate/run_template.go
@@ -42,6 +42,7 @@ var (
 	s3Endpoint              string
 	s3SSL                   bool
 	argouiEndpoint          string
+	kibanaEndpoint          string
 	concourseOnErrorDir     string
 
 	testrunChartPath         string
@@ -113,6 +114,7 @@ var runCmd = &cobra.Command{
 			S3Endpoint:          s3Endpoint,
 			S3SSL:               s3SSL,
 			ArgoUIEndpoint:      argouiEndpoint,
+			KibanaEndpoint:      kibanaEndpoint,
 			ConcourseOnErrorDir: concourseOnErrorDir,
 		}
 
@@ -184,6 +186,7 @@ func init() {
 	runCmd.Flags().StringVar(&s3Endpoint, "s3-endpoint", os.Getenv("S3_ENDPOINT"), "S3 endpoint of the testmachinery cluster.")
 	runCmd.Flags().BoolVar(&s3SSL, "s3-ssl", false, "S3 has SSL enabled.")
 	runCmd.Flags().StringVar(&argouiEndpoint, "argoui-endpoint", "", "ArgoUI endpoint of the testmachinery cluster.")
+	runCmd.Flags().StringVar(&kibanaEndpoint, "kibana-logging-endpoint", "", "Kibana endpoint used for logging of the testmachinery cluster.")
 	runCmd.Flags().StringVar(&concourseOnErrorDir, "concourse-onError-dir", os.Getenv("ON_ERROR_DIR"), "On error dir which is used by Concourse.")
 
 	// parameter flags

--- a/cmd/testrunner/cmd/runtestrun/run_testrun.go
+++ b/cmd/testrunner/cmd/runtestrun/run_testrun.go
@@ -90,6 +90,7 @@ var runTestrunCmd = &cobra.Command{
 		run := []*testrunner.Run{
 			{
 				Testrun: &tr,
+				Metadata: &testrunner.Metadata{},
 			},
 		}
 

--- a/pkg/testrunner/elasticsearch/elasticsearchbulk.go
+++ b/pkg/testrunner/elasticsearch/elasticsearchbulk.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/gardener/test-infra/pkg/util"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -27,7 +28,7 @@ var newLine = []byte("\n")
 
 // Marshal creates a elastic search bulk json of its metadata and sources.
 func (b *Bulk) Marshal() (*bytes.Buffer, error) {
-	meta, err := json.Marshal(b.Metadata)
+	meta, err := util.MarshalNoHTMLEscape(b.Metadata)
 	if err != nil {
 		return nil, fmt.Errorf("Cannot marshal ElasticsearchBulk %s", err.Error())
 	}
@@ -36,9 +37,7 @@ func (b *Bulk) Marshal() (*bytes.Buffer, error) {
 
 	for _, source := range b.Sources {
 		buf.Write(meta)
-		buf.Write(newLine)
 		buf.Write(source)
-		buf.Write(newLine)
 	}
 
 	return buf, nil
@@ -89,7 +88,7 @@ func parseExportedBulkFormat(name string, stepMeta interface{}, docs []byte) []b
 		var jsonBody map[string]interface{}
 		err := json.Unmarshal(doc, &jsonBody)
 		if err != nil {
-			log.Errorf("Cannot unmashal document %s", err.Error())
+			log.Errorf("Cannot unmarshal document %s", err.Error())
 			continue
 		}
 
@@ -100,9 +99,9 @@ func parseExportedBulkFormat(name string, stepMeta interface{}, docs []byte) []b
 		}
 
 		jsonBody["tm"] = stepMeta
-		patchedDoc, err := json.Marshal(jsonBody)
+		patchedDoc, err := util.MarshalNoHTMLEscape(jsonBody) // json.Marshal(jsonBody)
 		if err != nil {
-			log.Errorf("Cannot mashal artifact %s", err.Error())
+			log.Errorf("Cannot marshal artifact %s", err.Error())
 			continue
 		}
 
@@ -121,7 +120,7 @@ func parseExportedBulkFormat(name string, stepMeta interface{}, docs []byte) []b
 
 		buf, err := bulk.Marshal()
 		if err != nil {
-			log.Debugf("Cannot unmashal %s", err.Error())
+			log.Debugf("Cannot unmarshal %s", err.Error())
 			meta = nil
 			continue
 		}

--- a/pkg/testrunner/result/collect.go
+++ b/pkg/testrunner/result/collect.go
@@ -25,8 +25,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// Collect collects results of all testruns and write them to a file.
-// It returns wheter there are failed testruns or not.
+// Collect collects results of all testruns and writes them to a file.
+// It returns whether there are failed testruns or not.
 func Collect(config *Config, tmClient kubernetes.Interface, namespace string, runs testrunner.RunList) (bool, error) {
 	testrunsFailed := false
 	for _, run := range runs {

--- a/pkg/testrunner/result/types.go
+++ b/pkg/testrunner/result/types.go
@@ -31,6 +31,9 @@ type Config struct {
 	// Endpoint of the argo ui of the testmachinery.
 	ArgoUIEndpoint string
 
+	// Endpoint of kibana for the logs of the testmachinery.
+	KibanaEndpoint string
+
 	// Path to the error directory of concourse to put the notify.cfg in.
 	ConcourseOnErrorDir string
 }
@@ -44,4 +47,10 @@ type email struct {
 	Subject    string   `yaml:"subject"`
 	Recipients []string `yaml:"recipients"`
 	MailBody   string   `yaml:"mail_body"`
+}
+
+type kibanaFilter struct {
+	IndexPatternID string
+	WorkflowID     string
+	PodID          string
 }

--- a/pkg/testrunner/types.go
+++ b/pkg/testrunner/types.go
@@ -56,7 +56,7 @@ const (
 	SummaryTypeTeststep SummaryType = "teststep"
 )
 
-// Metadata is the common metadata of all ouputs and summaries.
+// Metadata is the common metadata of all outputs and summaries.
 type Metadata struct {
 	// Landscape describes the current dev,staging,canary,office or live.
 	Landscape         string `json:"landscape"`
@@ -71,9 +71,12 @@ type Metadata struct {
 	Testrun TestrunMetadata `json:"tr"`
 
 	// Link to the workflow in the argo ui
-	// Only set if an ingress with the name "argo-ui" for the argoui is set.
 	// Argo URL is in format: https://argo-endpoint.com/workflows/namespace/wf-name
-	ArgoUIExternalURL string `json:"argo_url"`
+	ArgoUIExternalURL string `json:"argo_url,omitempty"`
+
+	// Link to the logs in kibana
+	// Kibana URL is in format: https://kibana-endpoint.com/app/kibana#/discover/<very_complex_IDs_and_stuff>
+	KibanaExternalURL string `json:"kibana_url,omitempty"`
 }
 
 // TestrunMetadata represents the metadata of a testrun

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -15,6 +15,7 @@
 package util
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -168,4 +169,17 @@ func PrettyPrintStruct(obj interface{}) string {
 		return ""
 	}
 	return string(str)
+}
+
+// MarshalNoHTMLEscape is nearly same as json.Marshal but does NOT HTLM-escape <, > or &
+// However it does add a newline char at the end (as done by json.Encoder.Encode)
+func MarshalNoHTMLEscape(v interface{}) ([]byte, error) {
+	buffer := bytes.NewBuffer([]byte{})
+	enc := json.NewEncoder(buffer)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(v)
+	if err != nil {
+		return nil, err
+	}
+	return buffer.Bytes(), nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a direct link to the metadata of each testrun and teststep pointing to the respective kibana logging installation with a an active filter on the specific testrun.