### PR TITLE
Add distributed minio option in helm chart

### DIFF
--- a/charts/bootstrap_tm_prerequisites/templates/minio-distributed.yaml
+++ b/charts/bootstrap_tm_prerequisites/templates/minio-distributed.yaml
@@ -1,0 +1,120 @@
+# Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+{{ if .Values.objectStorage.distributed.enabled }}
+apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
+kind: StatefulSet
+metadata:
+  name: minio
+  namespace: {{.Release.Namespace}}
+  labels:
+    app: minio
+spec:
+  serviceName: minio
+  replicas: {{ .Values.objectStorage.distributed.replicas }}
+  selector:
+    matchLabels:
+      app: minio
+  template:
+    metadata:
+      labels:
+        app: minio
+    spec:
+      containers:
+      - name: minio
+        env:
+        - name: MINIO_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{.Values.objectStorage.secret.name}}
+              key: accessKey
+        - name: MINIO_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{.Values.objectStorage.secret.name}}
+              key: secretKey
+        image: minio/minio:latest
+        args:
+          - server
+          {{- range $i, $v := until ( int .Values.objectStorage.distributed.replicas ) }}
+          - http://minio-{{$i}}.minio.{{.Release.Namespace}}.svc.cluster.local/data
+          {{- end }}
+        ports:
+        - containerPort: 9000
+        resources:
+          limits:
+            memory: 256Mi
+          requests:
+            memory: 150Mi
+        # These volume mounts are persistent. Each pod in the StatefulSet
+        # gets a volume mounted based on this field.
+        volumeMounts:
+        - name: data
+          mountPath: /data
+  # These are converted to volume claims by the controller
+  # and mounted at the paths mentioned above.
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: "{{.Values.objectStorage.storage}}"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  namespace: {{.Release.Namespace}}
+  labels:
+    app: minio
+spec:
+  clusterIP: None
+  ports:
+  - port: {{.Values.objectStorage.port}}
+    targetPort: 9000
+    name: minio
+  selector:
+    app: minio
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: minio-create-bucket
+  namespace: {{.Release.Namespace}}
+  labels:
+    app: minio-create-bucket
+spec:
+  restartPolicy: OnFailure
+  containers:
+    - name: minio-mc
+      image: minio/mc
+      command: ["/bin/sh", "-c",
+      "set -e;
+      /usr/bin/mc config host add myminio http://{{ .Values.objectStorage.serviceEndpoint }}:{{ .Values.objectStorage.port }} $MINIO_ACCESS_KEY $MINIO_SECRET_KEY;
+      /usr/bin/mc mb --ignore-existing myminio/{{ .Values.objectStorage.bucketName }};
+      /usr/bin/mc policy download myminio/{{ .Values.objectStorage.bucketName }};"]
+      env:
+        - name: MINIO_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{.Values.objectStorage.secret.name}}
+              key: accessKey
+        - name: MINIO_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{.Values.objectStorage.secret.name}}
+              key: secretKey
+{{ end }}

--- a/charts/bootstrap_tm_prerequisites/templates/minio-ingress.yaml
+++ b/charts/bootstrap_tm_prerequisites/templates/minio-ingress.yaml
@@ -1,0 +1,34 @@
+# Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+{{ if .Values.objectStorage.ingress.enabled }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: minio
+  namespace: {{.Release.Namespace}}
+  labels:
+    garden.sapcloud.io/purpose: managed-cert
+spec:
+  tls:
+  - hosts:
+    - {{ .Values.objectStorage.ingress.domain }}
+    secretName: minio-tls
+  rules:
+  - host: {{ .Values.objectStorage.ingress.domain }}
+    http:
+      paths:
+      - backend:
+          serviceName: minio-service
+          servicePort: 9000
+{{ end }}

--- a/charts/bootstrap_tm_prerequisites/templates/minio-secret.yaml
+++ b/charts/bootstrap_tm_prerequisites/templates/minio-secret.yaml
@@ -1,0 +1,21 @@
+# Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: Secret
+metadata:
+    name: {{.Values.objectStorage.secret.name}}
+    namespace: {{.Release.Namespace}}
+data:
+    accessKey: {{.Values.objectStorage.secret.accessKey | b64enc}}
+    secretKey: {{.Values.objectStorage.secret.secretKey | b64enc}}

--- a/charts/bootstrap_tm_prerequisites/templates/minio-service.yaml
+++ b/charts/bootstrap_tm_prerequisites/templates/minio-service.yaml
@@ -1,0 +1,26 @@
+# Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: Service
+metadata:
+    name: "{{.Values.objectStorage.serviceEndpoint}}"
+    namespace: {{.Release.Namespace}}
+spec:
+    type: {{.Values.objectStorage.serviceType}}
+    ports:
+    - port: {{.Values.objectStorage.port}}
+      targetPort: 9000
+      protocol: TCP
+    selector:
+        app: minio

--- a/charts/bootstrap_tm_prerequisites/templates/minio-single.yaml
+++ b/charts/bootstrap_tm_prerequisites/templates/minio-single.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+{{ if not .Values.objectStorage.distributed.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -31,19 +31,21 @@ spec:
   # Uncomment and add storageClass specific to your requirements below. Read more https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class-1
   #storageClassName:
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   # This name uniquely identifies the Deployment
   name: minio-deployment
   namespace: {{.Release.Namespace}}
 spec:
+  selector:
+    matchLabels:
+      app: minio
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
-        # Label is used as selector in the service.
         app: minio
     spec:
       # Refer to the PVC created earlier
@@ -61,9 +63,15 @@ spec:
         env:
         # Minio access key and secret key
         - name: MINIO_ACCESS_KEY
-          value: "{{.Values.objectStorage.secret.accessKey}}"
+          valueFrom:
+            secretKeyRef:
+              name: {{.Values.objectStorage.secret.name}}
+              key: accessKey
         - name: MINIO_SECRET_KEY
-          value: "{{.Values.objectStorage.secret.secretKey}}"
+          valueFrom:
+            secretKeyRef:
+              name: {{.Values.objectStorage.secret.name}}
+              key: secretKey
         ports:
         - containerPort: 9000
         resources:
@@ -83,26 +91,4 @@ spec:
         volumeMounts:
         - name: storage # must match the volume name, above
           mountPath: "/storage"
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: "{{.Values.objectStorage.serviceEndpoint}}"
-  namespace: {{.Release.Namespace}}
-spec:
-  type: {{.Values.objectStorage.serviceType}}
-  ports:
-    - port: {{.Values.objectStorage.port}}
-      targetPort: 9000
-      protocol: TCP
-  selector:
-    app: minio
----
-apiVersion: v1
-kind: Secret
-metadata:
-    name: {{.Values.objectStorage.secret.name}}
-    namespace: {{.Release.Namespace}}
-data:
-    accessKey: {{.Values.objectStorage.secret.accessKey | b64enc}}
-    secretKey: {{.Values.objectStorage.secret.secretKey | b64enc}}
+{{ end }}

--- a/charts/bootstrap_tm_prerequisites/values.yaml
+++ b/charts/bootstrap_tm_prerequisites/values.yaml
@@ -20,15 +20,21 @@ argoui:
   serviceType: ClusterIP
 
 objectStorage:
+  distributed:
+    enabled: false # true will deploys a statefulset instead of a deployment
+    replicas: 4 # have to be even and min 4 -> https://docs.minio.io/docs/minio-erasure-code-quickstart-guide
   bucketName: "tm-bucket"
   serviceEndpoint: "minio-service"
   serviceType: ClusterIP
   port: 9000
-  storage: 10Gi
+  storage: 10Gi # when distributed there will be a volume for every replica
   secret:
     name: "minio-secret"
     accessKey: "hvLsnYycFGw"
     secretKey: "lzzlRK1Q7LE"
+  ingress:
+    enabled: false
+    domain: ""
 
 secrets:
   github: "" # base64 encoded secrets


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the options to deploy minio in a distributed mode to ensure a HA setup.
In addition, an optional ingress will be deployed.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Add distributed minio option in helm chart
```
