### PR TITLE
moved kibana url types to exclude from custom exported metadata

### DIFF
--- a/cmd/testrunner/cmd/collect/collect.go
+++ b/cmd/testrunner/cmd/collect/collect.go
@@ -38,7 +38,7 @@ var (
 
 	testrunName string
 
-	outputFilePath          string
+	outputDirPath           string
 	elasticSearchConfigName string
 	s3Endpoint              string
 	s3SSL                   bool
@@ -67,7 +67,7 @@ var collectCmd = &cobra.Command{
 		log.Info("Start testmachinery testrunner")
 
 		collectConfig := &result.Config{
-			OutputDir:           outputFilePath,
+			OutputDir:           outputDirPath,
 			ESConfigName:        elasticSearchConfigName,
 			S3Endpoint:          s3Endpoint,
 			S3SSL:               s3SSL,
@@ -115,7 +115,7 @@ func init() {
 	collectCmd.MarkFlagRequired("testruns-chart-path")
 
 	// parameter flags
-	collectCmd.Flags().StringVarP(&outputFilePath, "output-file-path", "o", "", "The filepath where the summary should be written to.")
+	collectCmd.Flags().StringVar(&outputDirPath, "output-dir-path", "./testout", "The filepath where the summary should be written to.")
 	collectCmd.Flags().StringVar(&elasticSearchConfigName, "es-config-name", "", "The elasticsearch secret-server config name.")
 	collectCmd.Flags().StringVar(&s3Endpoint, "s3-endpoint", os.Getenv("S3_ENDPOINT"), "S3 endpoint of the testmachinery cluster.")
 	collectCmd.Flags().BoolVar(&s3SSL, "s3-ssl", false, "S3 has SSL enabled.")

--- a/docs/testrunner/testrunner_collect.md
+++ b/docs/testrunner/testrunner_collect.md
@@ -19,7 +19,7 @@ testrunner collect [flags]
   -h, --help                             help for collect
       --kibana-logging-endpoint string   Kibana endpoint used for logging of the testmachinery cluster.
   -n, --namespace string                 Namespace where the testrun should be deployed. (default "default")
-  -o, --output-file-path string          The filepath where the summary should be written to.
+      --output-dir-path string           The filepath where the summary should be written to.
       --s3-endpoint string               S3 endpoint of the testmachinery cluster.
       --s3-ssl                           S3 has SSL enabled.
       --tm-kubeconfig-path string        Path to the testmachinery cluster kubeconfig

--- a/pkg/testrunner/result/ingest.go
+++ b/pkg/testrunner/result/ingest.go
@@ -35,7 +35,7 @@ const (
 func IngestDir(path string, esCfgName string) error {
 	files, err := ioutil.ReadDir(path)
 	if err != nil {
-		return fmt.Errorf("Cannot read directory %s: %s", path, err.Error())
+		return fmt.Errorf("cannot read directory '%s'd: %s", path, err.Error())
 	}
 	for _, file := range files {
 		if !file.IsDir() {

--- a/pkg/testrunner/result/types.go
+++ b/pkg/testrunner/result/types.go
@@ -52,5 +52,5 @@ type email struct {
 type kibanaFilter struct {
 	IndexPatternID string
 	WorkflowID     string
-	PodID          string
+	TestDefName    string
 }

--- a/pkg/testrunner/types.go
+++ b/pkg/testrunner/types.go
@@ -73,10 +73,6 @@ type Metadata struct {
 	// Link to the workflow in the argo ui
 	// Argo URL is in format: https://argo-endpoint.com/workflows/namespace/wf-name
 	ArgoUIExternalURL string `json:"argo_url,omitempty"`
-
-	// Link to the logs in kibana
-	// Kibana URL is in format: https://kibana-endpoint.com/app/kibana#/discover/<very_complex_IDs_and_stuff>
-	KibanaExternalURL string `json:"kibana_url,omitempty"`
 }
 
 // TestrunMetadata represents the metadata of a testrun
@@ -100,20 +96,22 @@ type StepExportMetadata struct {
 
 // TestrunSummary is the result of the overall testrun.
 type TestrunSummary struct {
-	Metadata  *Metadata        `json:"tm,omitempty"`
-	Type      SummaryType      `json:"type,omitempty"`
-	Phase     argov1.NodePhase `json:"phase,omitempty"`
-	StartTime *metav1.Time     `json:"startTime,omitempty"`
-	Duration  int64            `json:"duration,omitempty"`
-	TestsRun  int              `json:"testsRun,omitempty"`
+	Metadata          *Metadata        `json:"tm,omitempty"`
+	Type              SummaryType      `json:"type,omitempty"`
+	Phase             argov1.NodePhase `json:"phase,omitempty"`
+	StartTime         *metav1.Time     `json:"startTime,omitempty"`
+	Duration          int64            `json:"duration,omitempty"`
+	TestsRun          int              `json:"testsRun,omitempty"`
+	KibanaExternalURL string           `json:"kibana_url,omitempty"`
 }
 
 // StepSummary is the result of a specific step.
 type StepSummary struct {
-	Metadata  *Metadata        `json:"tm,omitempty"`
-	Type      SummaryType      `json:"type,omitempty"`
-	Name      string           `json:"name,omitempty"`
-	Phase     argov1.NodePhase `json:"phase,omitempty"`
-	StartTime *metav1.Time     `json:"startTime,omitempty"`
-	Duration  int64            `json:"duration,omitempty"`
+	Metadata          *Metadata        `json:"tm,omitempty"`
+	Type              SummaryType      `json:"type,omitempty"`
+	Name              string           `json:"name,omitempty"`
+	Phase             argov1.NodePhase `json:"phase,omitempty"`
+	StartTime         *metav1.Time     `json:"startTime,omitempty"`
+	Duration          int64            `json:"duration,omitempty"`
+	KibanaExternalURL string           `json:"kibana_url,omitempty"`
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Moves kibana url type definitions from broad Metadata to specific TestrunSummary and StepSummary to avoid "polluting" all custom exported metadata with this "huge" URL.
Adds specific kibana urls to StepSummary so that we can present a direct link to the logs of a specific TestStep.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
Adds kibana URLs to elasticsearch metadata to directly link to the logs of a respective TestRun or TestStep.
```
