### PR TITLE
Add build version to testrunner and testmachinery controller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,10 @@ WORKDIR /go/src/github.com/gardener/test-infra
 COPY . .
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go install \
-#   -ldflags "-w -X github.com/gardener/gardener/pkg/version.Version=$(cat VERSION)" \
+   -ldflags "-X github.com/gardener/test-infra/pkg/version.gitVersion=$(cat VERSION) \
+               -X github.com/gardener/test-infra/pkg/version.gitTreeState=$([ -z git status --porcelain 2>/dev/null ] && echo clean || echo dirty) \
+               -X github.com/gardener/test-infra/pkg/version.gitCommit=$(git rev-parse --verify HEAD) \
+               -X github.com/gardener/test-infra/pkg/version.buildDate=$(date --rfc-3339=seconds | sed 's/ /T/')" \
   ./cmd/...
 
 ############# tm-controller #############

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ PREPARESTEP_IMAGE := $(REGISTRY)/testmachinery-prepare
 NS ?= default
 KUBECONFIG ?= "~/.kube/config"
 TESTRUN ?= "examples/int-testrun.yaml"
+LD_FLAGS := $(shell ./hack/get-build-ld-flags)
 
 
 ################################
@@ -112,6 +113,12 @@ validate:
 ##################################
 # Binary build and docker image  #
 ##################################
+
+.PHONY: testrunner
+testrunner:
+	@go install -v \
+		-ldflags "$(LD_FLAGS)" \
+		./cmd/testrunner
 
 .PHONY: docker-images
 docker-images: docker-image-prepare docker-image-base docker-image-golang docker-image-run docker-image-controller

--- a/cmd/testmachinery-controller/main.go
+++ b/cmd/testmachinery-controller/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"context"
 	"flag"
+	"github.com/gardener/test-infra/pkg/version"
 	"os"
 
 	"github.com/gardener/test-infra/pkg/controller"
@@ -33,7 +34,6 @@ import (
 )
 
 var (
-	trFilePath string
 	masterURL  string
 	kubeconfig string
 	local      bool
@@ -41,7 +41,7 @@ var (
 
 func main() {
 
-	log.Info("Start Test Machinery")
+	log.Infof("Start Test Machinery with Version %s", version.Get().String())
 	flag.Parse()
 
 	if testmachinery.IsRunInsecure() {

--- a/cmd/testrunner/cmd/cmd.go
+++ b/cmd/testrunner/cmd/cmd.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"github.com/gardener/test-infra/cmd/testrunner/cmd/collect"
+	"github.com/gardener/test-infra/cmd/testrunner/cmd/version"
 	"os"
 
 	"github.com/gardener/test-infra/cmd/testrunner/cmd/docs"
@@ -49,6 +50,7 @@ func init() {
 
 	runtemplate.AddCommand(rootCmd)
 	runtestrun.AddCommand(rootCmd)
-	collect.AddCommand(rootCmd)
+	collectcmd.AddCommand(rootCmd)
 	docs.AddCommand(rootCmd)
+	versioncmd.AddCommand(rootCmd)
 }

--- a/cmd/testrunner/cmd/collect/collect.go
+++ b/cmd/testrunner/cmd/collect/collect.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package collect
+package collectcmd
 
 import (
 	"context"

--- a/cmd/testrunner/cmd/version/version.go
+++ b/cmd/testrunner/cmd/version/version.go
@@ -12,39 +12,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package server
+package versioncmd
 
 import (
+	"encoding/json"
+	"fmt"
 	"github.com/gardener/test-infra/pkg/version"
-	"net/http"
-	"sync"
-
-	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"log"
 )
 
-var (
-	mutex   sync.Mutex
-	healthy = false
-)
-
-func UpdateHealth(isHealthy bool) {
-	mutex.Lock()
-	healthy = isHealthy
-	mutex.Unlock()
+// AddCommand adds run-testrun to a command.
+func AddCommand(cmd *cobra.Command) {
+	cmd.AddCommand(versionCmd)
 }
 
-func healthz(w http.ResponseWriter, r *http.Request) {
-	mutex.Lock()
-	isHealthy := healthy
-	mutex.Unlock()
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Get testrunner version",
+	Run: func(cmd *cobra.Command, args []string) {
 
-	if isHealthy {
-		_, err := w.Write([]byte(version.Get().String()))
+		v, err := json.Marshal(version.Get())
 		if err != nil {
-			log.Debug(err.Error())
-			w.WriteHeader(http.StatusOK)
+			log.Fatal(err.Error())
 		}
-	} else {
-		w.WriteHeader(http.StatusInternalServerError)
-	}
+		fmt.Print(string(v))
+	},
 }

--- a/hack/get-build-ld-flags
+++ b/hack/get-build-ld-flags
@@ -1,0 +1,20 @@
+#!/bin/bash -e
+#
+# Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo "-X github.com/gardener/test-infra/pkg/version.gitVersion=$(cat VERSION)
+      -X github.com/gardener/test-infra/pkg/version.gitTreeState=$([ -z git status --porcelain 2>/dev/null ] && echo clean || echo dirty)
+      -X github.com/gardener/test-infra/pkg/version.gitCommit=$(git rev-parse --verify HEAD)
+      -X github.com/gardener/test-infra/pkg/version.buildDate=$(date '+%Y-%m-%dT%H:%M:%S%z' | sed 's/\([0-9][0-9]\)$/:\1/g')"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,59 @@
+// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+
+	apimachineryversion "k8s.io/apimachinery/pkg/version"
+)
+
+var (
+	gitVersion   = "0.0.0-dev"
+	gitCommit    string
+	gitTreeState string
+	buildDate    = "1970-01-01T00:00:00Z"
+)
+
+// Get returns the overall codebase version. It's for detecting
+// what code a binary was built from.
+// These variables typically come from -ldflags settings and in
+// their absence fallback to the settings in pkg/version/base.go
+func Get() apimachineryversion.Info {
+	var (
+		version  = strings.Split(gitVersion, ".")
+		gitMajor string
+		gitMinor string
+	)
+
+	if len(version) >= 2 {
+		gitMajor = version[0]
+		gitMinor = version[1]
+	}
+
+	return apimachineryversion.Info{
+		Major:        gitMajor,
+		Minor:        gitMinor,
+		GitVersion:   gitVersion,
+		GitCommit:    gitCommit,
+		GitTreeState: gitTreeState,
+		BuildDate:    buildDate,
+		GoVersion:    runtime.Version(),
+		Compiler:     runtime.Compiler,
+		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds build version information to testrunner and the tesmachinery controller

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Add build version to Testrunner and Test Machinery
```
