### PR TITLE
Fix panic when using single steps with serial behavior TestDefinition

### DIFF
--- a/pkg/apis/testmachinery/v1beta1/types.go
+++ b/pkg/apis/testmachinery/v1beta1/types.go
@@ -200,7 +200,7 @@ type ConfigElement struct {
 
 	// Only for type=file. Path where the file should be mounted.
 	// +optional
-	Path string `json:"path"`
+	Path string `json:"path,omitempty"`
 }
 
 // ConfigSource represents a source for the value of a config element.

--- a/pkg/testmachinery/testflow/flow.go
+++ b/pkg/testmachinery/testflow/flow.go
@@ -66,7 +66,9 @@ func NewFlow(flowID FlowIdentifier, root *Node, tf *tmv1beta1.TestFlow, tl testd
 			}
 		}
 
-		if isSerialStep(steps) {
+		// we need to check if the node is defined because a single "behavior: serial" step
+		// which skip the node creation in the normal flow will be created in further special serial steps creation..
+		if isSerialStep(steps) && node != nil {
 			node.TestDefinition.AddSerialStdOutput()
 			lastSerialNode = node
 		}

--- a/test/controller/testflow/testflow_suite_test.go
+++ b/test/controller/testflow/testflow_suite_test.go
@@ -176,6 +176,23 @@ var _ = Describe("Testflow execution tests", func() {
 			Expect(len(tr.Status.Steps[1])).To(Equal(1))
 			Expect(tr.Status.Steps[1][0].TestDefinition.Name).To(Equal("serial-testdef"))
 		})
+
+		It("should execute one serial step successfully", func() {
+			ctx := context.Background()
+			defer ctx.Done()
+			tr := resources.GetBasicTestrun(namespace, commitSha)
+			tr.Spec.TestFlow = [][]tmv1beta1.TestflowStep{
+				{
+					{
+						Name: "serial-testdef",
+					},
+				},
+			}
+
+			tr, _, err := utils.RunTestrun(ctx, tmClient, tr, argov1.NodeSucceeded, namespace, maxWaitTime)
+			defer utils.DeleteTestrun(tmClient, tr)
+			Expect(err).ToNot(HaveOccurred())
+		})
 	})
 
 	Context("File created in shared folder", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an Test Machinery controller panic when a single serial step is defined.
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Fixes `behavior: ["serial"]` bug that causes a TestMachinery crashloop.
```
