### PR TITLE
add debug msg to go image setup to be able to detect timeout problems

### DIFF
--- a/hack/images/golang/setup
+++ b/hack/images/golang/setup
@@ -15,6 +15,8 @@
 # limitations under the License.
 set -e
 
+echo 'Starting TestMachinery Setup'
+
 REPO_PATH=$1
 REPO=$2
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Sometimes we find TestSteps in Timeout condition without any hint on whether _something_ started at all in the respective pod.
This PR adds a simple debug msg on start of the setup script of the go base image used by most tests.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```improvement operator
NONE
```
