### PR TITLE
Fix/testrunner export parsing

### DIFF
--- a/charts/bootstrap_tm_prerequisites/templates/minio-distributed.yaml
+++ b/charts/bootstrap_tm_prerequisites/templates/minio-distributed.yaml
@@ -53,15 +53,6 @@ spec:
           {{- end }}
         ports:
         - containerPort: 9000
-        # Readiness probe detects situations when MinIO server instance
-        # is not ready to accept traffic. Kubernetes doesn't forward
-        # traffic to the pod while readiness checks fail.
-        readinessProbe:
-          httpGet:
-            path: /minio/health/ready
-            port: 9000
-          initialDelaySeconds: 120
-          periodSeconds: 20
         # Liveness probe detects situations where MinIO server instance
         # is not working properly and needs restart. Kubernetes automatically
         # restarts the pods if liveness checks fail.

--- a/cmd/testrunner/cmd/collect/collect.go
+++ b/cmd/testrunner/cmd/collect/collect.go
@@ -108,16 +108,16 @@ func init() {
 	// configuration flags
 	collectCmd.Flags().StringVar(&tmKubeconfigPath, "tm-kubeconfig-path", "", "Path to the testmachinery cluster kubeconfig")
 	if err := collectCmd.MarkFlagRequired("tm-kubeconfig-path"); err != nil {
-		log.Warn(err)
+		log.Debug(err)
 	}
 	if err := collectCmd.MarkFlagFilename("tm-kubeconfig-path"); err != nil {
-		log.Warn(err)
+		log.Debug(err)
 	}
 	collectCmd.Flags().StringVarP(&namespace, "namespace", "n", "default", "Namespace where the testrun should be deployed.")
 
 	collectCmd.Flags().StringVarP(&testrunName, "tr-name", "t", "", "Name of the testrun to collect results.")
-	if err := collectCmd.MarkFlagRequired("testruns-chart-path"); err != nil {
-		log.Warn(err)
+	if err := collectCmd.MarkFlagRequired("tr-name"); err != nil {
+		log.Debug(err)
 	}
 
 	// parameter flags

--- a/pkg/testrunner/elasticsearch/elasticsearchbulk.go
+++ b/pkg/testrunner/elasticsearch/elasticsearchbulk.go
@@ -114,7 +114,7 @@ func parseExportedBulkFormat(name string, stepMeta interface{}, docs []byte) Bul
 		var jsonBody map[string]interface{}
 		err := json.Unmarshal(doc, &jsonBody)
 		if err != nil {
-			log.Errorf("cannot unmarshal document %s", err.Error())
+			log.Debugf("cannot unmarshal document %s", err.Error())
 			continue
 		}
 
@@ -127,7 +127,7 @@ func parseExportedBulkFormat(name string, stepMeta interface{}, docs []byte) Bul
 		jsonBody["tm"] = stepMeta
 		patchedDoc, err := util.MarshalNoHTMLEscape(jsonBody) // json.Marshal(jsonBody)
 		if err != nil {
-			log.Errorf("cannot marshal artifact %s", err.Error())
+			log.Debugf("cannot marshal artifact %s", err.Error())
 			continue
 		}
 

--- a/pkg/testrunner/result/collect.go
+++ b/pkg/testrunner/result/collect.go
@@ -16,6 +16,7 @@ package result
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/gardener/test-infra/pkg/testrunner"
 
@@ -37,12 +38,17 @@ func Collect(config *Config, tmClient kubernetes.Interface, namespace string, ru
 
 		err = IngestDir(config.OutputDir, config.ESConfigName)
 		if err != nil {
-			log.Errorf("Cannot persist file %s: %s", config.OutputDir, err.Error())
+			log.Errorf("cannot persist file %s: %s", config.OutputDir, err.Error())
 		} else {
 			err := MarkTestrunsAsIngested(tmClient, run.Testrun)
 			if err != nil {
 				log.Warn(err.Error())
 			}
+		}
+
+		// clean folder
+		if err := os.RemoveAll(config.OutputDir); err != nil {
+			log.Debugf("unable to remove dir %s: %s", config.OutputDir, err.Error())
 		}
 
 		if run.Testrun.Status.Phase == tmv1beta1.PhaseStatusSuccess {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes 2 issues:
- massive error output when an exported artifact cannot be parsed
- duplicated test results in elasticsearch when multiple testrun run in parallel with one testrunner

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Fixed massive output error messages when an exported artifact cannot be parsed
```
```improvement operator
Fixed duplicated results in elasticsearch when multiple testrun run in parallel within one testrunner
```
