### PR TITLE
added PodDisruptionBudget for distributed minio

### DIFF
--- a/charts/bootstrap_tm_prerequisites/templates/minio-distributed.yaml
+++ b/charts/bootstrap_tm_prerequisites/templates/minio-distributed.yaml
@@ -84,6 +84,17 @@ spec:
         requests:
           storage: "{{.Values.objectStorage.storage}}"
 ---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: minio
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: minio
+---
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
**Release note**:
```improvement operator
Added a PodDisruptionBudget for distributed minio installations to avoid more than one pod being down while a node is drained.
```
