### PR TITLE
Refactor shared folders to use global artifacts

### DIFF
--- a/pkg/testmachinery/argo/argo.go
+++ b/pkg/testmachinery/argo/argo.go
@@ -69,13 +69,13 @@ func CreateTask(taskName, templateName, phaseRunning string, dependencies []stri
 		Template:     templateName,
 		Dependencies: dependencies,
 		Arguments: argov1.Arguments{
+			Artifacts: artifacts,
 			Parameters: []argov1.Parameter{
 				{
 					Name:  "phase",
 					Value: &phaseRunning,
 				},
 			},
-			Artifacts: artifacts,
 		},
 	}
 }

--- a/pkg/testmachinery/testdefinition/prepare.go
+++ b/pkg/testmachinery/testdefinition/prepare.go
@@ -33,7 +33,7 @@ import (
 
 // NewPrepare creates the TM prepare step
 // The step clones all needed github repositories and outputs these repos as argo artifacts with the name "repoOwner-repoName-revision".
-func NewPrepare(name string, kubeconfigs tmv1beta1.TestrunKubeconfigs) (*PrepareDefinition, error) {
+func NewPrepare(name string) (*PrepareDefinition, error) {
 	td := &tmv1beta1.TestDefinition{
 		Metadata: tmv1beta1.TestDefMetadata{
 			Name: name,
@@ -76,9 +76,6 @@ func NewPrepare(name string, kubeconfigs tmv1beta1.TestrunKubeconfigs) (*Prepare
 	if err := prepare.addNetrcFile(); err != nil {
 		return nil, err
 	}
-	if err := prepare.addKubeconfigs(kubeconfigs); err != nil {
-		return nil, err
-	}
 	prepare.TestDefinition.AddSerialStdOutput()
 
 	return prepare, nil
@@ -91,8 +88,9 @@ func (p *PrepareDefinition) AddLocation(loc Location) {
 		p.repositories = append(p.repositories, &PrepareRepository{Name: loc.Name(), URL: gitLoc.info.Repo, Revision: gitLoc.info.Revision})
 
 		p.TestDefinition.AddOutputArtifacts(argov1.Artifact{
-			Name: loc.Name(),
-			Path: fmt.Sprintf("%s/%s", testmachinery.TM_REPO_PATH, loc.Name()),
+			Name:       loc.Name(),
+			GlobalName: loc.Name(),
+			Path:       fmt.Sprintf("%s/%s", testmachinery.TM_REPO_PATH, loc.Name()),
 		})
 	}
 }
@@ -116,8 +114,8 @@ func (p *PrepareDefinition) AddRepositoriesAsArtifacts() error {
 	return nil
 }
 
-// addKubeconfig adds all defined kubeconfigs as files to the prepare pod
-func (p *PrepareDefinition) addKubeconfigs(kubeconfigs tmv1beta1.TestrunKubeconfigs) error {
+// AddKubeconfig adds all defined kubeconfigs as files to the prepare pod
+func (p *PrepareDefinition) AddKubeconfigs(kubeconfigs tmv1beta1.TestrunKubeconfigs) error {
 	if kubeconfigs.Gardener != nil {
 		if err := p.addKubeconfig("gardener", kubeconfigs.Gardener); err != nil {
 			return err

--- a/pkg/testmachinery/testdefinition/testdefinition.go
+++ b/pkg/testmachinery/testdefinition/testdefinition.go
@@ -72,6 +72,10 @@ func New(def *tmv1beta1.TestDefinition, loc Location, fileName string) (*TestDef
 					Value: testmachinery.TM_KUBECONFIG_PATH,
 				},
 				{
+					Name:  "TM_SHARED_PATH",
+					Value: testmachinery.TM_SHARED_PATH,
+				},
+				{
 					Name:  "TM_EXPORT_PATH",
 					Value: testmachinery.TM_EXPORT_PATH,
 				},
@@ -200,13 +204,15 @@ func (td *TestDefinition) AddVolumeMount(name, path, subpath string, readOnly bo
 // AddSerialStdOutput adds the Kubeconfig output to the TestDefinitions's template.
 func (td *TestDefinition) AddSerialStdOutput() {
 	kubeconfigArtifact := argov1.Artifact{
-		Name: "kubeconfigs",
-		Path: testmachinery.TM_KUBECONFIG_PATH,
+		Name:       "kubeconfigs",
+		GlobalName: "kubeconfigs",
+		Path:       testmachinery.TM_KUBECONFIG_PATH,
 	}
 	td.AddOutputArtifacts(kubeconfigArtifact)
 	sharedFolderArtifact := argov1.Artifact{
-		Name: "sharedFolder",
-		Path: testmachinery.TM_SHARED_PATH,
+		Name:       "sharedFolder",
+		GlobalName: "sharedFolder",
+		Path:       testmachinery.TM_SHARED_PATH,
 	}
 	td.AddOutputArtifacts(sharedFolderArtifact)
 }

--- a/pkg/testmachinery/testrun/testrun.go
+++ b/pkg/testmachinery/testrun/testrun.go
@@ -35,8 +35,11 @@ func New(tr *tmv1beta1.Testrun) (*Testrun, error) {
 	globalConfig := config.New(tr.Spec.Config)
 
 	// create initial prepare step
-	prepare, err := testdefinition.NewPrepare("Prepare", tr.Spec.Kubeconfigs)
+	prepare, err := testdefinition.NewPrepare("Prepare")
 	if err != nil {
+		return nil, err
+	}
+	if err := prepare.AddKubeconfigs(tr.Spec.Kubeconfigs); err != nil {
 		return nil, err
 	}
 	tf, err := testflow.New(testflow.FlowIDTest, &tr.Spec.TestFlow, testDefinitions, globalConfig, prepare)
@@ -44,11 +47,7 @@ func New(tr *tmv1beta1.Testrun) (*Testrun, error) {
 		return nil, err
 	}
 
-	onExitPrepare, err := testdefinition.NewPrepare("PostPrepare", tr.Spec.Kubeconfigs)
-	if err != nil {
-		return nil, err
-	}
-	onExitFlow, err := testflow.New(testflow.FlowIDExit, &tr.Spec.OnExit, testDefinitions, globalConfig, onExitPrepare)
+	onExitFlow, err := testflow.New(testflow.FlowIDExit, &tr.Spec.OnExit, testDefinitions, globalConfig, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/test/controller/garbagecollection/garbagecollection_test.go
+++ b/test/controller/garbagecollection/garbagecollection_test.go
@@ -63,7 +63,7 @@ var _ = Describe("Garbage collection tests", func() {
 		})
 		Expect(err).ToNot(HaveOccurred())
 
-		utils.WaitForClusterReadiness(tmClient, namespace, maxWaitTime)
+		Expect(utils.WaitForClusterReadiness(tmClient, namespace, maxWaitTime)).ToNot(HaveOccurred())
 		osConfig := utils.WaitForMinioService(tmClient, minioEndpoint, namespace, maxWaitTime)
 
 		minioBucket = osConfig.BucketName

--- a/test/controller/resultcollection/resultcollection_test.go
+++ b/test/controller/resultcollection/resultcollection_test.go
@@ -55,8 +55,7 @@ var _ = Describe("Result collection tests", func() {
 		})
 		Expect(err).ToNot(HaveOccurred())
 
-		utils.WaitForClusterReadiness(tmClient, namespace, maxWaitTime)
-
+		Expect(utils.WaitForClusterReadiness(tmClient, namespace, maxWaitTime)).ToNot(HaveOccurred())
 	})
 
 	Context("step status", func() {

--- a/test/controller/testdefinition/testdefinition_suite_test.go
+++ b/test/controller/testdefinition/testdefinition_suite_test.go
@@ -61,8 +61,7 @@ var _ = Describe("Testrun tests", func() {
 			Scheme: testmachinery.TestMachineryScheme,
 		})
 		Expect(err).ToNot(HaveOccurred())
-		utils.WaitForClusterReadiness(tmClient, namespace, maxWaitTime)
-
+		Expect(utils.WaitForClusterReadiness(tmClient, namespace, maxWaitTime)).ToNot(HaveOccurred())
 	})
 
 	Context("config", func() {

--- a/test/controller/testflow/testflow_suite_test.go
+++ b/test/controller/testflow/testflow_suite_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Testflow execution tests", func() {
 			Scheme: testmachinery.TestMachineryScheme,
 		})
 		Expect(err).ToNot(HaveOccurred())
-		utils.WaitForClusterReadiness(tmClient, namespace, maxWaitTime)
+		Expect(utils.WaitForClusterReadiness(tmClient, namespace, maxWaitTime)).ToNot(HaveOccurred())
 	})
 
 	Context("testflow", func() {

--- a/test/testrunner/output/testrunner_output_execution_test.go
+++ b/test/testrunner/output/testrunner_output_execution_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Testrunner execution tests", func() {
 		})
 		Expect(err).ToNot(HaveOccurred())
 
-		utils.WaitForClusterReadiness(tmClient, namespace, maxWaitTime)
+		Expect(utils.WaitForClusterReadiness(tmClient, namespace, maxWaitTime)).ToNot(HaveOccurred())
 		utils.WaitForMinioService(tmClient, s3Endpoint, namespace, maxWaitTime)
 	})
 

--- a/test/testrunner/run/testrunner_run_test.go
+++ b/test/testrunner/run/testrunner_run_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Testrunner execution tests", func() {
 		})
 		Expect(err).ToNot(HaveOccurred())
 
-		utils.WaitForClusterReadiness(tmClient, namespace, maxWaitTime)
+		Expect(utils.WaitForClusterReadiness(tmClient, namespace, maxWaitTime)).ToNot(HaveOccurred())
 		utils.WaitForMinioService(tmClient, s3Endpoint, namespace, maxWaitTime)
 	})
 

--- a/test/validationwebhook/testrun_validation_test.go
+++ b/test/validationwebhook/testrun_validation_test.go
@@ -52,8 +52,7 @@ var _ = Describe("Testrun validation tests", func() {
 			Scheme: testmachinery.TestMachineryScheme,
 		})
 		Expect(err).ToNot(HaveOccurred())
-		utils.WaitForClusterReadiness(tmClient, namespace, maxWaitTime)
-
+		Expect(utils.WaitForClusterReadiness(tmClient, namespace, maxWaitTime)).ToNot(HaveOccurred())
 	})
 
 	Context("Metadata", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the handling of the kubeconfigs and sharedFolder artifact.
Now a global artifact is used so that data in these artifacts can be shared across DAG(testflow and onExit flow) which is needed or some cleanup logic like in garden setup.
It also increases performance and decreases network load as repositories are only cloned once in the initial prepare step.


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Refactor shared artifact handling by using argo's global artifacts.
```
