### PR TITLE
added reserve excess capacity pods to helm charts

### DIFF
--- a/charts/bootstrap_tm_prerequisites/templates/reserve-excess-capacity.yaml
+++ b/charts/bootstrap_tm_prerequisites/templates/reserve-excess-capacity.yaml
@@ -1,0 +1,55 @@
+# Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+{{- if .Values.reserveExcessCapacity.enabled }}
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: tm-reserve-excess-capacity
+value: -5
+globalDefault: false
+description: "This class is used to reserve excess resource capacity on the testmachinery cluster"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reserve-excess-capacity
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: reserve-excess-capacity
+spec:
+  revisionHistoryLimit: 0
+  replicas: {{ .Values.reserveExcessCapacity.replicas }}
+  selector:
+    matchLabels:
+      app: reserve-excess-capacity
+  template:
+    metadata:
+      labels:
+        app: reserve-excess-capacity
+    spec:
+      terminationGracePeriodSeconds: 5
+      containers:
+      - name: pause-container
+        image: gcr.io/google_containers/pause-amd64:3.1
+        imagePullPolicy: IfNotPresent
+        resources:
+          requests:
+            cpu: 1000m
+            memory: 1000Mi
+          limits:
+            cpu: 1000m
+            memory: 1000Mi
+      priorityClassName: tm-reserve-excess-capacity
+{{- end }}

--- a/charts/bootstrap_tm_prerequisites/values.yaml
+++ b/charts/bootstrap_tm_prerequisites/values.yaml
@@ -42,3 +42,7 @@ secrets:
   pullSecrets: []
   # - name: myDockerPullSecretName
   #   dockerconfigjson: base64 encoded dockerconfigjson
+
+reserveExcessCapacity:
+  enabled: false
+  replicas: 5 # each replica reserves 1 CPU and 1GB memory


### PR DESCRIPTION
**What this PR does / why we need it**:

**Release note**:
```improvement operator
Adds a customizable amount of low priority class CPU and mem reserving pods to ensure that starting teststeps do not need to wait for a new VM to be spawn.
```
