### PR TITLE
pod anti affinity for distributed minio

### DIFF
--- a/charts/bootstrap_tm_prerequisites/templates/minio-distributed.yaml
+++ b/charts/bootstrap_tm_prerequisites/templates/minio-distributed.yaml
@@ -31,6 +31,18 @@ spec:
       labels:
         app: minio
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - minio
+              topologyKey: kubernetes.io/hostname
       containers:
       - name: minio
         env:


### PR DESCRIPTION
```improvement operator
Distributed minio now has a pod anti affinity to avoid that all replicas are getting scheduled to the same node.
```
