### PR TITLE
Add support for continuing the testflow on error

### DIFF
--- a/docs/GetStarted.md
+++ b/docs/GetStarted.md
@@ -200,6 +200,7 @@ spec:
   testFlow:
   - - name: create-shoot
   - - label: default
+      continueOnError: true # optional; default: false -> continues the workflow even if the step fails.
   - - name: e2e-test
       locationSet: other # ref to the locationset that should be used.
   - - name: delete-shoot

--- a/pkg/apis/testmachinery/v1beta1/types.go
+++ b/pkg/apis/testmachinery/v1beta1/types.go
@@ -229,6 +229,9 @@ type TestflowStep struct {
 	Name  string `json:"name,omitempty"`
 	Label string `json:"label,omitempty"`
 
+	// Continue the execution of the workflow even when the step errors or fails.
+	ContinueOnError bool `json:"continueOnError,omitempty"`
+
 	// Condition when the step should be executed.
 	// Only used if the step is in the onExit testflow.
 	// +optional

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -371,6 +371,12 @@ func schema_pkg_apis_testmachinery_v1beta1_TestflowStep(ref common.ReferenceCall
 							Format: "",
 						},
 					},
+					"continueOnError": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
 					"condition": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Condition when the step should be executed. Only used if the step is in the onExit testflow.",

--- a/pkg/testmachinery/argo/argo.go
+++ b/pkg/testmachinery/argo/argo.go
@@ -63,11 +63,15 @@ func DeployWorkflow(wf *argov1.Workflow, masterURL, kubeconfig string) (*argov1.
 }
 
 // CreateTask takes a name, the running phase name, dependencies and artifacts, and return an argo task object.
-func CreateTask(taskName, templateName, phaseRunning string, dependencies []string, artifacts []argov1.Artifact) *argov1.DAGTask {
+func CreateTask(taskName, templateName, phaseRunning string, continueOnError bool, dependencies []string, artifacts []argov1.Artifact) *argov1.DAGTask {
 	return &argov1.DAGTask{
 		Name:         taskName,
 		Template:     templateName,
 		Dependencies: dependencies,
+		ContinueOn: &argov1.ContinueOn{
+			Error:  continueOnError,
+			Failed: continueOnError,
+		},
 		Arguments: argov1.Arguments{
 			Artifacts: artifacts,
 			Parameters: []argov1.Parameter{

--- a/pkg/testmachinery/testflow/node.go
+++ b/pkg/testmachinery/testflow/node.go
@@ -34,7 +34,7 @@ func NewNode(parents []*Node, lastSerialNode, rootNode *Node, td *testdefinition
 	}
 
 	if lastSerialNode != nil {
-		node.addTask()
+		node.addTask(step.Info.ContinueOnError)
 	}
 
 	node.Status = &tmv1beta1.TestflowStepStatus{
@@ -75,7 +75,7 @@ func (n *Node) Name() string {
 
 // addTask adds an argo task to the node.AddTask
 // Standard artifacts like kubeconfigs and the cloned repository are added as well as a execution condition if specified.
-func (n *Node) addTask() {
+func (n *Node) addTask(continueOnError bool) {
 	artifacts := []argov1.Artifact{
 		{
 			Name: "kubeconfigs",
@@ -93,7 +93,7 @@ func (n *Node) addTask() {
 			From: fmt.Sprintf("{{workflow.outputs.artifacts.%s}}", n.TestDefinition.Location.Name()),
 		})
 	}
-	task := argo.CreateTask(n.TestDefinition.Template.Name, n.TestDefinition.Template.Name, testmachinery.PHASE_RUNNING, n.GetParentNames(), artifacts)
+	task := argo.CreateTask(n.TestDefinition.Template.Name, n.TestDefinition.Template.Name, testmachinery.PHASE_RUNNING, continueOnError, n.GetParentNames(), artifacts)
 
 	switch n.step.Condition {
 	case tmv1beta1.ConditionTypeSuccess:

--- a/pkg/testmachinery/testflow/testflow.go
+++ b/pkg/testmachinery/testflow/testflow.go
@@ -36,7 +36,7 @@ func New(flowID FlowIdentifier, tf *tmv1beta1.TestFlow, locs locations.Locations
 		rootPrepare = prepareDef
 	}
 	rootNode := NewNode(nil, nil, nil, rootPrepare.TestDefinition, &Step{nil, -1, -1}, flowID)
-	rootNode.Task = argo.CreateTask(rootNode.TestDefinition.Template.Name, rootNode.TestDefinition.Template.Name, testmachinery.PHASE_RUNNING, rootNode.GetParentNames(), nil)
+	rootNode.Task = argo.CreateTask(rootNode.TestDefinition.Template.Name, rootNode.TestDefinition.Template.Name, testmachinery.PHASE_RUNNING, false, rootNode.GetParentNames(), nil)
 	if err := rootNode.TestDefinition.AddConfig(globalConfig); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Added support continuing steps even if they fail

:warning: argo v2.3.0 or greater is needed

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Add support for continuing the workflow when steps fail. :warning: argo v2.3.0 or greater is needed
```
