### PR TITLE
Mitigate argo global artifact behavior

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -68,7 +68,7 @@
     "pkg/client/clientset/versioned/typed/workflow/v1alpha1",
   ]
   pruneopts = "NUT"
-  revision = "v2.3.0-rc3"
+  revision = "v2.3.0"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -38,7 +38,7 @@ required = [
 
 [[constraint]]
   name = "github.com/argoproj/argo"
-  revision = "v2.3.0-rc3"
+  revision = "v2.3.0"
 
 [[override]]
   name = "gopkg.in/fsnotify.v1"

--- a/charts/bootstrap_tm_prerequisites/values.yaml
+++ b/charts/bootstrap_tm_prerequisites/values.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 argo:
-  tag: v2.3.0-rc3
+  tag: v2.3.0
 
 configmap:
   name: tm-config

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -47,7 +47,7 @@ func Serve(ctx context.Context, mgr manager.Manager) {
 
 	go func() {
 		log.Infof("Starting HTTP server on %s", listenAddressHTTP)
-		if err := serverHTTP.ListenAndServe(); err != nil &&  err != http.ErrServerClosed {
+		if err := serverHTTP.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			log.Errorf("Could not start HTTP server: %s", err.Error())
 		}
 	}()

--- a/pkg/testmachinery/testflow/node.go
+++ b/pkg/testmachinery/testflow/node.go
@@ -34,7 +34,7 @@ func NewNode(parents []*Node, lastSerialNode, rootNode *Node, td *testdefinition
 	}
 
 	if lastSerialNode != nil {
-		node.addTask(step.Info.ContinueOnError)
+		node.addTask(lastSerialNode, step.Info.ContinueOnError)
 	}
 
 	node.Status = &tmv1beta1.TestflowStepStatus{
@@ -75,11 +75,11 @@ func (n *Node) Name() string {
 
 // addTask adds an argo task to the node.AddTask
 // Standard artifacts like kubeconfigs and the cloned repository are added as well as a execution condition if specified.
-func (n *Node) addTask(continueOnError bool) {
+func (n *Node) addTask(lastSerialNode *Node, continueOnError bool) {
 	artifacts := []argov1.Artifact{
 		{
 			Name: "kubeconfigs",
-			From: "{{workflow.outputs.artifacts.kubeconfigs}}",
+			From: fmt.Sprintf("{{tasks.%s.outputs.artifacts.kubeconfigs}}", lastSerialNode.Task.Name),
 		},
 		{
 			Name: "sharedFolder",

--- a/pkg/testmachinery/testrun/testrun.go
+++ b/pkg/testmachinery/testrun/testrun.go
@@ -48,7 +48,11 @@ func New(tr *tmv1beta1.Testrun) (*Testrun, error) {
 		return nil, err
 	}
 
-	onExitFlow, err := testflow.New(testflow.FlowIDExit, &tr.Spec.OnExit, locs, globalConfig, nil)
+	postPrepareDef, err := prepare.New("PostPrepare", true)
+	if err != nil {
+		return nil, err
+	}
+	onExitFlow, err := testflow.New(testflow.FlowIDExit, &tr.Spec.OnExit, locs, globalConfig, postPrepareDef)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes https://github.com/argoproj/argo/issues/1366

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Mitigate argo global artifact behavior by reverting use of global artifact for kubeconfigs
```
