### PR TITLE
fixed annotation to trigger pod restart

### DIFF
--- a/charts/testmachinery/templates/deployment-tm-controller.yaml
+++ b/charts/testmachinery/templates/deployment-tm-controller.yaml
@@ -17,8 +17,6 @@ kind: Deployment
 metadata:
   name: testmachinery-controller
   namespace: {{ .Release.Namespace }}
-  annotations:
-    checksum/tls-secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
   labels:
     app: tm-controller
 spec:
@@ -28,6 +26,8 @@ spec:
       app: tm-controller
   template:
     metadata:
+      annotations:
+        checksum/tls-secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
       labels:
         app: tm-controller
     spec:


### PR DESCRIPTION
**What this PR does / why we need it**:
Moves the checksum annotation to the correct place, where it'll trigger a rolling update of the tm controller pod once the secrets change.

