### PR TITLE
Add testdef name and id to annotations

### DIFF
--- a/pkg/testmachinery/prepare/prepare.go
+++ b/pkg/testmachinery/prepare/prepare.go
@@ -106,7 +106,7 @@ func (p *Definition) AddRepositoriesAsArtifacts() error {
 	if err != nil {
 		return fmt.Errorf("Cannot add repositories to prepare step: %s", err.Error())
 	}
-	p.TestDefinition.Template.Inputs.Artifacts = append(p.TestDefinition.Template.Inputs.Artifacts, argov1.Artifact{
+	p.TestDefinition.AddInputArtifacts(argov1.Artifact{
 		Name: "repos",
 		Path: "/tm/repos.json",
 		ArtifactLocation: argov1.ArtifactLocation{

--- a/pkg/testmachinery/testdefinition/testdefinition.go
+++ b/pkg/testmachinery/testdefinition/testdefinition.go
@@ -37,8 +37,7 @@ var (
 // Annotation keys defined on the testdefinition template
 const (
 	AnnotationTestDefName = "testmachinery.sapcloud.io/TestDefinition"
-	AnnotationFlow        = "testmachinery.sapcloud.io/Flow"
-	AnnotationPosition    = "testmachinery.sapcloud.io/Position" // position of the source step in the format row/colum
+	AnnotationTestDefID   = "testmachinery.sapcloud.io/ID"
 )
 
 // New takes a CRD TestDefinition and its locations, and creates a TestDefinition object.
@@ -57,6 +56,11 @@ func New(def *tmv1beta1.TestDefinition, loc Location, fileName string) (*TestDef
 
 	template := &argov1.Template{
 		Name: "",
+		Metadata: argov1.Metadata{
+			Annotations: map[string]string{
+				AnnotationTestDefName: def.Metadata.Name,
+			},
+		},
 		ArchiveLocation: &argov1.ArtifactLocation{
 			ArchiveLogs: &archiveLogs,
 		},
@@ -142,10 +146,15 @@ func (td *TestDefinition) Copy() *TestDefinition {
 }
 
 func (td *TestDefinition) SetName(name string) {
+	td.AddAnnotation(AnnotationTestDefID, name)
 	td.Template.Name = name
 }
 func (td *TestDefinition) GetName() string {
 	return td.Template.Name
+}
+
+func (td *TestDefinition) GetTemplate() argov1.Template {
+	return *td.Template
 }
 
 // HasBehavior checks if the testrun has defined a specific behavior like serial or disruptiv.
@@ -294,11 +303,9 @@ func (td *TestDefinition) AddVolumeFromConfig(cfg *config.Element) error {
 }
 
 // GetAnnotations returns Template annotations for a testdefinition
-func GetAnnotations(name, flow, position string) map[string]string {
-	annotations := map[string]string{
-		AnnotationTestDefName: name,
-		AnnotationFlow:        flow,
-		AnnotationPosition:    position,
+func (td *TestDefinition) AddAnnotation(key, value string) {
+	if td.Template.Metadata.Annotations == nil {
+		td.Template.Metadata.Annotations = make(map[string]string, 0)
 	}
-	return annotations
+	td.Template.Metadata.Annotations[key] = value
 }

--- a/pkg/testmachinery/testflow/flow.go
+++ b/pkg/testmachinery/testflow/flow.go
@@ -64,7 +64,7 @@ func NewFlow(flowID FlowIdentifier, root *node.Node, tf tmv1beta1.TestFlow, loc 
 func (f *Flow) GetTemplates() ([]argov1.Template, error) {
 	var templates []argov1.Template
 	for td := range f.testdefinitions {
-		templates = append(templates, *td.Template)
+		templates = append(templates, td.GetTemplate())
 	}
 
 	return templates, nil

--- a/pkg/testmachinery/testflow/node/node.go
+++ b/pkg/testmachinery/testflow/node/node.go
@@ -103,7 +103,7 @@ func (n *Node) ParentNames() []string {
 
 // Name return the unique name of the node's task
 func (n *Node) Name() string {
-	return n.TestDefinition.Template.Name
+	return n.TestDefinition.GetName()
 }
 
 // Task returns the argo task definition for the node.


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds Testdefinition name and node id to the template annotations.
This template annotations will result in annotations on the actual pod which can then be referenced in our logging.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Add TestDefinition Name and Node ID to template annotations
```
