### PR TITLE
Fix duplicated output artifacts when a step has outputs and is serial

### DIFF
--- a/pkg/testmachinery/testdefinition/testdefinition.go
+++ b/pkg/testmachinery/testdefinition/testdefinition.go
@@ -93,40 +93,48 @@ func New(def *tmv1beta1.TestDefinition, loc Location, fileName string) (*TestDef
 			Parameters: []argov1.Parameter{
 				{Name: "phase"},
 			},
-			Artifacts: []argov1.Artifact{
-				{
-					Name:     "kubeconfigs",
-					Path:     testmachinery.TM_KUBECONFIG_PATH,
-					Optional: true,
-				},
-				{
-					Name:     "sharedFolder",
-					Path:     testmachinery.TM_SHARED_PATH,
-					Optional: true,
-				},
-			},
+			Artifacts: make([]argov1.Artifact, 0),
 		},
 		Outputs: argov1.Outputs{
-			Artifacts: []argov1.Artifact{
-				{
-					Name:     testmachinery.ExportArtifact,
-					Path:     testmachinery.TM_EXPORT_PATH,
-					Optional: true,
-				},
-			},
+			Artifacts: make([]argov1.Artifact, 0),
+		},
+	}
+
+	inputArtifacts := []argov1.Artifact{
+		{
+			Name:     "kubeconfigs",
+			Path:     testmachinery.TM_KUBECONFIG_PATH,
+			Optional: true,
+		},
+		{
+			Name:     "sharedFolder",
+			Path:     testmachinery.TM_SHARED_PATH,
+			Optional: true,
+		},
+	}
+	outputArtifacts := []argov1.Artifact{
+		{
+			Name:     testmachinery.ExportArtifact,
+			Path:     testmachinery.TM_EXPORT_PATH,
+			Optional: true,
 		},
 	}
 
 	td := &TestDefinition{
-		Info:     def,
-		Location: loc,
-		FileName: fileName,
-		Template: template,
-		Config:   config.New(def.Spec.Config),
+		Info:            def,
+		Location:        loc,
+		FileName:        fileName,
+		Template:        template,
+		Config:          config.New(def.Spec.Config),
+		inputArtifacts:  make(map[string]bool, 0),
+		outputArtifacts: make(map[string]bool, 0),
 	}
 	if err := td.AddConfig(td.Config); err != nil {
 		return nil, err
 	}
+
+	td.AddInputArtifacts(inputArtifacts...)
+	td.AddOutputArtifacts(outputArtifacts...)
 
 	return td, nil
 }
@@ -177,19 +185,29 @@ func (td *TestDefinition) HasLabel(label string) bool {
 	return false
 }
 
-// AddEnvVars adds environment varibales to the container of the TestDefinition's template.
+// AddEnvVars adds environment variables to the container of the TestDefinition's template.
 func (td *TestDefinition) AddEnvVars(envs ...apiv1.EnvVar) {
 	td.Template.Container.Env = append(td.Template.Container.Env, envs...)
 }
 
 // AddInputArtifacts adds argo artifacts to the input of the TestDefinitions's template.
 func (td *TestDefinition) AddInputArtifacts(artifacts ...argov1.Artifact) {
-	td.Template.Inputs.Artifacts = append(td.Template.Inputs.Artifacts, artifacts...)
+	for _, a := range artifacts {
+		if _, ok := td.inputArtifacts[a.Name]; !ok {
+			td.Template.Inputs.Artifacts = append(td.Template.Inputs.Artifacts, a)
+			td.inputArtifacts[a.Name] = true
+		}
+	}
 }
 
 // AddOutputArtifacts adds argo artifacts to the output of the TestDefinitions's template.
 func (td *TestDefinition) AddOutputArtifacts(artifacts ...argov1.Artifact) {
-	td.Template.Outputs.Artifacts = append(td.Template.Outputs.Artifacts, artifacts...)
+	for _, a := range artifacts {
+		if _, ok := td.inputArtifacts[a.Name]; !ok {
+			td.Template.Outputs.Artifacts = append(td.Template.Outputs.Artifacts, artifacts...)
+			td.outputArtifacts[a.Name] = true
+		}
+	}
 }
 
 // AddInputParameter adds a parameter to the input of the TestDefinitions's template.
@@ -222,7 +240,9 @@ func (td *TestDefinition) AddStdOutput(global bool) {
 
 	if global {
 		kubeconfigArtifact.GlobalName = kubeconfigArtifact.Name
+		kubeconfigArtifact.Name = fmt.Sprintf("%s-global", kubeconfigArtifact.Name)
 		sharedFolderArtifact.GlobalName = sharedFolderArtifact.Name
+		sharedFolderArtifact.Name = fmt.Sprintf("%s-global", sharedFolderArtifact.Name)
 	}
 
 	td.AddOutputArtifacts(kubeconfigArtifact)

--- a/pkg/testmachinery/testdefinition/testdefinition.go
+++ b/pkg/testmachinery/testdefinition/testdefinition.go
@@ -192,6 +192,9 @@ func (td *TestDefinition) AddEnvVars(envs ...apiv1.EnvVar) {
 
 // AddInputArtifacts adds argo artifacts to the input of the TestDefinitions's template.
 func (td *TestDefinition) AddInputArtifacts(artifacts ...argov1.Artifact) {
+	if td.inputArtifacts == nil {
+		td.inputArtifacts = make(map[string]bool, 0)
+	}
 	for _, a := range artifacts {
 		if _, ok := td.inputArtifacts[a.Name]; !ok {
 			td.Template.Inputs.Artifacts = append(td.Template.Inputs.Artifacts, a)
@@ -202,6 +205,9 @@ func (td *TestDefinition) AddInputArtifacts(artifacts ...argov1.Artifact) {
 
 // AddOutputArtifacts adds argo artifacts to the output of the TestDefinitions's template.
 func (td *TestDefinition) AddOutputArtifacts(artifacts ...argov1.Artifact) {
+	if td.outputArtifacts == nil {
+		td.outputArtifacts = make(map[string]bool, 0)
+	}
 	for _, a := range artifacts {
 		if _, ok := td.inputArtifacts[a.Name]; !ok {
 			td.Template.Outputs.Artifacts = append(td.Template.Outputs.Artifacts, artifacts...)

--- a/pkg/testmachinery/testdefinition/types.go
+++ b/pkg/testmachinery/testdefinition/types.go
@@ -17,6 +17,9 @@ type TestDefinition struct {
 	Config   []*config.Element
 
 	Volumes []apiv1.Volume
+
+	inputArtifacts  map[string]bool
+	outputArtifacts map[string]bool
 }
 
 // Location is an interface for different testDefLocation types like git or local

--- a/test/controller/testflow/testflow_suite_test.go
+++ b/test/controller/testflow/testflow_suite_test.go
@@ -189,7 +189,7 @@ var _ = Describe("Testflow execution tests", func() {
 
 		})
 
-		It("should execute the testflow with a step that is serial and globally serial", func() {
+		It("should execute the testflow with a step that has outputs and is serial", func() {
 			ctx := context.Background()
 			defer ctx.Done()
 			tr := resources.GetBasicTestrun(namespace, commitSha)
@@ -204,7 +204,7 @@ var _ = Describe("Testflow execution tests", func() {
 					Name:      "B",
 					DependsOn: []string{"A"},
 					Definition: tmv1beta1.StepDefinition{
-						Label: "integration-testdef",
+						Name: "integration-testdef",
 					},
 				},
 				&tmv1beta1.DAGStep{


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix duplicated output artifacts when a step has outputs and is serial.

also added additional checks that no artifacts can have the same name.
If there are 2 artifacts calculated with the same name then the first one is taken.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Fix duplicated output artifacts when a step has outputs and is serial
```
