### PR TITLE
Increase random string size of config names

### DIFF
--- a/pkg/testmachinery/config/config.go
+++ b/pkg/testmachinery/config/config.go
@@ -25,7 +25,7 @@ import (
 
 // NewElement creates a new config element object.
 func NewElement(config *tmv1beta1.ConfigElement) *Element {
-	name := fmt.Sprintf("%s-%s", config.Type, util.RandomString(3))
+	name := fmt.Sprintf("%s-%s", config.Type, util.RandomString(5))
 	return &Element{config, name}
 }
 
@@ -48,10 +48,10 @@ func (c *Element) Name() string {
 // a valuefrom is specified.
 func (c *Element) Volume() (*corev1.Volume, error) {
 	if c.Info.Type != tmv1beta1.ConfigTypeFile {
-		return nil, fmt.Errorf("No volume for ConfigType 'file'")
+		return nil, fmt.Errorf("no volume for ConfigType 'file'")
 	}
 	if c.Info.Value != "" {
-		return nil, fmt.Errorf("No volume for config with value")
+		return nil, fmt.Errorf("no volume for config with value")
 	}
 	volume := &corev1.Volume{
 		Name: c.Name(),


### PR DESCRIPTION
**What this PR does / why we need it**:

Decreases the possibility for duplicate config names by increasing the random string size of configs

**Which issue(s) this PR fixes**:
Fixes #88

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Increase random string size of config names
```
