### PR TITLE
Make post prepare global

### DIFF
--- a/pkg/testmachinery/prepare/prepare.go
+++ b/pkg/testmachinery/prepare/prepare.go
@@ -36,7 +36,7 @@ import (
 
 // New creates the TM prepare step
 // The step clones all needed github repositories and outputs these repos as argo artifacts with the name "repoOwner-repoName-revision".
-func New(name string, addOutput bool) (*Definition, error) {
+func New(name string, addGlobalInput bool) (*Definition, error) {
 	td := &tmv1beta1.TestDefinition{
 		Metadata: tmv1beta1.TestDefMetadata{
 			Name: name,
@@ -74,13 +74,13 @@ func New(name string, addOutput bool) (*Definition, error) {
 			},
 		},
 	}
-	prepare := &Definition{&testdefinition.TestDefinition{Info: td, Template: template}, []*Repository{}}
+	prepare := &Definition{&testdefinition.TestDefinition{Info: td, Template: template}, addGlobalInput, []*Repository{}}
 
 	if err := prepare.addNetrcFile(); err != nil {
 		return nil, err
 	}
-	if addOutput {
-		prepare.TestDefinition.AddStdOutput(false)
+	if addGlobalInput {
+		prepare.TestDefinition.AddInputArtifacts(testdefinition.GetStdInputArtifacts()...)
 	}
 
 	return prepare, nil

--- a/pkg/testmachinery/prepare/step.go
+++ b/pkg/testmachinery/prepare/step.go
@@ -4,7 +4,7 @@ import "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
 
 func GetPrepareStep(useGlobalArtifacts bool) *v1beta1.DAGStep {
 	return &v1beta1.DAGStep{
-		Name: "prepare",
+		Name:               "prepare",
 		UseGlobalArtifacts: useGlobalArtifacts,
 	}
 }

--- a/pkg/testmachinery/prepare/step.go
+++ b/pkg/testmachinery/prepare/step.go
@@ -2,8 +2,9 @@ package prepare
 
 import "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
 
-func GetPrepareStep() *v1beta1.DAGStep {
+func GetPrepareStep(useGlobalArtifacts bool) *v1beta1.DAGStep {
 	return &v1beta1.DAGStep{
 		Name: "prepare",
+		UseGlobalArtifacts: useGlobalArtifacts,
 	}
 }

--- a/pkg/testmachinery/prepare/types.go
+++ b/pkg/testmachinery/prepare/types.go
@@ -5,6 +5,7 @@ import "github.com/gardener/test-infra/pkg/testmachinery/testdefinition"
 // PrepareDefinition is the TestDefinition of the prepare step to initiliaze the setup.
 type Definition struct {
 	TestDefinition *testdefinition.TestDefinition
+	GlobalInput    bool
 	repositories   []*Repository
 }
 

--- a/pkg/testmachinery/testdefinition/artifactset.go
+++ b/pkg/testmachinery/testdefinition/artifactset.go
@@ -1,0 +1,36 @@
+// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testdefinition
+
+type ArtifactSet map[string]empty
+
+type empty struct{}
+
+func (s ArtifactSet) Add(key string) {
+	s[key] = empty{}
+}
+
+func (s ArtifactSet) Has(key string) bool {
+	_, ok := s[key]
+	return ok
+}
+
+func (s ArtifactSet) Copy() ArtifactSet {
+	newSet := make(ArtifactSet, len(s))
+	for key, value := range s {
+		newSet[key] = value
+	}
+	return newSet
+}

--- a/pkg/testmachinery/testdefinition/testdefinition.go
+++ b/pkg/testmachinery/testdefinition/testdefinition.go
@@ -100,18 +100,6 @@ func New(def *tmv1beta1.TestDefinition, loc Location, fileName string) (*TestDef
 		},
 	}
 
-	inputArtifacts := []argov1.Artifact{
-		{
-			Name:     "kubeconfigs",
-			Path:     testmachinery.TM_KUBECONFIG_PATH,
-			Optional: true,
-		},
-		{
-			Name:     "sharedFolder",
-			Path:     testmachinery.TM_SHARED_PATH,
-			Optional: true,
-		},
-	}
 	outputArtifacts := []argov1.Artifact{
 		{
 			Name:     testmachinery.ExportArtifact,
@@ -133,7 +121,7 @@ func New(def *tmv1beta1.TestDefinition, loc Location, fileName string) (*TestDef
 		return nil, err
 	}
 
-	td.AddInputArtifacts(inputArtifacts...)
+	td.AddInputArtifacts(GetStdInputArtifacts()...)
 	td.AddOutputArtifacts(outputArtifacts...)
 
 	return td, nil

--- a/pkg/testmachinery/testdefinition/types.go
+++ b/pkg/testmachinery/testdefinition/types.go
@@ -3,6 +3,7 @@ package testdefinition
 import (
 	argov1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
 	tmv1beta1 "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
+	"github.com/gardener/test-infra/pkg/testmachinery"
 	"github.com/gardener/test-infra/pkg/testmachinery/config"
 	apiv1 "k8s.io/api/core/v1"
 )
@@ -32,4 +33,21 @@ type Location interface {
 	Name() string
 	// GetLocation returns the original TestLocation object
 	GetLocation() *tmv1beta1.TestLocation
+}
+
+// GetStdInputArtifacts returns the default input artifacts of testdefionitions.
+// Thes artifacts include kubeconfig and shared folder inputs
+func GetStdInputArtifacts() []argov1.Artifact {
+	return []argov1.Artifact{
+		{
+			Name:     "kubeconfigs",
+			Path:     testmachinery.TM_KUBECONFIG_PATH,
+			Optional: true,
+		},
+		{
+			Name:     "sharedFolder",
+			Path:     testmachinery.TM_SHARED_PATH,
+			Optional: true,
+		},
+	}
 }

--- a/pkg/testmachinery/testdefinition/types.go
+++ b/pkg/testmachinery/testdefinition/types.go
@@ -1,6 +1,7 @@
 package testdefinition
 
 import (
+	"fmt"
 	argov1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
 	tmv1beta1 "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
 	"github.com/gardener/test-infra/pkg/testmachinery"
@@ -19,8 +20,8 @@ type TestDefinition struct {
 
 	Volumes []apiv1.Volume
 
-	inputArtifacts  map[string]bool
-	outputArtifacts map[string]bool
+	inputArtifacts  ArtifactSet
+	outputArtifacts ArtifactSet
 }
 
 // Location is an interface for different testDefLocation types like git or local
@@ -50,4 +51,28 @@ func GetStdInputArtifacts() []argov1.Artifact {
 			Optional: true,
 		},
 	}
+}
+
+// GetStdOutputArtifacts returns the default output artifacts of a step.
+// These artifacts include kubeconfigs and the shared folder.
+func GetStdOutputArtifacts(global bool) []argov1.Artifact {
+	kubeconfigArtifact := argov1.Artifact{
+		Name:     "kubeconfigs",
+		Path:     testmachinery.TM_KUBECONFIG_PATH,
+		Optional: true,
+	}
+	sharedFolderArtifact := argov1.Artifact{
+		Name:     "sharedFolder",
+		Path:     testmachinery.TM_SHARED_PATH,
+		Optional: true,
+	}
+
+	if global {
+		kubeconfigArtifact.GlobalName = kubeconfigArtifact.Name
+		kubeconfigArtifact.Name = fmt.Sprintf("%s-global", kubeconfigArtifact.Name)
+		sharedFolderArtifact.GlobalName = sharedFolderArtifact.Name
+		sharedFolderArtifact.Name = fmt.Sprintf("%s-global", sharedFolderArtifact.Name)
+	}
+
+	return []argov1.Artifact{kubeconfigArtifact, sharedFolderArtifact}
 }

--- a/pkg/testmachinery/testflow/flow_operations.go
+++ b/pkg/testmachinery/testflow/flow_operations.go
@@ -157,10 +157,10 @@ func ApplyOutputScope(steps map[string]*Step) error {
 func SetSerialNodes(root *node.Node) {
 	children := root.Children
 	for len(children) != 0 {
-		children = children.GetChildren()
 		// node is a real serial step if all children of the root node point to one child.
 		if len(children) == 1 {
 			children.List()[0].SetSerial()
 		}
+		children = children.GetChildren()
 	}
 }

--- a/pkg/testmachinery/testflow/flow_operations_test.go
+++ b/pkg/testmachinery/testflow/flow_operations_test.go
@@ -1,12 +1,13 @@
 package testflow_test
 
 import (
+	"testing"
+
 	argov1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
 	"github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
 	"github.com/gardener/test-infra/pkg/testmachinery/testdefinition"
 	"github.com/gardener/test-infra/pkg/testmachinery/testflow"
 	"github.com/gardener/test-infra/pkg/testmachinery/testflow/node"
-	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -223,6 +224,10 @@ var _ = Describe("flow operations", func() {
 
 			Expect(testflow.ApplyOutputScope(steps)).ToNot(HaveOccurred())
 
+			Expect(rootNode.HasOutput()).To(BeTrue())
+			Expect(rootNode.TestDefinition.Template.Outputs.Artifacts).To(ContainElement(testdefinition.GetStdOutputArtifacts(false)[0]))
+			Expect(rootNode.TestDefinition.Template.Outputs.Artifacts).To(ContainElement(testdefinition.GetStdOutputArtifacts(false)[1]))
+			Expect(rootNode.TestDefinition.Template.Outputs.Artifacts).To(HaveLen(2))
 			Expect(A.GetInputSource()).To(Equal(rootNode))
 
 			Expect(B.GetInputSource()).To(Equal(A))
@@ -244,6 +249,20 @@ var _ = Describe("flow operations", func() {
 			Expect(A.IsSerial()).To(BeFalse())
 			Expect(B.IsSerial()).To(BeFalse())
 			Expect(C.IsSerial()).To(BeFalse())
+			Expect(D.IsSerial()).To(BeTrue())
+		})
+
+		It("should mark all nodes as serial", func() {
+			A := testNode("A", node.NewSet(), &defaultTestDef)
+			B := testNode("B", node.NewSet(A), &defaultTestDef)
+			C := testNode("C", node.NewSet(B), &defaultTestDef)
+			D := testNode("D", node.NewSet(C), &defaultTestDef)
+
+			testflow.SetSerialNodes(A)
+
+			Expect(A.IsSerial()).To(BeFalse())
+			Expect(B.IsSerial()).To(BeTrue())
+			Expect(C.IsSerial()).To(BeTrue())
 			Expect(D.IsSerial()).To(BeTrue())
 		})
 

--- a/pkg/testmachinery/testflow/node/node.go
+++ b/pkg/testmachinery/testflow/node/node.go
@@ -200,6 +200,11 @@ func (n *Node) EnableOutput() {
 	}
 }
 
+// HasOutput inidactes if the node has output
+func (n *Node) HasOutput() bool {
+	return n.hasOutput
+}
+
 // SetInputSource sets the input source node for artifacts that are mounted to the test.
 func (n *Node) SetInputSource(node *Node) {
 	n.inputSource = node

--- a/pkg/testmachinery/testflow/testflow.go
+++ b/pkg/testmachinery/testflow/testflow.go
@@ -34,7 +34,7 @@ func New(flowID FlowIdentifier, tf tmv1beta1.TestFlow, locs locations.Locations,
 	if prepareDef != nil {
 		rootPrepare = prepareDef
 	}
-	rootNode := node.NewNode(rootPrepare.TestDefinition, prepare.GetPrepareStep(), string(flowID))
+	rootNode := node.NewNode(rootPrepare.TestDefinition, prepare.GetPrepareStep(rootPrepare.GlobalInput), string(flowID))
 	if err := rootNode.TestDefinition.AddConfig(globalConfig); err != nil {
 		return nil, err
 	}

--- a/pkg/testmachinery/testrun/testrun.go
+++ b/pkg/testmachinery/testrun/testrun.go
@@ -48,7 +48,7 @@ func New(tr *tmv1beta1.Testrun) (*Testrun, error) {
 		return nil, err
 	}
 
-	postPrepareDef, err := prepare.New("PostPrepare", false)
+	postPrepareDef, err := prepare.New("PostPrepare", true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
adds global input artifacts to the post prepare step so that kubeconfigs and shared folder can be shared across tasks

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Use global artifacts as input in postprepare step
```
```improvement operator
Fix serial step determination where first step was not respected
```
