### PR TITLE
Add environment configuration to status output

### DIFF
--- a/pkg/apis/testmachinery/v1beta1/types.go
+++ b/pkg/apis/testmachinery/v1beta1/types.go
@@ -161,11 +161,12 @@ type StepStatus struct {
 
 // StepStatusTestDefinition holds information about the used testdefinition and its location.
 type StepStatusTestDefinition struct {
-	Name                  string       `json:"name,omitempty"`
-	Location              TestLocation `json:"location,omitempty"`
-	Owner                 string       `json:"owner,omitempty"`
-	RecipientsOnFailure   []string     `json:"recipientsOnFailure"`
-	ActiveDeadlineSeconds *int64       `json:"activeDeadlineSeconds"`
+	Name                  string           `json:"name,omitempty"`
+	Location              TestLocation     `json:"location,omitempty"`
+	Config                []*ConfigElement `json:"config,omitempty"`
+	Owner                 string           `json:"owner,omitempty"`
+	RecipientsOnFailure   []string         `json:"recipientsOnFailure"`
+	ActiveDeadlineSeconds *int64           `json:"activeDeadlineSeconds"`
 }
 
 type StepStatusPosition struct {

--- a/pkg/apis/testmachinery/v1beta1/types.go
+++ b/pkg/apis/testmachinery/v1beta1/types.go
@@ -148,7 +148,7 @@ type TestrunStatus struct {
 
 // StepStatus is the status of Testflow step
 type StepStatus struct {
-	Name              string                   `json:"name,omitempty"`
+	Name              string                   `json:"name"`
 	Position          StepStatusPosition       `json:"position"`
 	TestDefinition    StepStatusTestDefinition `json:"testdefinition,omitempty"`
 	Phase             argov1.NodePhase         `json:"phase,omitempty"`

--- a/pkg/apis/testmachinery/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/testmachinery/v1beta1/zz_generated.deepcopy.go
@@ -172,6 +172,17 @@ func (in *StepStatusPosition) DeepCopy() *StepStatusPosition {
 func (in *StepStatusTestDefinition) DeepCopyInto(out *StepStatusTestDefinition) {
 	*out = *in
 	out.Location = in.Location
+	if in.Config != nil {
+		in, out := &in.Config, &out.Config
+		*out = make([]*ConfigElement, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(ConfigElement)
+				(*in).DeepCopyInto(*out)
+			}
+		}
+	}
 	if in.RecipientsOnFailure != nil {
 		in, out := &in.RecipientsOnFailure, &out.RecipientsOnFailure
 		*out = make([]string, len(*in))

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -383,6 +383,18 @@ func schema_pkg_apis_testmachinery_v1beta1_StepStatusTestDefinition(ref common.R
 							Ref: ref("github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1.TestLocation"),
 						},
 					},
+					"config": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref("github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1.ConfigElement"),
+									},
+								},
+							},
+						},
+					},
 					"owner": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
@@ -413,7 +425,7 @@ func schema_pkg_apis_testmachinery_v1beta1_StepStatusTestDefinition(ref common.R
 			},
 		},
 		Dependencies: []string{
-			"github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1.TestLocation"},
+			"github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1.ConfigElement", "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1.TestLocation"},
 	}
 }
 

--- a/pkg/testmachinery/config/set.go
+++ b/pkg/testmachinery/config/set.go
@@ -14,6 +14,8 @@
 
 package config
 
+import "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
+
 func NewSet(elements ...*Element) Set {
 	s := make(Set, 0)
 	for _, e := range elements {
@@ -27,6 +29,16 @@ func (s Set) List() []*Element {
 	i := 0
 	for _, e := range s {
 		list[i] = e
+		i++
+	}
+	return list
+}
+
+func (s Set) RawList() []*v1beta1.ConfigElement {
+	list := make([]*v1beta1.ConfigElement, len(s))
+	i := 0
+	for _, e := range s {
+		list[i] = e.Info
 		i++
 	}
 	return list

--- a/pkg/testmachinery/testflow/node/node.go
+++ b/pkg/testmachinery/testflow/node/node.go
@@ -149,6 +149,7 @@ func (n *Node) Status() *tmv1beta1.StepStatus {
 		TestDefinition: tmv1beta1.StepStatusTestDefinition{
 			Name:                  td.Info.Metadata.Name,
 			Owner:                 td.Info.Spec.Owner,
+			Config:                td.GetConfig().RawList(),
 			RecipientsOnFailure:   td.Info.Spec.RecipientsOnFailure,
 			ActiveDeadlineSeconds: td.Info.Spec.ActiveDeadlineSeconds,
 		},

--- a/pkg/testrunner/result/helper.go
+++ b/pkg/testrunner/result/helper.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/test-infra/pkg/testmachinery"
+	"github.com/gardener/test-infra/pkg/testrunner"
 	"github.com/gardener/test-infra/pkg/util"
 	log "github.com/sirupsen/logrus"
 	"io/ioutil"
@@ -40,6 +41,24 @@ func writeToFile(filePath string, data []byte) error {
 	}
 
 	return nil
+}
+
+func mashalAndAppendSummaries(summary testrunner.TestrunSummary, stepSummaries []testrunner.StepSummary) ([][]byte, error) {
+	b, err := util.MarshalNoHTMLEscape(summary)
+	if err != nil {
+		return nil, fmt.Errorf("cannot marshal %s", err.Error())
+	}
+
+	s := [][]byte{b}
+	for _, summary := range stepSummaries {
+		b, err := util.MarshalNoHTMLEscape(summary)
+		if err != nil {
+			return nil, fmt.Errorf("cannot marshal %s", err.Error())
+		}
+		s = append(s, b)
+	}
+	return s, nil
+
 }
 
 func getOSConfig(tmClient kubernetes.Interface, namespace, minioEndpoint string, ssl bool) (*testmachinery.ObjectStoreConfig, error) {

--- a/pkg/testrunner/result/helper.go
+++ b/pkg/testrunner/result/helper.go
@@ -43,7 +43,7 @@ func writeToFile(filePath string, data []byte) error {
 	return nil
 }
 
-func mashalAndAppendSummaries(summary testrunner.TestrunSummary, stepSummaries []testrunner.StepSummary) ([][]byte, error) {
+func marshalAndAppendSummaries(summary testrunner.TestrunSummary, stepSummaries []testrunner.StepSummary) ([][]byte, error) {
 	b, err := util.MarshalNoHTMLEscape(summary)
 	if err != nil {
 		return nil, fmt.Errorf("cannot marshal %s", err.Error())

--- a/pkg/testrunner/result/output.go
+++ b/pkg/testrunner/result/output.go
@@ -43,7 +43,7 @@ func Output(config *Config, tmClient kubernetes.Interface, namespace string, tr 
 	if err != nil {
 		return err
 	}
-	trStatusSummaries, err := mashalAndAppendSummaries(trSummary, summaries)
+	trStatusSummaries, err := marshalAndAppendSummaries(trSummary, summaries)
 	if err != nil {
 		return err
 	}

--- a/pkg/testrunner/result/output_test.go
+++ b/pkg/testrunner/result/output_test.go
@@ -1,0 +1,78 @@
+package result_test
+
+import (
+	"github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
+	"github.com/gardener/test-infra/pkg/testrunner"
+	"github.com/gardener/test-infra/pkg/testrunner/result"
+	"github.com/gardener/test-infra/test/resources"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestValidationWebhook(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Result collection Integration Test Suite")
+}
+
+var _ = Describe("output generation tests", func() {
+
+	Context("configuration", func() {
+		It("should include environment variable configuration to in the metadata", func() {
+			configElement := v1beta1.ConfigElement{
+				Type:  v1beta1.ConfigTypeEnv,
+				Name:  "test",
+				Value: "val",
+			}
+			tr := resources.GetBasicTestrun("", "")
+
+			tr.Status = v1beta1.TestrunStatus{
+				Steps: []*v1beta1.StepStatus{
+					{
+						TestDefinition: v1beta1.StepStatusTestDefinition{
+							Config: []*v1beta1.ConfigElement{
+								&configElement,
+							},
+						},
+					},
+				},
+			}
+
+			_, summaries, err := result.DetermineTestrunSummary(tr, &testrunner.Metadata{}, &result.Config{})
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(summaries).To(HaveLen(1))
+			Expect(summaries[0].Metadata.Configuration).To(HaveLen(1))
+			Expect(summaries[0].Metadata.Configuration).To(HaveKey(configElement.Name))
+			Expect(summaries[0].Metadata.Configuration[configElement.Name]).To(Equal(configElement.Value))
+		})
+	})
+
+	It("should exnclude file variable configuration from in the metadata", func() {
+		configElement := v1beta1.ConfigElement{
+			Type:  v1beta1.ConfigTypeFile,
+			Name:  "test",
+			Value: "val",
+		}
+		tr := resources.GetBasicTestrun("", "")
+
+		tr.Status = v1beta1.TestrunStatus{
+			Steps: []*v1beta1.StepStatus{
+				{
+					TestDefinition: v1beta1.StepStatusTestDefinition{
+						Config: []*v1beta1.ConfigElement{
+							&configElement,
+						},
+					},
+				},
+			},
+		}
+
+		_, summaries, err := result.DetermineTestrunSummary(tr, &testrunner.Metadata{}, &result.Config{})
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(summaries).To(HaveLen(1))
+		Expect(summaries[0].Metadata.Configuration).To(HaveLen(0))
+	})
+})

--- a/pkg/testrunner/types.go
+++ b/pkg/testrunner/types.go
@@ -65,14 +65,13 @@ type Metadata struct {
 
 	// ComponentDescriptor describes the current component_descriptor of the direct landscape-setup components.
 	// It is formated as an array of components: { name: "my_component", version: "0.0.1" }
-	ComponentDescriptor interface{} `json:"bom"`
+	ComponentDescriptor interface{} ``
 
 	// Name of the testrun crd object.
 	Testrun TestrunMetadata `json:"tr"`
 
-	// Link to the workflow in the argo ui
-	// Argo URL is in format: https://argo-endpoint.com/workflows/namespace/wf-name
-	ArgoUIExternalURL string `json:"argo_url,omitempty"`
+	// all environment configuration values
+	Configuration map[string]string `json:"config"`
 }
 
 // TestrunMetadata represents the metadata of a testrun

--- a/test/controller/resultcollection/resultcollection_test.go
+++ b/test/controller/resultcollection/resultcollection_test.go
@@ -97,6 +97,29 @@ var _ = Describe("Result collection tests", func() {
 
 		})
 
+		It("should collect configurations for steps", func() {
+			ctx := context.Background()
+			defer ctx.Done()
+
+			configElement := tmv1beta1.ConfigElement{
+				Type:  tmv1beta1.ConfigTypeEnv,
+				Name:  "test",
+				Value: "val",
+			}
+
+			tr := resources.GetBasicTestrun(namespace, commitSha)
+			tr.Spec.TestFlow[0].Definition.Config = []tmv1beta1.ConfigElement{configElement}
+
+			tr, _, err := utils.RunTestrun(ctx, tmClient, tr, argov1.NodeSucceeded, namespace, maxWaitTime)
+			defer utils.DeleteTestrun(tmClient, tr)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(tr.Status.Steps).To(HaveLen(1), "Should be one steps status")
+
+			status := tr.Status.Steps[0]
+			Expect(status.TestDefinition.Config).To(ContainElement(&configElement))
+		})
+
 		It("should collect status of multiple workflow nodes", func() {
 			ctx := context.Background()
 			defer ctx.Done()


### PR DESCRIPTION
**What this PR does / why we need it**:
Add environment variable configuration to the metadata that is persisted into elastic seach.

this gives us the ability to have dynamic metadata information (for example when running a full gardener test with multiple cloudproviders/k8s versions).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Add environment variable configuration to the metadata of test results
```
