### PR TITLE
Add feature to exclude labels

### DIFF
--- a/.ci/integration
+++ b/.ci/integration
@@ -115,13 +115,9 @@ echo "$prerequisites_chart" | kubectl --kubeconfig=$TM_KUBECONFIG create -f -
 echo "$controller_chart" | kubectl --kubeconfig=$TM_KUBECONFIG create -f -
 
 # run integration tests with ginkgo
-TM_NAMESPACE=${NAMESPACE} TM_KUBECONFIG_PATH=$TM_KUBECONFIG GIT_COMMIT_SHA=$GIT_COMMIT_SHA ginkgo -p --nodes=3 ./test/validationwebhook
-TM_NAMESPACE=${NAMESPACE} TM_KUBECONFIG_PATH=$TM_KUBECONFIG GIT_COMMIT_SHA=$GIT_COMMIT_SHA ginkgo -p --nodes=3 ./test/controller/locations
-TM_NAMESPACE=${NAMESPACE} TM_KUBECONFIG_PATH=$TM_KUBECONFIG GIT_COMMIT_SHA=$GIT_COMMIT_SHA ginkgo -p --nodes=3 ./test/controller/testflow
-TM_NAMESPACE=${NAMESPACE} TM_KUBECONFIG_PATH=$TM_KUBECONFIG GIT_COMMIT_SHA=$GIT_COMMIT_SHA ginkgo -p --nodes=3 ./test/controller/testdefinition
-TM_NAMESPACE=${NAMESPACE} TM_KUBECONFIG_PATH=$TM_KUBECONFIG GIT_COMMIT_SHA=$GIT_COMMIT_SHA ginkgo -p --nodes=3 ./test/controller/garbagecollection
-TM_NAMESPACE=${NAMESPACE} TM_KUBECONFIG_PATH=$TM_KUBECONFIG GIT_COMMIT_SHA=$GIT_COMMIT_SHA ginkgo -p --nodes=3 ./test/controller/resultcollection
-TM_NAMESPACE=${NAMESPACE} TM_KUBECONFIG_PATH=$TM_KUBECONFIG GIT_COMMIT_SHA=$GIT_COMMIT_SHA ginkgo -p --nodes=3 ./test/testrunner/...
+TM_NAMESPACE=${NAMESPACE} TM_KUBECONFIG_PATH=$TM_KUBECONFIG GIT_COMMIT_SHA=$GIT_COMMIT_SHA ginkgo -p --nodes=5 ./test/validationwebhook
+TM_NAMESPACE=${NAMESPACE} TM_KUBECONFIG_PATH=$TM_KUBECONFIG GIT_COMMIT_SHA=$GIT_COMMIT_SHA ginkgo -r -p --nodes=5 ./test/controller
+TM_NAMESPACE=${NAMESPACE} TM_KUBECONFIG_PATH=$TM_KUBECONFIG GIT_COMMIT_SHA=$GIT_COMMIT_SHA ginkgo -p --nodes=5 ./test/testrunner/...
 
 
 #######################

--- a/.ci/scripts/gh_config.py
+++ b/.ci/scripts/gh_config.py
@@ -18,7 +18,7 @@ import util
 import yaml
 import ctx
 
-github_config_names=['github_com']
+github_config_names=['tm_github_com']
 
 def get_config(name: str):
     util.check_type(name, str)

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1350,6 +1350,7 @@
     "github.com/gardener/gardener/pkg/utils",
     "github.com/gardener/gardener/pkg/utils/flow",
     "github.com/gardener/gardener/pkg/utils/kubernetes/health",
+    "github.com/gardener/gardener/pkg/utils/retry",
     "github.com/go-openapi/spec",
     "github.com/google/go-github/github",
     "github.com/joho/godotenv",

--- a/docs/GetStarted.md
+++ b/docs/GetStarted.md
@@ -313,7 +313,7 @@ spec:
     artifactsFrom: create-shoot # optional, default get from last "serial" step
   - name: test2
     definition:
-      name: default
+      label: "default,!beta" # matches all testdefintions with label default and not labeled beta
     dependsOn: [ create-shoot ]
     artifactsFrom: # automatically resolved to create-shoot
   - name: delete-shoot

--- a/docs/GetStarted.md
+++ b/docs/GetStarted.md
@@ -289,8 +289,8 @@ revision: master # tag, commit or branch
 A testflow can be specified for the the real tests `spec.testflow` or exit handlers `.spec.onExit`.
 The exit handler flow is called when the testflow finished (success or unsuccessful).
 
-A flow is a DAG (Directed Asycyclic graph) that can be described by using the `dependsOn` to set a dependency to another step.
-The `dependsOn` attribute is a list of step names :warning: do not use `definition.name`.
+A flow is a DAG (Directed Acyclic graph) that can be described by using the `dependsOn` to set a dependency to another step.
+The `dependsOn` attribute is a list of step names :warning: do not use `definition.name` as dependency.
 
 ```yaml
 apiVersion: testmachinery.sapcloud.io/v1beta1
@@ -322,6 +322,47 @@ spec:
     dependsOn: [ test1, test2 ]
     artifactsFrom: # automatically resolved to create-shoot
 ```
+
+#### Step Definition
+Step definitions define the testdefinitions with their configuration that should be executed within this step.
+
+Test Definitions can be defined by specifying a Testdefinition `name` or `label`.
+##### Name
+If a definition is specified by a name, then only one TestDefinition with the specified name is searched in the locationSet and executed.
+
+#### Label
+If a definition is specified by a labelSelector, then the Test Machinery searches for all TestDefinitions in a locationSet where the specified label Selector is true.
+The labelSelector consists of a list of comma separated label names where labels can be included or excluded by adding a `!` at the beginning of the label.
+
+Examples:
+
+TestDefinitions:
+```yaml
+kind: TestDefinition
+metadata:
+  name: def1
+spec:
+  labels: "default_1"
+```
+```yaml
+kind: TestDefinition
+metadata:
+  name: def2
+spec:
+  labels: "default_2" 
+```
+```yaml
+kind: TestDefinition
+metadata:
+  name: def3
+spec:
+  labels: "default_1,default_2"
+```
+
+`definition.label: "default_1"`: matches `def1` and `def3` <br>
+`definition.label: "default_2"`: matches `def2` and `def3` <br>
+`definition.label: "default_1,default_2"`: matches `def3` <br>
+`definition.label: "default_1,!default_2"`: matches `def1`
 
 ## Configuration
 

--- a/pkg/testmachinery/locations/testlocations.go
+++ b/pkg/testmachinery/locations/testlocations.go
@@ -72,7 +72,7 @@ func (l *testLocation) GetTestDefinitions(step tmv1beta1.StepDefinition) ([]*tes
 		return []*testdefinition.TestDefinition{td}, nil
 	}
 	if step.Label != "" {
-		defs := []*testdefinition.TestDefinition{}
+		defs := make([]*testdefinition.TestDefinition, 0)
 		for _, td := range l.TestDefinitions {
 			if td.HasLabel(step.Label) {
 				newTd := td.Copy()

--- a/pkg/testmachinery/testdefinition/testdefinition.go
+++ b/pkg/testmachinery/testdefinition/testdefinition.go
@@ -18,6 +18,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"path"
+	"strings"
 
 	"github.com/gardener/test-infra/pkg/testmachinery/config"
 	"github.com/gardener/test-infra/pkg/util"
@@ -178,12 +179,24 @@ func (td *TestDefinition) HasBehavior(behavior string) bool {
 
 // HasLabel checks if the TestDefinition has a specific label. (Group in testdef)
 func (td *TestDefinition) HasLabel(label string) bool {
-	for _, l := range td.Info.Spec.Labels {
-		if l == label {
-			return true
+	wantedLabels := strings.Split(label, ",")
+
+	for _, wantedLabel := range wantedLabels {
+		hasLabel := false
+		for _, haveLabel := range td.Info.Spec.Labels {
+			if strings.HasPrefix(wantedLabel, "!") && strings.TrimPrefix(wantedLabel, "!") == haveLabel {
+				return false
+			}
+			if haveLabel == wantedLabel {
+				hasLabel = true
+				break
+			}
+		}
+		if !hasLabel {
+			return false
 		}
 	}
-	return false
+	return true
 }
 
 // AddEnvVars adds environment variables to the container of the TestDefinition's template.

--- a/pkg/testmachinery/testdefinition/testdefinition_test.go
+++ b/pkg/testmachinery/testdefinition/testdefinition_test.go
@@ -1,0 +1,59 @@
+// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testdefinition_test
+
+import (
+	"github.com/gardener/test-infra/pkg/testmachinery"
+	"github.com/gardener/test-infra/pkg/testmachinery/testdefinition"
+
+	tmv1beta1 "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("TestDefinition", func() {
+
+	testmachinery.Setup()
+
+	Context("has label", func() {
+		var testdef *testdefinition.TestDefinition
+		BeforeEach(func() {
+			testdef = &testdefinition.TestDefinition{
+				Info: &tmv1beta1.TestDefinition{
+					Spec: tmv1beta1.TestDefSpec{
+						Labels: []string{"default", "default2", "not"},
+					},
+				},
+			}
+		})
+
+		It("should return true when the labels match", func() {
+			Expect(testdef.HasLabel("default")).To(BeTrue())
+		})
+
+		It("should return true when 2 labels match ", func() {
+			Expect(testdef.HasLabel("default,default2")).To(BeTrue())
+		})
+
+		It("should return false when 1 labels does not match ", func() {
+			Expect(testdef.HasLabel("default,default1")).To(BeFalse())
+		})
+
+		It("should return false when the testdefinition has 1 excluding label", func() {
+			Expect(testdef.HasLabel("default,!not")).To(BeFalse())
+		})
+
+	})
+})

--- a/pkg/testmachinery/testdefinition/validation.go
+++ b/pkg/testmachinery/testdefinition/validation.go
@@ -43,6 +43,13 @@ func Validate(identifier string, td *tmv1beta1.TestDefinition) error {
 	if len(td.Spec.RecipientsOnFailure) != 0 && !isEmailListValid(td.Spec.RecipientsOnFailure) {
 		return fmt.Errorf("Invalid TestDefinition (%s) ReceipientsOnFailure: \"%s\": spec.notifyOnFailure : Required value: valid email has to be defined", identifier, td.Spec.RecipientsOnFailure)
 	}
+
+	for i, label := range td.Spec.Labels {
+		identifier := fmt.Sprintf("Invalid TestDefinition (%s): spec.labels[%d]", identifier, i)
+		if err := ValidateLabelName(identifier, label); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -68,6 +75,15 @@ func ValidateName(identifier, name string) error {
 		return fmt.Errorf("Invalid TestDefinition (%s): metadata.name : Invalid value: %s", identifier, strings.Join(errMsgs, ";"))
 	}
 
+	return nil
+}
+
+// ValidateLabelName validates the TestDefinition label string.
+// label starting with "!" are not valid as this is considered to mean exclude label
+func ValidateLabelName(identifier, label string) error {
+	if strings.HasPrefix(label, "!") {
+		return fmt.Errorf("%s : Invalid label: name must not contain '!'", identifier)
+	}
 	return nil
 }
 

--- a/pkg/testmachinery/testflow/flow_operations_test.go
+++ b/pkg/testmachinery/testflow/flow_operations_test.go
@@ -513,7 +513,7 @@ func testNode(name string, parents node.Set, td *testdefinition.TestDefinition, 
 	if parents == nil {
 		parents = node.NewSet()
 	}
-	n := node.NewEmtpy(name)
+	n := node.NewEmpty(name)
 	n.Parents = parents
 	n.Children = node.NewSet()
 	n.TestDefinition = td

--- a/pkg/testmachinery/testflow/node/node.go
+++ b/pkg/testmachinery/testflow/node/node.go
@@ -59,8 +59,8 @@ func NewNode(td *testdefinition.TestDefinition, step *tmv1beta1.DAGStep, flow st
 	return node
 }
 
-// NewEmpty creates and new emtpy node with a name.
-func NewEmtpy(name string) *Node {
+// NewEmpty creates and new empty node with a name.
+func NewEmpty(name string) *Node {
 	return &Node{
 		name:     name,
 		Parents:  NewSet(),

--- a/test/controller/locations/locations_locationset_suite_test.go
+++ b/test/controller/locations/locations_locationset_suite_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gardener/test-infra/pkg/testmachinery"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 
@@ -34,7 +35,7 @@ import (
 )
 
 var (
-	maxWaitTime int64 = 300
+	maxWaitTime = 300 * time.Second
 )
 
 var (

--- a/test/controller/resultcollection/resultcollection_test.go
+++ b/test/controller/resultcollection/resultcollection_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 var (
-	maxWaitTime int64 = 300
+	maxWaitTime = 10 * time.Minute
 )
 
 var _ = Describe("Result collection tests", func() {

--- a/test/controller/testdefinition/testdefinition_suite_test.go
+++ b/test/controller/testdefinition/testdefinition_suite_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/gardener/test-infra/pkg/testmachinery"
 
@@ -35,7 +36,7 @@ import (
 )
 
 var (
-	maxWaitTime int64 = 300
+	maxWaitTime = 10 * time.Minute
 )
 
 func TestValidationWebhook(t *testing.T) {

--- a/test/controller/testflow/testflow_kubeconfig_suite_test.go
+++ b/test/controller/testflow/testflow_kubeconfig_suite_test.go
@@ -17,6 +17,7 @@ package testflow_test
 import (
 	"context"
 	"encoding/base64"
+	log "github.com/sirupsen/logrus"
 	"io/ioutil"
 	"path/filepath"
 
@@ -71,7 +72,7 @@ var _ = Describe("Testflow execution tests", func() {
 
 	})
 
-	Context("kubeconfigs configsrouce", func() {
+	Context("kubeconfigs config source", func() {
 		It("should add a shoot kubeconfig referenced from a secret to all test steps", func() {
 			ctx := context.Background()
 			defer ctx.Done()
@@ -82,7 +83,7 @@ var _ = Describe("Testflow execution tests", func() {
 
 			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "test-kubeconfig",
+					GenerateName: "test-kubeconfig-",
 					Namespace:    namespace,
 				},
 				Type: corev1.SecretTypeOpaque,
@@ -96,6 +97,7 @@ var _ = Describe("Testflow execution tests", func() {
 				err := tmClient.Client().Delete(ctx, secret)
 				Expect(err).ToNot(HaveOccurred(), "Cannot delete secret")
 			}()
+			log.Debugf("created secret %s", secret.Name)
 
 			tr := resources.GetBasicTestrun(namespace, commitSha)
 			tr.Spec.Kubeconfigs.Shoot = strconf.FromConfig(strconf.ConfigSource{

--- a/test/controller/testflow/testflow_suite_test.go
+++ b/test/controller/testflow/testflow_suite_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/gardener/test-infra/pkg/util/strconf"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"strings"
 	"testing"
@@ -44,7 +45,7 @@ import (
 )
 
 var (
-	maxWaitTime int64 = 300
+	maxWaitTime = 10 * time.Minute
 )
 
 var (
@@ -65,6 +66,10 @@ var _ = Describe("Testflow execution tests", func() {
 		commitSha = os.Getenv("GIT_COMMIT_SHA")
 		tmKubeconfig := os.Getenv("TM_KUBECONFIG_PATH")
 		namespace = os.Getenv("TM_NAMESPACE")
+
+		if os.Getenv("DEBUG") == "true" {
+			log.SetLevel(log.DebugLevel)
+		}
 
 		tmClient, err = kubernetes.NewClientFromFile("", tmKubeconfig, client.Options{
 			Scheme: testmachinery.TestMachineryScheme,

--- a/test/testrunner/output/testrunner_output_execution_test.go
+++ b/test/testrunner/output/testrunner_output_execution_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/gardener/test-infra/pkg/testrunner"
 
@@ -42,7 +43,7 @@ import (
 )
 
 var (
-	maxWaitTime int64 = 300
+	maxWaitTime = 300 * time.Second
 )
 
 func TestValidationWebhook(t *testing.T) {
@@ -75,7 +76,8 @@ var _ = Describe("Testrunner execution tests", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(utils.WaitForClusterReadiness(tmClient, namespace, maxWaitTime)).ToNot(HaveOccurred())
-		utils.WaitForMinioService(tmClient, s3Endpoint, namespace, maxWaitTime)
+		_, err = utils.WaitForMinioService(tmClient, s3Endpoint, namespace, maxWaitTime)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	BeforeEach(func() {

--- a/test/testrunner/run/testrunner_run_test.go
+++ b/test/testrunner/run/testrunner_run_test.go
@@ -17,6 +17,7 @@ package testrunner_test
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/gardener/test-infra/pkg/testmachinery"
 
@@ -33,7 +34,7 @@ import (
 )
 
 var (
-	maxWaitTime int64 = 300
+	maxWaitTime = 300 * time.Second
 )
 
 func TestValidationWebhook(t *testing.T) {
@@ -65,14 +66,15 @@ var _ = Describe("Testrunner execution tests", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(utils.WaitForClusterReadiness(tmClient, namespace, maxWaitTime)).ToNot(HaveOccurred())
-		utils.WaitForMinioService(tmClient, s3Endpoint, namespace, maxWaitTime)
+		_, err = utils.WaitForMinioService(tmClient, s3Endpoint, namespace, maxWaitTime)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	BeforeEach(func() {
 		testrunConfig = testrunner.Config{
 			TmClient:  tmClient,
 			Namespace: namespace,
-			Timeout:   maxWaitTime,
+			Timeout:   int64(maxWaitTime),
 			Interval:  5,
 		}
 	})

--- a/test/validationwebhook/testrun_validation_test.go
+++ b/test/validationwebhook/testrun_validation_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"github.com/gardener/test-infra/pkg/util/strconf"
 	"os"
+	"time"
 
 	"github.com/gardener/test-infra/pkg/testmachinery"
 
@@ -39,7 +40,7 @@ var _ = Describe("Testrun validation tests", func() {
 		commitSha   string
 		namespace   string
 		tmClient    kubernetes.Interface
-		maxWaitTime int64 = 300
+		maxWaitTime = 300 * time.Second
 	)
 
 	BeforeSuite(func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the feature to have a comma separated list of labels in the step definition `.spec.tesflow.x.definition.label`.

With this change a step can now have multiple labels which all have to be on a testdefinition in order to be picked up.
In addition, labels can be excluded by prefixing the label with `!`:

Examples:

TestDefinitions:
```yaml
kind: TestDefinition
metadata:
  name: def1
spec:
  labels: "default_1"
```
```yaml
kind: TestDefinition
metadata:
  name: def2
spec:
  labels: "default_2" 
```
```yaml
kind: TestDefinition
metadata:
  name: def3
spec:
  labels: "default_1,default_2"
```

`definition.label: "default_1"`: matches `def1` and `def3`
`definition.label: "default_2"`: matches `def2` and `def3`
`definition.label: "default_1,default_2"`: matches `def3`
`definition.label: "default_1,!default_2"`: matches `def1`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Add feature to specify multiple labels and exclude labels
```
