### PR TITLE
Add testrunner for full gardener lifecycle tests and remove deprecated kibana url

### DIFF
--- a/cmd/hostscheduler/scheduler/gardener_cleaner_helper.go
+++ b/cmd/hostscheduler/scheduler/gardener_cleaner_helper.go
@@ -26,7 +26,7 @@ var (
 	// NotMonitoringComponent is a requirement that something doesn't have the GardenRole GardenRoleMonitoring.
 	NotMonitoringComponent = botanist.MustNewRequirement(common.GardenRole, selection.NotEquals, common.GardenRoleMonitoring)
 
-	// NotAddonManagerReconcile is a requirment that something doesnt have the label addonmanager.kubernetes.io/mode = Reconcile
+	// NotAddonManagerReconcile is a requirement that something doesnt have the label addonmanager.kubernetes.io/mode = Reconcile
 	NotAddonManagerReconcile = botanist.MustNewRequirement("addonmanager.kubernetes.io/mode", selection.NotEquals, "Reconcile")
 
 	// NotSystemComponentSelector is a selector that excludes system components.

--- a/cmd/testrunner/cmd/cmd.go
+++ b/cmd/testrunner/cmd/cmd.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"github.com/gardener/test-infra/cmd/testrunner/cmd/collect"
+	"github.com/gardener/test-infra/cmd/testrunner/cmd/rungardenertemplate"
 	"github.com/gardener/test-infra/cmd/testrunner/cmd/version"
 	"os"
 
@@ -47,9 +48,11 @@ func init() {
 	log.SetOutput(os.Stderr)
 
 	rootCmd.PersistentFlags().BoolP("debug", "d", false, "Set debug mode for additional output")
+	rootCmd.PersistentFlags().Bool("dry-run", false, "Dry run will print the rendered template")
 
 	runtemplate.AddCommand(rootCmd)
 	runtestrun.AddCommand(rootCmd)
+	rungardenertemplate.AddCommand(rootCmd)
 	collectcmd.AddCommand(rootCmd)
 	docs.AddCommand(rootCmd)
 	versioncmd.AddCommand(rootCmd)

--- a/cmd/testrunner/cmd/collect/collect.go
+++ b/cmd/testrunner/cmd/collect/collect.go
@@ -42,8 +42,6 @@ var (
 	elasticSearchConfigName string
 	s3Endpoint              string
 	s3SSL                   bool
-	argouiEndpoint          string
-	kibanaEndpoint          string
 	concourseOnErrorDir     string
 )
 
@@ -71,8 +69,6 @@ var collectCmd = &cobra.Command{
 			ESConfigName:        elasticSearchConfigName,
 			S3Endpoint:          s3Endpoint,
 			S3SSL:               s3SSL,
-			ArgoUIEndpoint:      argouiEndpoint,
-			KibanaEndpoint:      kibanaEndpoint,
 			ConcourseOnErrorDir: concourseOnErrorDir,
 		}
 		log.Debugln(util.PrettyPrintStruct(collectConfig))
@@ -125,8 +121,6 @@ func init() {
 	collectCmd.Flags().StringVar(&elasticSearchConfigName, "es-config-name", "", "The elasticsearch secret-server config name.")
 	collectCmd.Flags().StringVar(&s3Endpoint, "s3-endpoint", os.Getenv("S3_ENDPOINT"), "S3 endpoint of the testmachinery cluster.")
 	collectCmd.Flags().BoolVar(&s3SSL, "s3-ssl", false, "S3 has SSL enabled.")
-	collectCmd.Flags().StringVar(&argouiEndpoint, "argoui-endpoint", "", "ArgoUI endpoint of the testmachinery cluster.")
-	collectCmd.Flags().StringVar(&kibanaEndpoint, "kibana-logging-endpoint", "", "Kibana endpoint used for logging of the testmachinery cluster.")
 	collectCmd.Flags().StringVar(&concourseOnErrorDir, "concourse-onError-dir", os.Getenv("ON_ERROR_DIR"), "On error dir which is used by Concourse.")
 
 }

--- a/docs/Testrunner.md
+++ b/docs/Testrunner.md
@@ -5,10 +5,10 @@ Testrunner is an additional component of the Test Machinery that abstracts templ
 - [Testrunner](#testrunner)
   - [Usage](#usage)
   - [Pipeline Usage](#pipeline-usage)
-    - [Templating Configuration](#templating-configuration)
-    - [Templating Parameters](#templating-parameters)
     - [Component Descriptor](#component-descriptor)
-    - [Helm Template Format](#helm-template-format)
+  - [run-template cmd](#run-template)
+  - [run-gardener-template cmd](#run-template)
+ 
 
 <p align="center">
   <img alt= "testrunner overview" src="https://github.com/gardener/test-infra/raw/master/docs/testrunner_overview.png">
@@ -26,7 +26,8 @@ testrunner [flags]
 ```
 
 Available commands ([technical detailed docs](testrunner/testrunner.md)):
-* [run-template](#pipeline-usage)
+* [run-template](#run-template)
+* [run-gardener-template](#run-gardener-template)
 * run-testrun
 
 ## Pipeline Usage
@@ -34,49 +35,16 @@ Available commands ([technical detailed docs](testrunner/testrunner.md)):
 The default usage of the testrunner is in a CI/CD pipline with the helm templating command.
 In addition results of the helm-templated testruns are collected and stored in a database.
 
-The templating can be used via
+The templating for default landscape tests can be used via
 ```
 testrunner run|run-tmpl [flags]
 ```
+
+Templating for gardener full lifecycle test can be used via
+```
+testrunner run-gardener-template [flags]
+```
 :warning: As this command is intended to run in a CI/CD pipeline it depends on the gardener [cc-utils](https://github.com/gardener/cc-utils) library to store test results in an elasticsearch database.
-
-### Templating Configuration
-
-| flag | default | description | required
-| ---- | ---- | ---- | --- |
-| tm-kubeconfig-path | | Path to the kubeconfig of the cluster running the Test Machinery | x |
-| testruns-chart-path | | Path to the Testrun helm template that should be deployed. (Additional information about the parameters can be found [here](#helm-template)) | x |
-| testrun-prefix | | Prefix of the deployed Testrun. This prefix is used for the `metadata.generateName` of Testruns in the helm template. | x |
-| namespace | default | Namespace where the testrun is deployed. |  |
-| timeout | 3600 | Max seconds to wait for all Testruns to finish. | |
-| version-matrix | false | Run the testrun with all available versions of the specified cloudprovider. :warning: The `k8s-version` is ingored if this parameter is set to true.| |
-| output-file-path | "./testout" | The filepath where the test summary and results should be written to. | |
-| s3-endpoint | EnvVar ("S3_ENDPOINT") | Accessible S3 endpoint of the s3 storage used by argo. This parameter is needed when tests export test results and the testrunner needs to fetch them and add them to the summary. | |
-| s3-ssl | false | Enables ssl support for the corresponding s3 storage. | |
-| argoui-endpoint | | Endpoint of the ArgoUI watching the Testmachinery cluster. | |
-| es-config-name | | Elasticsearch server config name that is used with the cc-utils cli | |
-| concourse-onError-dir | EnvVar ("ON_ERROR_DIR") | Directory where the `notify.cfg` should be written to. | |
-
-
-### Templating Parameters
-
-| flag | default | description | required
-| ---- | ---- | ---- | --- |
-| gardener-kubeconfig-path | | Path to a kubeconfig where a gardener is running. The kubeconfig will be base64 encoded and passed to the Testrun. | x |
-| shoot-name | | Name of the shoot which is created for testing. | x |
-| project-name | | Gardener project name where the shoot should be deployed. | x |
-| cloudprovider | | Cloudprovider of the shoot. Can be `aws`, `azure`, `gcp`, `openstack`, `alicloud` | x |
-| cloudprofile | | Cloudprofile that should be used to create the shoot. | x |
-| secret-binding | | Gardener secret that should be used to create the shoot. <br>:warning: This needs to point to a valid secret for the cloudprofile. | x |
-| region | | Region of the shoot | x |
-| zone | | Zone of the shoot workers. <br>:warning: Note that currently only 1 workerpool is supported for testing. | x |
-| k8s-version | | Kubernetes version of the created shoot. | x |
-| machinetype | | Machinetype of the first worker pool. |  |
-| autoscaler-min | | Minimum number of worker nodes of the first worker pool. | |
-| autoscaler-max | | Maximum number of worker nodes of the first worker pool. | |
-| floating-pool-name | | Floating pool name of the created cluster. Needed for Openstack. | Only required for Openstack clusters|
-| component-descriptor-path | | Path to a component descriptor. The component descriptor will be automatically parsed and all github modules will be added to the testrun's `testLocations`. For further information see [here](#component-descriptor). | |
-| landscape | | Semantic metadata information about the current landscape that is tested. | |
 
 ### Component Descriptor
 
@@ -102,6 +70,45 @@ components:
       version: "" # 1967.3.0
 ```
 
+## run-template
+
+### Templating Configuration
+
+| flag | default | description | required
+| ---- | ---- | ---- | --- |
+| tm-kubeconfig-path | | Path to the kubeconfig of the cluster running the Test Machinery | x |
+| testruns-chart-path | | Path to the Testrun helm template that should be deployed. (Additional information about the parameters can be found [here](#helm-template)) | x |
+| testrun-prefix | | Prefix of the deployed Testrun. This prefix is used for the `metadata.generateName` of Testruns in the helm template. | x |
+| namespace | default | Namespace where the testrun is deployed. |  |
+| timeout | 3600 | Max seconds to wait for all Testruns to finish. | |
+| all-k8s-versions | false | Run the testrun with all available versions of the specified cloudprovider. :warning: The `k8s-version` is ignored if this parameter is set to true.| |
+| output-file-path | "./testout" | The filepath where the test summary and results should be written to. | |
+| s3-endpoint | EnvVar ("S3_ENDPOINT") | Accessible S3 endpoint of the s3 storage used by argo. This parameter is needed when tests export test results and the testrunner needs to fetch them and add them to the summary. | |
+| s3-ssl | false | Enables ssl support for the corresponding s3 storage. | |
+| es-config-name | | Elasticsearch server config name that is used with the cc-utils cli | |
+| concourse-onError-dir | EnvVar ("ON_ERROR_DIR") | Directory where the `notify.cfg` should be written to. | |
+
+
+### Templating Parameters
+
+| flag | default | description | required
+| ---- | ---- | ---- | --- |
+| gardener-kubeconfig-path | | Path to a kubeconfig where a gardener is running. The kubeconfig will be base64 encoded and passed to the Testrun. | x |
+| shoot-name | | Name of the shoot which is created for testing. | x |
+| project-name | | Gardener project name where the shoot should be deployed. | x |
+| cloudprovider | | Cloudprovider of the shoot. Can be `aws`, `azure`, `gcp`, `openstack`, `alicloud` | x |
+| cloudprofile | | Cloudprofile that should be used to create the shoot. | x |
+| secret-binding | | Gardener secret that should be used to create the shoot. <br>:warning: This needs to point to a valid secret for the cloudprofile. | x |
+| region | | Region of the shoot | x |
+| zone | | Zone of the shoot workers. <br>:warning: Note that currently only 1 workerpool is supported for testing. | x |
+| k8s-version | | Kubernetes version of the created shoot. | x |
+| machinetype | | Machinetype of the first worker pool. |  |
+| autoscaler-min | | Minimum number of worker nodes of the first worker pool. | |
+| autoscaler-max | | Maximum number of worker nodes of the first worker pool. | |
+| floating-pool-name | | Floating pool name of the created cluster. Needed for Openstack. | Only required for Openstack clusters|
+| component-descriptor-path | | Path to a component descriptor. The component descriptor will be automatically parsed and all github modules will be added to the testrun's `testLocations`. For further information see [here](#component-descriptor). | |
+| landscape | | Semantic metadata information about the current landscape that is tested. | |
+
 ### Helm Template Format
 
 The Testrunner integrates the helm templating engine and uses it to simplify the specification of different Testruns with different purposes.
@@ -110,6 +117,7 @@ It it also supported to have multiple testruns in one helm chart which all can b
 The helm charts need to have a specific format to be properly handled.
 
 :information_source: The `generateName` attribute is automatically set by the Test Machinery using the commandline provided prefix.
+
 
 ```yaml
 apiVersion: testmachinery.sapcloud.io/v1beta1
@@ -146,41 +154,151 @@ spec:
       value: {{ .Values.shoot.k8sVersion | default "1.12.4" }}
 
   testFlow:
-  - - name: create-shoot
-      config:
-      - name: CLOUDPROFILE
-        type: env
-        value: {{ .Values.shoot.cloudprofile | default "gcp" }}
-      - name: SECRET_BINDING
-        type: env
-        value: {{ .Values.shoot.secretBinding }}
-      - name: REGION
-        type: env
-        value: {{ .Values.shoot.region }}
-      - name: ZONE
-        type: env
-        value: {{ .Values.shoot.zone }}
-      {{ if .Values.shoot.machinetype }}
-      - name: MACHINE_TYPE
-        type: env
-        value: {{ .Values.shoot.machinetype }}
-      {{ end }}
-      {{ if .Values.shoot.autoscalerMin }}
-      - name: AUTOSCALER_MIN
-        type: env
-        value: {{ .Values.shoot.autoscalerMin }}
-      {{ end }}
-      {{ if .Values.shoot.autoscalerMax }}
-      - name: AUTOSCALER_MAX
-        type: env
-        value: {{ .Values.shoot.autoscalerMax }}
-      {{ end }}
+    - name: create-shoot
+      definition:
+        name: create-shoot
+        config:
+        - name: CLOUDPROFILE
+          type: env
+          value: {{ .Values.shoot.cloudprofile | default "gcp" }}
+        - name: SECRET_BINDING
+          type: env
+          value: {{ .Values.shoot.secretBinding }}
+        - name: REGION
+          type: env
+          value: {{ .Values.shoot.region }}
+        - name: ZONE
+          type: env
+          value: {{ .Values.shoot.zone }}
+        {{ if .Values.shoot.machinetype }}
+        - name: MACHINE_TYPE
+          type: env
+          value: {{ .Values.shoot.machinetype }}
+        {{ end }}
+        {{ if .Values.shoot.autoscalerMin }}
+        - name: AUTOSCALER_MIN
+          type: env
+          value: {{ .Values.shoot.autoscalerMin }}
+        {{ end }}
+        {{ if .Values.shoot.autoscalerMax }}
+        - name: AUTOSCALER_MAX
+          type: env
+          value: {{ .Values.shoot.autoscalerMax }}
+        {{ end }}
+  
+    - name: tests
+      dependsOn: [ create-shoot ]
+      definition:
+        label: default
+        continueOnError: true
+    - name: delete-shoot
+      dependsOn: [ tests ]
+      definition:
+        name: delete-shoot
+  
+  onExit:
+    - name: delete-shoot
+      definition:
+        name: delete-shoot
 
-  - - label: default
-  - - name: delete-shoot
+```
+
+
+## run-gardener-template
+
+This template is intended to be used for a full gardener lifecycle test.
+Such a full test consists of the following steps:
+
+- get host machine
+- create gardener on the host machine (done wiht [garden-setup](https://github.com/gardener/garden-setup))
+- create some shoots (different cloudproviders, k8s versions etc.)
+- update gardener to the next version
+- test previously created shoots
+- create new shoots and test
+- delete all shoots
+- delete gardener
+- hibernate host cluster
+
+### Templating Configuration
+
+| flag | default | description | required
+| ---- | ---- | ---- | --- |
+| tm-kubeconfig-path | | Path to the kubeconfig of the cluster running the Test Machinery | x |
+| testruns-chart-path | | Path to the Testrun helm template that should be deployed. (Additional information about the parameters can be found [here](#helm-template)) | x |
+| testrun-prefix | | Prefix of the deployed Testrun. This prefix is used for the `metadata.generateName` of Testruns in the helm template. | x |
+| namespace | default | Namespace where the testrun is deployed. |  |
+| timeout | 3600 | Max seconds to wait for all Testruns to finish. | |
+| output-file-path | "./testout" | The filepath where the test summary and results should be written to. | |
+| s3-endpoint | EnvVar ("S3_ENDPOINT") | Accessible S3 endpoint of the s3 storage used by argo. This parameter is needed when tests export test results and the testrunner needs to fetch them and add them to the summary. | |
+| s3-ssl | false | Enables ssl support for the corresponding s3 storage. | |
+| es-config-name | | Elasticsearch server config name that is used with the cc-utils cli | |
+| concourse-onError-dir | EnvVar ("ON_ERROR_DIR") | Directory where the `notify.cfg` should be written to. | |
+
+
+### Templating Parameters
+
+| flag | default | description | required
+| ---- | ---- | ---- | --- |
+| component-descriptor-path | | Path to a component descriptor. The component descriptor will be automatically parsed and all github modules will be added to the testrun's `spec.locationSets.default` as the default locationSet. For further information see [here](#component-descriptor). | |
+| upgraded-component-descriptor-path | | Path to a component descriptor. The component descriptor will be automatically parsed and all github modules will be added to the testrun's `spec.locationSets.upgraded` as another lcoationSet with the name `upgraded`. For further information see [here](#component-descriptor). | |
+
+### Helm Template Format
+
+The Testrunner integrates the helm templating engine and uses it to simplify the specification of different Testruns with different purposes.
+It it also supported to have multiple testruns in one helm chart which all can be handled by the testrunner.
+
+The helm charts need to have a specific format to be properly handled.
+
+:information_source: The `generateName` attribute is automatically set by the Test Machinery using the commandline provided prefix.
+
+```yaml
+{{- $prefix := (randAlpha 5 | lower) -}}
+apiVersion: testmachinery.sapcloud.io/v1beta1
+kind: Testrun
+metadata:
+  namespace: default
+spec:
+
+  ttlSecondsAfterFinished: 172800 # 2 days
+    
+  locationSets:
+    - name: default
+      default: true
+      locations:
+      - type: git
+        repo: https://github.com/gardener/test-infra.git
+        revision: master
+      - type: git
+        repo: https://github.com/gardener/gardener.git
+        revision: 0.24.0
+      - type: git
+        repo: https://github.com/gardener/garden-setup.git
+        revision: master
+  
+    - name: upgraded
+      locations:
+      - type: git
+        repo: https://github.com/schrodit/test-infra.git
+        revision: master
+      - type: git
+        repo: https://github.com/gardener/gardener.git
+        revision: 0.25.0
+      - type: git
+        repo: https://github.com/gardener/garden-setup.git
+        revision: master
+
+  config:
+  - name: GARDENER_PREFIX
+    type: env
+    value: {{ $prefix }}
+  - name: PROJECT_NAMESPACE
+    type: env
+     value: garden-core
+
+  testFlow:
+  ...
 
   onExit:
-  - - name: delete-shoot
-      condition: error
+  ...
 
 ```

--- a/docs/testrunner/testrunner.md
+++ b/docs/testrunner/testrunner.md
@@ -9,14 +9,17 @@ Testrunner for Test Machinery
 ### Options
 
 ```
-  -d, --debug   Set debug mode for additional output
-  -h, --help    help for testrunner
+  -d, --debug     Set debug mode for additional output
+      --dry-run   Dry run will print the rendered template
+  -h, --help      help for testrunner
 ```
 
 ### SEE ALSO
 
 * [testrunner collect](testrunner_collect.md)	 - Collects results from a completed testrun.
 * [testrunner docs](testrunner_docs.md)	 - Generate docs for the testrunner
+* [testrunner run-gardener-template](testrunner_run-gardener-template.md)	 - Run the testrunner with a helm template containing testruns
 * [testrunner run-template](testrunner_run-template.md)	 - Run the testrunner with a helm template containing testruns
 * [testrunner run-testrun](testrunner_run-testrun.md)	 - Run the testrunner with a testrun
+* [testrunner version](testrunner_version.md)	 - Get testrunner version
 

--- a/docs/testrunner/testrunner_collect.md
+++ b/docs/testrunner/testrunner_collect.md
@@ -13,23 +13,22 @@ testrunner collect [flags]
 ### Options
 
 ```
-      --argoui-endpoint string           ArgoUI endpoint of the testmachinery cluster.
-      --concourse-onError-dir string     On error dir which is used by Concourse.
-      --es-config-name string            The elasticsearch secret-server config name.
-  -h, --help                             help for collect
-      --kibana-logging-endpoint string   Kibana endpoint used for logging of the testmachinery cluster.
-  -n, --namespace string                 Namespace where the testrun should be deployed. (default "default")
-  -o, --output-dir-path string           The filepath where the summary should be written to. (default "./testout")
-      --s3-endpoint string               S3 endpoint of the testmachinery cluster.
-      --s3-ssl                           S3 has SSL enabled.
-      --tm-kubeconfig-path string        Path to the testmachinery cluster kubeconfig
-  -t, --tr-name string                   Name of the testrun to collect results.
+      --concourse-onError-dir string   On error dir which is used by Concourse.
+      --es-config-name string          The elasticsearch secret-server config name.
+  -h, --help                           help for collect
+  -n, --namespace string               Namespace where the testrun should be deployed. (default "default")
+  -o, --output-dir-path string         The filepath where the summary should be written to. (default "./testout")
+      --s3-endpoint string             S3 endpoint of the testmachinery cluster.
+      --s3-ssl                         S3 has SSL enabled.
+      --tm-kubeconfig-path string      Path to the testmachinery cluster kubeconfig
+  -t, --tr-name string                 Name of the testrun to collect results.
 ```
 
 ### Options inherited from parent commands
 
 ```
-  -d, --debug   Set debug mode for additional output
+  -d, --debug     Set debug mode for additional output
+      --dry-run   Dry run will print the rendered template
 ```
 
 ### SEE ALSO

--- a/docs/testrunner/testrunner_docs.md
+++ b/docs/testrunner/testrunner_docs.md
@@ -20,7 +20,8 @@ testrunner docs [flags]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug   Set debug mode for additional output
+  -d, --debug     Set debug mode for additional output
+      --dry-run   Dry run will print the rendered template
 ```
 
 ### SEE ALSO

--- a/docs/testrunner/testrunner_run-full-gardener-template.md
+++ b/docs/testrunner/testrunner_run-full-gardener-template.md
@@ -1,0 +1,42 @@
+## testrunner run-full-gardener-template
+
+Run the testrunner with a helm template containing testruns
+
+### Synopsis
+
+Run the testrunner with a helm template containing testruns
+
+```
+testrunner run-full-gardener-template [flags]
+```
+
+### Options
+
+```
+      --component-descriptor-path string            Path to the component descriptor (BOM) of the current landscape.
+      --concourse-onError-dir string                On error dir which is used by Concourse.
+      --es-config-name string                       The elasticsearch secret-server config name. (default "sap_internal")
+  -h, --help                                        help for run-full-gardener-template
+      --interval int                                Poll interval in seconds of the testrunner to poll for the testrun status. (default 20)
+  -n, --namespace string                            Namesapce where the testrun should be deployed. (default "default")
+      --output-dir-path string                      The filepath where the summary should be written to. (default "./testout")
+      --s3-endpoint string                          S3 endpoint of the testmachinery cluster.
+      --s3-ssl                                      S3 has SSL enabled.
+      --testrun-prefix string                       Testrun name prefix which is used to generate a unique testrun name. (default "default-")
+      --testruns-chart-path string                  Path to the testruns chart.
+      --timeout int                                 Timout in seconds of the testrunner to wait for the complete testrun to finish. (default 3600)
+      --tm-kubeconfig-path string                   Path to the testmachinery cluster kubeconfig
+      --upgraded-component-descriptor-path string   Path to the component descriptor (BOM) of the new landscape.
+```
+
+### Options inherited from parent commands
+
+```
+  -d, --debug     Set debug mode for additional output
+      --dry-run   Dry run will print the rendered template
+```
+
+### SEE ALSO
+
+* [testrunner](testrunner.md)	 - Testrunner for Test Machinery
+

--- a/docs/testrunner/testrunner_run-gardener-template.md
+++ b/docs/testrunner/testrunner_run-gardener-template.md
@@ -1,0 +1,46 @@
+## testrunner run-gardener-template
+
+Run the testrunner with a helm template containing testruns
+
+### Synopsis
+
+Run the testrunner with a helm template containing testruns
+
+```
+testrunner run-gardener-template [flags]
+```
+
+### Options
+
+```
+      --component-descriptor-path string            Path to the component descriptor (BOM) of the current landscape.
+      --concourse-onError-dir string                On error dir which is used by Concourse.
+      --es-config-name string                       The elasticsearch secret-server config name. (default "sap_internal")
+      --gardener-current-revision string            Set current revision of gardener. This will result in the helm value {{ .Values.gardener.current.revision }}
+      --gardener-current-version string             Set current version of gardener. This will result in the helm value {{ .Values.gardener.current.version }}
+      --gardener-upgraded-revision string           Set current revision of gardener. This will result in the helm value {{ .Values.gardener.upgraded.revision }}
+      --gardener-upgraded-version string            Set current version of gardener. This will result in the helm value {{ .Values.gardener.upgraded.version }}
+  -h, --help                                        help for run-gardener-template
+      --interval int                                Poll interval in seconds of the testrunner to poll for the testrun status. (default 20)
+  -n, --namespace string                            Namesapce where the testrun should be deployed. (default "default")
+      --output-dir-path string                      The filepath where the summary should be written to. (default "./testout")
+      --s3-endpoint string                          S3 endpoint of the testmachinery cluster.
+      --s3-ssl                                      S3 has SSL enabled.
+      --testrun-prefix string                       Testrun name prefix which is used to generate a unique testrun name. (default "default-")
+      --testruns-chart-path string                  Path to the testruns chart.
+      --timeout int                                 Timout in seconds of the testrunner to wait for the complete testrun to finish. (default 3600)
+      --tm-kubeconfig-path string                   Path to the testmachinery cluster kubeconfig
+      --upgraded-component-descriptor-path string   Path to the component descriptor (BOM) of the new landscape.
+```
+
+### Options inherited from parent commands
+
+```
+  -d, --debug     Set debug mode for additional output
+      --dry-run   Dry run will print the rendered template
+```
+
+### SEE ALSO
+
+* [testrunner](testrunner.md)	 - Testrunner for Test Machinery
+

--- a/docs/testrunner/testrunner_run-template.md
+++ b/docs/testrunner/testrunner_run-template.md
@@ -27,7 +27,6 @@ testrunner run-template [flags]
   -h, --help                               help for run-template
       --interval int                       Poll interval in seconds of the testrunner to poll for the testrun status. (default 20)
       --k8s-version string                 Kubernetes version of the shoot.
-      --kibana-logging-endpoint string     Kibana endpoint used for logging of the testmachinery cluster.
       --landscape string                   Current gardener landscape.
       --loadbalancer-provider string       LoadBalancer Provider like haproxy. Only applicable for Openstack.
       --machinetype string                 Machinetype of the shoot's worker nodes.
@@ -49,7 +48,8 @@ testrunner run-template [flags]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug   Set debug mode for additional output
+  -d, --debug     Set debug mode for additional output
+      --dry-run   Dry run will print the rendered template
 ```
 
 ### SEE ALSO

--- a/docs/testrunner/testrunner_run-testrun.md
+++ b/docs/testrunner/testrunner_run-testrun.md
@@ -25,7 +25,8 @@ testrunner run-testrun [flags]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug   Set debug mode for additional output
+  -d, --debug     Set debug mode for additional output
+      --dry-run   Dry run will print the rendered template
 ```
 
 ### SEE ALSO

--- a/docs/testrunner/testrunner_version.md
+++ b/docs/testrunner/testrunner_version.md
@@ -19,7 +19,8 @@ testrunner version [flags]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug   Set debug mode for additional output
+  -d, --debug     Set debug mode for additional output
+      --dry-run   Dry run will print the rendered template
 ```
 
 ### SEE ALSO

--- a/pkg/apis/testmachinery/v1beta1/types.go
+++ b/pkg/apis/testmachinery/v1beta1/types.go
@@ -217,11 +217,11 @@ type ConfigElement struct {
 	Name string `json:"name"`
 
 	// Private indicates if the config is shared with further steps
-	Private *bool `json:"private"`
+	Private *bool `json:"private,omitempty"`
 
 	// value of the environment variable.
 	// +optional
-	Value string `json:"value"`
+	Value string `json:"value,omitempty"`
 
 	// Fetches the value from a secret or configmap on the testmachinery cluster.
 	// +optional

--- a/pkg/testrunner/componentdescriptor/componentdescriptor.go
+++ b/pkg/testrunner/componentdescriptor/componentdescriptor.go
@@ -47,7 +47,7 @@ func GetComponentsFromFile(file string) (ComponentList, error) {
 	}
 	data, err := ioutil.ReadFile(file)
 	if err != nil {
-		return nil, fmt.Errorf("Cannot read component descriptor file %s: %s", file, err.Error())
+		return nil, fmt.Errorf("cannot read component descriptor file %s: %s", file, err.Error())
 	}
 	return GetComponents(data)
 }

--- a/pkg/testrunner/componentdescriptor/componentdescriptor.go
+++ b/pkg/testrunner/componentdescriptor/componentdescriptor.go
@@ -14,7 +14,10 @@
 package componentdescriptor
 
 import (
-	yaml "gopkg.in/yaml.v2"
+	"fmt"
+	"io/ioutil"
+
+	"gopkg.in/yaml.v2"
 )
 
 // GetComponents returns a list of all git/component dependencies.
@@ -35,6 +38,18 @@ func GetComponents(content []byte) (ComponentList, error) {
 	}
 
 	return components.components, nil
+}
+
+// GetComponentsFromFile read a component descriptor and returns a ComponentList
+func GetComponentsFromFile(file string) (ComponentList, error) {
+	if file == "" {
+		return make(ComponentList, 0), nil
+	}
+	data, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, fmt.Errorf("Cannot read component descriptor file %s: %s", file, err.Error())
+	}
+	return GetComponents(data)
 }
 
 // JSON returns the json output for a list of components

--- a/pkg/testrunner/template/gardener.go
+++ b/pkg/testrunner/template/gardener.go
@@ -24,8 +24,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// RenderShootTestrun renders a helm chart with containing testruns, adds the provided parameters and values, and returns the parsed and modified testruns.
-// Adds the component descriptor to metadata.
+// RenderGardenerTestrun renders a helm chart with containing testruns.
+// The current component_descriptor as well as the upgraded component_descriptor are added to the locationSets.
 func RenderGardenerTestrun(tmClient kubernetes.Interface, parameters *GardenerTestrunParameters, metadata *testrunner.Metadata) (testrunner.RunList, error) {
 	var componentDescriptor componentdescriptor.ComponentList
 

--- a/pkg/testrunner/template/gardener.go
+++ b/pkg/testrunner/template/gardener.go
@@ -1,0 +1,95 @@
+// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package template
+
+import (
+	"fmt"
+	"github.com/gardener/gardener/pkg/chartrenderer"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/test-infra/pkg/testrunner"
+	"github.com/gardener/test-infra/pkg/testrunner/componentdescriptor"
+	"github.com/gardener/test-infra/pkg/util"
+	log "github.com/sirupsen/logrus"
+)
+
+// RenderShootTestrun renders a helm chart with containing testruns, adds the provided parameters and values, and returns the parsed and modified testruns.
+// Adds the component descriptor to metadata.
+func RenderGardenerTestrun(tmClient kubernetes.Interface, parameters *GardenerTestrunParameters, metadata *testrunner.Metadata) (testrunner.RunList, error) {
+	var componentDescriptor componentdescriptor.ComponentList
+
+	componentDescriptor, err := componentdescriptor.GetComponentsFromFile(parameters.ComponentDescriptorPath)
+	if err != nil {
+		return nil, fmt.Errorf("cannot decode and parse the component descriptor: %s", err.Error())
+	}
+	metadata.ComponentDescriptor = componentDescriptor.JSON()
+	upgradedComponentDescriptor, err := componentdescriptor.GetComponentsFromFile(parameters.UpgradedComponentDescriptorPath)
+	if err != nil {
+		return nil, fmt.Errorf("cannot decode and parse the component descriptor: %s", err.Error())
+	}
+	metadata.UpgradedComponentDescriptor = upgradedComponentDescriptor.JSON()
+
+	tmChartRenderer, err := chartrenderer.NewForConfig(tmClient.RESTConfig())
+	if err != nil {
+		return nil, fmt.Errorf("cannot create chartrenderer for tm cluster: %s", err.Error())
+	}
+
+	chart, err := tmChartRenderer.Render(parameters.TestrunChartPath, "", parameters.Namespace, map[string]interface{}{
+		"gardener": map[string]interface{}{
+			"current": map[string]string{
+				"version":  util.StringDefault(parameters.GardenerCurrentVersion, getGardenerVersionFromComponentDescriptor(componentDescriptor)),
+				"revision": util.StringDefault(parameters.GardenerCurrentRevision, getGardenerVersionFromComponentDescriptor(componentDescriptor)),
+			},
+			"upgraded": map[string]string{
+				"version":  util.StringDefault(parameters.GardenerUpgradedVersion, getGardenerVersionFromComponentDescriptor(upgradedComponentDescriptor)),
+				"revision": util.StringDefault(parameters.GardenerUpgradedRevision, getGardenerVersionFromComponentDescriptor(upgradedComponentDescriptor)),
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cannot render chart: %s", err.Error())
+	}
+
+	files := ParseTestrunChart(chart, TestrunFileMetadata{})
+
+	// parse the rendered testruns and add locations from BOM of a bom was provided.
+	testruns := make([]*testrunner.Run, 0)
+	for _, file := range files {
+		tr, err := util.ParseTestrun([]byte(file.File))
+		if err != nil {
+			log.Warnf("Cannot parse rendered file: %s", err.Error())
+		}
+
+		testrunMetadata := *metadata
+
+		// Add all repositories defined in the component descriptor to the testrun locations.
+		// This gives us all dependent repositories as well as there deployed version.
+		addBOMLocationsToTestrun(&tr, "default", componentDescriptor)
+		addBOMLocationsToTestrun(&tr, "upgraded", upgradedComponentDescriptor)
+
+		// Add runtime annotations to the testrun
+		addAnnotationsToTestrun(&tr, metadata.Annotations())
+
+		testruns = append(testruns, &testrunner.Run{
+			Testrun:  &tr,
+			Metadata: &testrunMetadata,
+		})
+	}
+
+	if len(testruns) == 0 {
+		return nil, fmt.Errorf("no testruns in the helm chart at %s", parameters.TestrunChartPath)
+	}
+
+	return testruns, nil
+}

--- a/pkg/testrunner/template/types.go
+++ b/pkg/testrunner/template/types.go
@@ -14,8 +14,8 @@
 
 package template
 
-// TestrunParameters are the parameters which describe the test that is executed by the testrunner.
-type TestrunParameters struct {
+// ShootTestrunParameters are the parameters which describe the test that is executed by the testrunner.
+type ShootTestrunParameters struct {
 	// Path to the kubeconfig where the gardener is running.
 	GardenKubeconfigPath string
 	Namespace            string
@@ -40,6 +40,19 @@ type TestrunParameters struct {
 	ComponentDescriptorPath string
 
 	GardenerVersion string
+}
+
+type GardenerTestrunParameters struct {
+	Namespace        string
+	TestrunChartPath string
+
+	ComponentDescriptorPath         string
+	UpgradedComponentDescriptorPath string
+
+	GardenerCurrentVersion   string
+	GardenerCurrentRevision  string
+	GardenerUpgradedVersion  string
+	GardenerUpgradedRevision string
 }
 
 // TestrunFile is the internal representation of a rendered testrun chart with metadata information

--- a/pkg/testrunner/types.go
+++ b/pkg/testrunner/types.go
@@ -64,8 +64,12 @@ type Metadata struct {
 	KubernetesVersion string `json:"k8s_version"`
 
 	// ComponentDescriptor describes the current component_descriptor of the direct landscape-setup components.
-	// It is formated as an array of components: { name: "my_component", version: "0.0.1" }
-	ComponentDescriptor interface{} ``
+	// It is formatted as an array of components: { name: "my_component", version: "0.0.1" }
+	ComponentDescriptor interface{} `json:"bom"`
+
+	// UpgradedComponentDescriptor describes the updated component_descriptor.
+	// It is formatted as an array of components: { name: "my_component", version: "0.0.1" }
+	UpgradedComponentDescriptor interface{} `json:"upgraded_bom,omitempty"`
 
 	// Name of the testrun crd object.
 	Testrun TestrunMetadata `json:"tr"`
@@ -95,22 +99,20 @@ type StepExportMetadata struct {
 
 // TestrunSummary is the result of the overall testrun.
 type TestrunSummary struct {
-	Metadata          *Metadata        `json:"tm,omitempty"`
-	Type              SummaryType      `json:"type,omitempty"`
-	Phase             argov1.NodePhase `json:"phase,omitempty"`
-	StartTime         *metav1.Time     `json:"startTime,omitempty"`
-	Duration          int64            `json:"duration,omitempty"`
-	TestsRun          int              `json:"testsRun,omitempty"`
-	KibanaExternalURL string           `json:"kibana_url,omitempty"`
+	Metadata  *Metadata        `json:"tm,omitempty"`
+	Type      SummaryType      `json:"type,omitempty"`
+	Phase     argov1.NodePhase `json:"phase,omitempty"`
+	StartTime *metav1.Time     `json:"startTime,omitempty"`
+	Duration  int64            `json:"duration,omitempty"`
+	TestsRun  int              `json:"testsRun,omitempty"`
 }
 
 // StepSummary is the result of a specific step.
 type StepSummary struct {
-	Metadata          *Metadata        `json:"tm,omitempty"`
-	Type              SummaryType      `json:"type,omitempty"`
-	Name              string           `json:"name,omitempty"`
-	Phase             argov1.NodePhase `json:"phase,omitempty"`
-	StartTime         *metav1.Time     `json:"startTime,omitempty"`
-	Duration          int64            `json:"duration,omitempty"`
-	KibanaExternalURL string           `json:"kibana_url,omitempty"`
+	Metadata  *Metadata        `json:"tm,omitempty"`
+	Type      SummaryType      `json:"type,omitempty"`
+	Name      string           `json:"name,omitempty"`
+	Phase     argov1.NodePhase `json:"phase,omitempty"`
+	StartTime *metav1.Time     `json:"startTime,omitempty"`
+	Duration  int64            `json:"duration,omitempty"`
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -184,6 +184,7 @@ func MarshalNoHTMLEscape(v interface{}) ([]byte, error) {
 	return buffer.Bytes(), nil
 }
 
+// StringArrayContains checks if a string array contains s string element
 func StringArrayContains(ar []string, elem string) bool {
 	for _, val := range ar {
 		if val == elem {
@@ -191,4 +192,13 @@ func StringArrayContains(ar []string, elem string) bool {
 		}
 	}
 	return false
+}
+
+// String default checks of a string is defined.
+// If the value is emtpy the default string is returned
+func StringDefault(value, def string) string {
+	if value == "" {
+		return def
+	}
+	return value
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -184,7 +184,7 @@ func MarshalNoHTMLEscape(v interface{}) ([]byte, error) {
 	return buffer.Bytes(), nil
 }
 
-// StringArrayContains checks if a string array contains s string element
+// StringArrayContains checks if a string array contains the string elem
 func StringArrayContains(ar []string, elem string) bool {
 	for _, val := range ar {
 		if val == elem {
@@ -194,7 +194,7 @@ func StringArrayContains(ar []string, elem string) bool {
 	return false
 }
 
-// String default checks of a string is defined.
+// StringDefault checks if a string is defined.
 // If the value is emtpy the default string is returned
 func StringDefault(value, def string) string {
 	if value == "" {


### PR DESCRIPTION
**What this PR does / why we need it**:
Added a testrunner for gardener lifecycle tests which means that we do not need dynamic parameters like cloudprovider, k8s versions etcd in the first step.
Maybe we will need this for later easier testing but for now the lifecycle is hardcoded.

Therefore the only thing we need for this gardener tempalting is 2 component descriptors: 1 fomr the latest stable release and one from the current release.

- removed deprecated kibana field

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Added a testrunner for gardener lifecycle tests
```
