### PR TITLE
Add link to argo ui on testrunner start 

### DIFF
--- a/cmd/testrunner/cmd/runtemplate/run_template.go
+++ b/cmd/testrunner/cmd/runtemplate/run_template.go
@@ -37,6 +37,7 @@ var (
 	namespace        string
 	timeout          int64
 	interval         int64
+	failOnError      bool
 
 	outputDirPath           string
 	elasticSearchConfigName string
@@ -165,7 +166,7 @@ var runCmd = &cobra.Command{
 		result.GenerateNotificationConfigForAlerting(finishedRuns.GetTestruns(), rsConfig.ConcourseOnErrorDir)
 
 		log.Info("Testrunner finished.")
-		if failed {
+		if failOnError && failed {
 			os.Exit(1)
 		}
 	},
@@ -187,6 +188,7 @@ func init() {
 	runCmd.Flags().StringVarP(&namespace, "namespace", "n", "default", "Namesapce where the testrun should be deployed.")
 	runCmd.Flags().Int64Var(&timeout, "timeout", 3600, "Timout in seconds of the testrunner to wait for the complete testrun to finish.")
 	runCmd.Flags().Int64Var(&interval, "interval", 20, "Poll interval in seconds of the testrunner to poll for the testrun status.")
+	runCmd.Flags().BoolVar(&failOnError, "fail-on-error", true, "Testrunners exits with 1 if one testruns failed.")
 
 	runCmd.Flags().StringVar(&outputDirPath, "output-dir-path", "./testout", "The filepath where the summary should be written to.")
 	runCmd.Flags().StringVar(&elasticSearchConfigName, "es-config-name", "sap_internal", "The elasticsearch secret-server config name.")

--- a/pkg/controller/testrun_control.go
+++ b/pkg/controller/testrun_control.go
@@ -17,6 +17,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"github.com/gardener/test-infra/pkg/testmachinery"
 
 	argov1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
 	tmv1beta1 "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
@@ -54,7 +55,7 @@ func (r *TestrunReconciler) Reconcile(request reconcile.Request) (reconcile.Resu
 	///////////////
 
 	foundWf := &argov1.Workflow{}
-	err = r.Get(ctx, types.NamespacedName{Name: getWorkflowName(tr), Namespace: tr.Namespace}, foundWf)
+	err = r.Get(ctx, types.NamespacedName{Name: testmachinery.GetWorkflowName(tr), Namespace: tr.Namespace}, foundWf)
 	if err != nil && !errors.IsNotFound(err) {
 		return reconcile.Result{}, err
 	}
@@ -91,7 +92,7 @@ func (r *TestrunReconciler) Reconcile(request reconcile.Request) (reconcile.Resu
 			return reconcile.Result{}, err
 		}
 	} else if err != nil {
-		log.Errorf("Cannot get workflow %s in namespace %s: %s", getWorkflowName(tr), tr.Namespace, err.Error())
+		log.Errorf("Cannot get workflow %s in namespace %s: %s", testmachinery.GetWorkflowName(tr), tr.Namespace, err.Error())
 		return reconcile.Result{}, err
 	}
 
@@ -110,10 +111,10 @@ func (r *TestrunReconciler) Reconcile(request reconcile.Request) (reconcile.Resu
 func (r *TestrunReconciler) createWorkflow(ctx context.Context, testrunDef *tmv1beta1.Testrun) (*argov1.Workflow, error) {
 	tr, err := testrun.New(testrunDef)
 	if err != nil {
-		return nil, fmt.Errorf("Error parsing testrun: %s", err.Error())
+		return nil, fmt.Errorf("error parsing testrun: %s", err.Error())
 	}
 
-	wf, err := tr.GetWorkflow(getWorkflowName(testrunDef), testrunDef.Namespace, r.getImagePullSecrets(ctx))
+	wf, err := tr.GetWorkflow(testmachinery.GetWorkflowName(testrunDef), testrunDef.Namespace, r.getImagePullSecrets(ctx))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/testrun_control_delete.go
+++ b/pkg/controller/testrun_control_delete.go
@@ -16,6 +16,7 @@ package controller
 
 import (
 	"context"
+	"github.com/gardener/test-infra/pkg/testmachinery"
 	"time"
 
 	argov1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
@@ -35,7 +36,7 @@ func (r *TestrunReconciler) deleteTestrun(ctx context.Context, tr *tmv1beta1.Tes
 	}
 
 	foundWf := &argov1.Workflow{}
-	if err := r.Get(ctx, types.NamespacedName{Name: getWorkflowName(tr), Namespace: tr.Namespace}, foundWf); err == nil {
+	if err := r.Get(ctx, types.NamespacedName{Name: testmachinery.GetWorkflowName(tr), Namespace: tr.Namespace}, foundWf); err == nil {
 		log.Infof("Cleanup testrun %s", tr.Name)
 
 		// garbage collect all outputs by traversing through nodes and collect outputs artifacts from minio

--- a/pkg/controller/testrun_control_utils.go
+++ b/pkg/controller/testrun_control_utils.go
@@ -16,19 +16,13 @@ package controller
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
-	tmv1beta1 "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
 	"github.com/gardener/test-infra/pkg/testmachinery"
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
-
-func getWorkflowName(tr *tmv1beta1.Testrun) string {
-	return fmt.Sprintf("%s-wf", tr.Name)
-}
 
 func (r *TestrunReconciler) getImagePullSecrets(ctx context.Context) []string {
 	configMap := &corev1.ConfigMap{}

--- a/pkg/testmachinery/config.go
+++ b/pkg/testmachinery/config.go
@@ -53,6 +53,7 @@ const (
 	// ExportArtifact is the name of the output artifact where results are stored.
 	ExportArtifact = "ExportArtifact"
 
+	// ConfigMapName is the name of the testmachinery configmap in the cluster
 	ConfigMapName = "tm-config"
 )
 

--- a/pkg/testmachinery/testmachinery.go
+++ b/pkg/testmachinery/testmachinery.go
@@ -15,12 +15,14 @@
 package testmachinery
 
 import (
+	"fmt"
+	"github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
 	"os"
 
 	"github.com/gardener/test-infra/pkg/util"
 
 	log "github.com/sirupsen/logrus"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 var tmConfig *TmConfiguration
@@ -61,4 +63,9 @@ func GetConfig() *TmConfiguration {
 // IsRunInsecure returns if the testmachinery is run locally
 func IsRunInsecure() bool {
 	return tmConfig.Insecure
+}
+
+// GetWorkflowName returns the workflow name of a testruns
+func GetWorkflowName(tr *v1beta1.Testrun) string {
+	return fmt.Sprintf("%s-wf", tr.Name)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Added dynamic fetching of argo ui depending on a ingress.
Ingresses currently have to be in the `default` namespace with the name `argo-ui`
Maybe we need to change this in the future when the argo-ui is placed into another namespace.

Added flag to make testrunner exit with 0 even when a testrun failed.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
Added argoui link to testrun on testrunner start
```
```improvement operator
Added flag to disable testrunner fail on Testrun failure
```
