### PR TITLE
Add landscape to gardener testrunner + small improvements

### DIFF
--- a/cmd/testrunner/cmd/rungardenertemplate/run_template.go
+++ b/cmd/testrunner/cmd/rungardenertemplate/run_template.go
@@ -50,6 +50,7 @@ var (
 	upgradedComponentDescriptorPath string
 
 	// optional
+	landscape                string
 	gardenerCurrentVersion   string
 	gardenerCurrentRevision  string
 	gardenerUpgradedVersion  string
@@ -117,7 +118,9 @@ var runCmd = &cobra.Command{
 			UpgradedComponentDescriptorPath: upgradedComponentDescriptorPath,
 		}
 
-		metadata := &testrunner.Metadata{}
+		metadata := &testrunner.Metadata{
+			Landscape: landscape,
+		}
 		runs, err := testrunnerTemplate.RenderGardenerTestrun(tmClient, parameters, metadata)
 		if err != nil {
 			log.Fatal(err)
@@ -175,6 +178,7 @@ func init() {
 	runCmd.Flags().StringVar(&componentDescriptorPath, "component-descriptor-path", "", "Path to the component descriptor (BOM) of the current landscape.")
 	runCmd.Flags().StringVar(&upgradedComponentDescriptorPath, "upgraded-component-descriptor-path", "", "Path to the component descriptor (BOM) of the new landscape.")
 
+	runCmd.Flags().StringVar(&landscape, "landscape", "", "Current gardener landscape.")
 	runCmd.Flags().StringVar(&gardenerCurrentVersion, "gardener-current-version", "", "Set current version of gardener. This will result in the helm value {{ .Values.gardener.current.version }}")
 	runCmd.Flags().StringVar(&gardenerCurrentRevision, "gardener-current-revision", "", "Set current revision of gardener. This will result in the helm value {{ .Values.gardener.current.revision }}")
 	runCmd.Flags().StringVar(&gardenerUpgradedVersion, "gardener-upgraded-version", "", "Set current version of gardener. This will result in the helm value {{ .Values.gardener.upgraded.version }}")

--- a/pkg/testrunner/template/types.go
+++ b/pkg/testrunner/template/types.go
@@ -49,6 +49,7 @@ type GardenerTestrunParameters struct {
 	ComponentDescriptorPath         string
 	UpgradedComponentDescriptorPath string
 
+	Landscape                string
 	GardenerCurrentVersion   string
 	GardenerCurrentRevision  string
 	GardenerUpgradedVersion  string

--- a/pkg/testrunner/types.go
+++ b/pkg/testrunner/types.go
@@ -59,13 +59,13 @@ const (
 // Metadata is the common metadata of all outputs and summaries.
 type Metadata struct {
 	// Landscape describes the current dev,staging,canary,office or live.
-	Landscape         string `json:"landscape"`
-	CloudProvider     string `json:"cloudprovider"`
-	KubernetesVersion string `json:"k8s_version"`
+	Landscape         string `json:"landscape,omitempty"`
+	CloudProvider     string `json:"cloudprovider,omitempty"`
+	KubernetesVersion string `json:"k8s_version,omitempty"`
 
 	// ComponentDescriptor describes the current component_descriptor of the direct landscape-setup components.
 	// It is formatted as an array of components: { name: "my_component", version: "0.0.1" }
-	ComponentDescriptor interface{} `json:"bom"`
+	ComponentDescriptor interface{} `json:"bom,omitempty"`
 
 	// UpgradedComponentDescriptor describes the updated component_descriptor.
 	// It is formatted as an array of components: { name: "my_component", version: "0.0.1" }
@@ -75,7 +75,7 @@ type Metadata struct {
 	Testrun TestrunMetadata `json:"tr"`
 
 	// all environment configuration values
-	Configuration map[string]string `json:"config"`
+	Configuration map[string]string `json:"config,omitempty"`
 }
 
 // TestrunMetadata represents the metadata of a testrun


### PR DESCRIPTION
**What this PR does / why we need it**:
Ignore some metadata parameters if they are emtpy.
Add landscape parameter to gardener testrunner to differentiate testruns in kibana.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
