### PR TITLE
Add additional metadata

### DIFF
--- a/integration-tests/e2e/kubetest/setup/setup.go
+++ b/integration-tests/e2e/kubetest/setup/setup.go
@@ -128,7 +128,7 @@ func downloadKubectl(k8sVersion string) error {
 	if err := util.MoveFile("./kubectl", kubectlBinPath); err != nil {
 		return err
 	}
-	if err := os.Chmod(kubectlBinPath,0755); err != nil {
+	if err := os.Chmod(kubectlBinPath, 0755); err != nil {
 		return err
 	}
 

--- a/integration-tests/e2e/util/util.go
+++ b/integration-tests/e2e/util/util.go
@@ -118,7 +118,6 @@ type CmdOutput struct {
 	StdErr string
 }
 
-
 /*
    GoLang: os.Rename() give error "invalid cross-device link" for Docker container with Volumes.
    MoveFile(source, destination) will work moving file between folders

--- a/pkg/apis/testmachinery/v1beta1/types.go
+++ b/pkg/apis/testmachinery/v1beta1/types.go
@@ -151,6 +151,7 @@ type StepStatus struct {
 	Name              string                   `json:"name"`
 	Position          StepStatusPosition       `json:"position"`
 	TestDefinition    StepStatusTestDefinition `json:"testdefinition,omitempty"`
+	Annotations       map[string]string        `json:"annotations,omitempty"`
 	Phase             argov1.NodePhase         `json:"phase,omitempty"`
 	StartTime         *metav1.Time             `json:"startTime,omitempty"`
 	CompletionTime    *metav1.Time             `json:"completionTime,omitempty"`
@@ -236,11 +237,12 @@ type ConfigElement struct {
 type TestFlow []*DAGStep
 
 type DAGStep struct {
-	Name               string         `json:"name,omitempty"`
-	Definition         StepDefinition `json:"definition,omitempty"`
-	UseGlobalArtifacts bool           `json:"useGlobalArtifacts,omitempty"`
-	DependsOn          []string       `json:"dependsOn,omitempty"`
-	ArtifactsFrom      string         `json:"artifactsFrom,omitempty"`
+	Name               string            `json:"name,omitempty"`
+	Definition         StepDefinition    `json:"definition,omitempty"`
+	UseGlobalArtifacts bool              `json:"useGlobalArtifacts,omitempty"`
+	DependsOn          []string          `json:"dependsOn,omitempty"`
+	ArtifactsFrom      string            `json:"artifactsFrom,omitempty"`
+	Annotations        map[string]string `json:"annotations,omitempty"`
 }
 
 // StepDefinition is a reference to one or more TestDefinitions to execute in a series of steps.StepDefinition

--- a/pkg/apis/testmachinery/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/testmachinery/v1beta1/zz_generated.deepcopy.go
@@ -59,6 +59,13 @@ func (in *DAGStep) DeepCopyInto(out *DAGStep) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Annotations != nil {
+		in, out := &in.Annotations, &out.Annotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 
@@ -126,6 +133,13 @@ func (in *StepStatus) DeepCopyInto(out *StepStatus) {
 	*out = *in
 	in.Position.DeepCopyInto(&out.Position)
 	in.TestDefinition.DeepCopyInto(&out.TestDefinition)
+	if in.Annotations != nil {
+		in, out := &in.Annotations, &out.Annotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.StartTime != nil {
 		in, out := &in.StartTime, &out.StartTime
 		*out = (*in).DeepCopy()

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -99,7 +99,7 @@ func schema_pkg_apis_testmachinery_v1beta1_ConfigElement(ref common.ReferenceCal
 						},
 					},
 				},
-				Required: []string{"type", "name", "private"},
+				Required: []string{"type", "name"},
 			},
 		},
 		Dependencies: []string{
@@ -147,6 +147,19 @@ func schema_pkg_apis_testmachinery_v1beta1_DAGStep(ref common.ReferenceCallback)
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
 							Format: "",
+						},
+					},
+					"annotations": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
 						},
 					},
 				},
@@ -284,6 +297,19 @@ func schema_pkg_apis_testmachinery_v1beta1_StepStatus(ref common.ReferenceCallba
 							Ref: ref("github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1.StepStatusTestDefinition"),
 						},
 					},
+					"annotations": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
 					"phase": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
@@ -319,7 +345,7 @@ func schema_pkg_apis_testmachinery_v1beta1_StepStatus(ref common.ReferenceCallba
 						},
 					},
 				},
-				Required: []string{"position", "exportArtifactKey", "podName"},
+				Required: []string{"name", "position", "exportArtifactKey", "podName"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/testmachinery/testflow/node/node.go
+++ b/pkg/testmachinery/testflow/node/node.go
@@ -145,7 +145,8 @@ func (n *Node) Status() *tmv1beta1.StepStatus {
 			DependsOn: n.ParentNames(),
 			Flow:      n.flow,
 		},
-		Phase: tmv1beta1.PhaseStatusInit,
+		Annotations: n.step.Annotations,
+		Phase:       tmv1beta1.PhaseStatusInit,
 		TestDefinition: tmv1beta1.StepStatusTestDefinition{
 			Name:                  td.Info.Metadata.Name,
 			Owner:                 td.Info.Spec.Owner,

--- a/pkg/testrunner/result/output.go
+++ b/pkg/testrunner/result/output.go
@@ -105,12 +105,14 @@ func DetermineTestrunSummary(tr *tmv1beta1.Testrun, metadata *testrunner.Metadat
 		}
 
 		summary := testrunner.StepSummary{
-			Metadata:  &stepMetadata,
-			Type:      testrunner.SummaryTypeTeststep,
-			Name:      step.TestDefinition.Name,
-			Phase:     step.Phase,
-			StartTime: step.StartTime,
-			Duration:  step.Duration,
+			Metadata:    &stepMetadata,
+			Type:        testrunner.SummaryTypeTeststep,
+			Name:        step.TestDefinition.Name,
+			StepName:    step.Name,
+			Annotations: step.Annotations,
+			Phase:       step.Phase,
+			StartTime:   step.StartTime,
+			Duration:    step.Duration,
 		}
 
 		summaries = append(summaries, summary)

--- a/pkg/testrunner/types.go
+++ b/pkg/testrunner/types.go
@@ -109,10 +109,12 @@ type TestrunSummary struct {
 
 // StepSummary is the result of a specific step.
 type StepSummary struct {
-	Metadata  *Metadata        `json:"tm,omitempty"`
-	Type      SummaryType      `json:"type,omitempty"`
-	Name      string           `json:"name,omitempty"`
-	Phase     argov1.NodePhase `json:"phase,omitempty"`
-	StartTime *metav1.Time     `json:"startTime,omitempty"`
-	Duration  int64            `json:"duration,omitempty"`
+	Metadata    *Metadata         `json:"tm,omitempty"`
+	Type        SummaryType       `json:"type,omitempty"`
+	Name        string            `json:"name,omitempty"`
+	StepName    string            `json:"stepName,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
+	Phase       argov1.NodePhase  `json:"phase,omitempty"`
+	StartTime   *metav1.Time      `json:"startTime,omitempty"`
+	Duration    int64             `json:"duration,omitempty"`
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the step name and additional annotations to the persisted metadata.
The additional annotations can be defined for each step and is passed to the status and testrunner metadata.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
Added support for additional step annotations
```
