### PR TITLE
Add annotations from testrun to es metadata

### DIFF
--- a/pkg/testrunner/metadata.go
+++ b/pkg/testrunner/metadata.go
@@ -10,7 +10,7 @@ const (
 	AnnotationCloudProvider = "testrunner.testmachinery.sapcloud.io/cloudprovider"
 )
 
-func (m *Metadata) Annotations() map[string]string {
+func (m *Metadata) CreateAnnotations() map[string]string {
 	return map[string]string{
 		AnnotationLandscape:     m.Landscape,
 		AnnotationK8sVersion:    m.KubernetesVersion,

--- a/pkg/testrunner/template/gardener.go
+++ b/pkg/testrunner/template/gardener.go
@@ -79,7 +79,7 @@ func RenderGardenerTestrun(tmClient kubernetes.Interface, parameters *GardenerTe
 		addBOMLocationsToTestrun(&tr, "upgraded", upgradedComponentDescriptor)
 
 		// Add runtime annotations to the testrun
-		addAnnotationsToTestrun(&tr, metadata.Annotations())
+		addAnnotationsToTestrun(&tr, metadata.CreateAnnotations())
 
 		testruns = append(testruns, &testrunner.Run{
 			Testrun:  &tr,

--- a/pkg/testrunner/template/shoot.go
+++ b/pkg/testrunner/template/shoot.go
@@ -61,7 +61,7 @@ func RenderShootTestrun(tmClient kubernetes.Interface, parameters *ShootTestrunP
 		addBOMLocationsToTestrun(&tr, "default", componentDescriptor)
 
 		// Add runtime annotations to the testrun
-		addAnnotationsToTestrun(&tr, metadata.Annotations())
+		addAnnotationsToTestrun(&tr, metadata.CreateAnnotations())
 
 		testruns = append(testruns, &testrunner.Run{
 			Testrun:  &tr,

--- a/pkg/testrunner/types.go
+++ b/pkg/testrunner/types.go
@@ -76,6 +76,9 @@ type Metadata struct {
 
 	// all environment configuration values
 	Configuration map[string]string `json:"config,omitempty"`
+
+	// Additional annotations form the testrun or steps
+	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
 // TestrunMetadata represents the metadata of a testrun
@@ -109,12 +112,11 @@ type TestrunSummary struct {
 
 // StepSummary is the result of a specific step.
 type StepSummary struct {
-	Metadata    *Metadata         `json:"tm,omitempty"`
-	Type        SummaryType       `json:"type,omitempty"`
-	Name        string            `json:"name,omitempty"`
-	StepName    string            `json:"stepName,omitempty"`
-	Annotations map[string]string `json:"annotations,omitempty"`
-	Phase       argov1.NodePhase  `json:"phase,omitempty"`
-	StartTime   *metav1.Time      `json:"startTime,omitempty"`
-	Duration    int64             `json:"duration,omitempty"`
+	Metadata  *Metadata        `json:"tm,omitempty"`
+	Type      SummaryType      `json:"type,omitempty"`
+	Name      string           `json:"name,omitempty"`
+	StepName  string           `json:"stepName,omitempty"`
+	Phase     argov1.NodePhase `json:"phase,omitempty"`
+	StartTime *metav1.Time     `json:"startTime,omitempty"`
+	Duration  int64            `json:"duration,omitempty"`
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Add annotations from testrun to elastic search metadata information

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
testrun annotations are now included in the metadata information
```
