### PR TITLE
Minor bugfixes

### DIFF
--- a/docs/GetStarted.md
+++ b/docs/GetStarted.md
@@ -83,7 +83,7 @@ spec:
 | ------------- |-------------|
 | TM_KUBECONFIG_PATH      | points to a directory containing all kubeconfig files (defaults to `/tmp/env/kubeconfig`). </br> The files contained in this dir depend on the concrete TestRun and can contain up to 3 files: <ul><li>_gardener.config_: the kubeconfig pointing to the gardener cluster created by TM (or predefined/given by a TestRun)</li><li>_seed.config_: the kubeconfig pointing to the seed cluster configured by TM (or predefined/given by a TestRun)</li><li>_shoot.config_: the kubeconfig pointing to the shoot cluster created by TM (or predefined/given by a TestRun)</li></ul>|
 | TM_EXPORT_PATH | points to a directory where the test can place arbitrary test-run data which will be archived at the end. Useful if some postprocessing needs to be done on that data. Further information can be found [here](#export-contract) |
-
+| TM_TESTRUN_ID | Name of the testrun |
 
 ### Export Contract
 

--- a/docs/GetStarted.md
+++ b/docs/GetStarted.md
@@ -420,6 +420,7 @@ Test configuration can be of type "env" and of type "file".
   ```
 
 "file" configration is available as mounted file at the specified `path`.
+The path to the mounted file is exposed through a Environment Variable with the configname pointing to the file. (e.g `export file="/file/path"`)
   ```yaml
   config:
   - type: file

--- a/pkg/testmachinery/config.go
+++ b/pkg/testmachinery/config.go
@@ -53,6 +53,9 @@ const (
 	// ExportArtifact is the name of the output artifact where results are stored.
 	ExportArtifact = "ExportArtifact"
 
+	// TM_TESTRUN_ID_NAME is the name of the environment variable that holds the current testrun id
+	TM_TESTRUN_ID_NAME = "TM_TESTRUN_ID"
+
 	// ConfigMapName is the name of the testmachinery configmap in the cluster
 	ConfigMapName = "tm-config"
 )

--- a/pkg/testmachinery/config/types.go
+++ b/pkg/testmachinery/config/types.go
@@ -21,10 +21,10 @@ import (
 type Level int
 
 const (
-	LevelGlobal         Level = 0
-	LevelShared         Level = 5
-	LevelStep           Level = 10
-	LevelTestDefinition Level = 15
+	LevelTestDefinition Level = 0
+	LevelGlobal         Level = 5
+	LevelShared         Level = 10
+	LevelStep           Level = 15
 )
 
 // Element represents a configuration parameter for tests.

--- a/pkg/testmachinery/testdefinition/testdefinition.go
+++ b/pkg/testmachinery/testdefinition/testdefinition.go
@@ -287,7 +287,9 @@ func (td *TestDefinition) addConfigAsFile(element *config.Element) error {
 		}
 
 		// add as input parameter to see parameters in argo ui
-		td.AddInputParameter(element.Name(), fmt.Sprintf("%s: %s", element.Info.Name, element.Info.Value))
+		td.AddInputParameter(element.Name(), fmt.Sprintf("%s: %s", element.Info.Name, element.Info.Path))
+		// Add the file path as env var with the config name to the pod
+		td.AddEnvVars(apiv1.EnvVar{Name: element.Info.Name, Value: element.Info.Path})
 		td.AddInputArtifacts(argov1.Artifact{
 			Name: element.Name(),
 			Path: element.Info.Path,
@@ -298,7 +300,7 @@ func (td *TestDefinition) addConfigAsFile(element *config.Element) error {
 			},
 		})
 	} else if element.Info.ValueFrom != nil {
-		td.AddInputParameter(element.Name(), fmt.Sprintf("%s: %s", element.Info.Name, "from secret or configmap"))
+		td.AddInputParameter(element.Name(), fmt.Sprintf("%s: %s", element.Info.Name, element.Info.Path))
 		td.AddVolumeMount(element.Name(), element.Info.Path, path.Base(element.Info.Path), true)
 		return td.AddVolumeFromConfig(element)
 	}

--- a/pkg/testrunner/run.go
+++ b/pkg/testrunner/run.go
@@ -56,7 +56,7 @@ func runTestrun(tmClient kubernetes.Interface, tr *tmv1beta1.Testrun, namespace,
 	}
 	log.Infof("Testrun %s deployed", tr.Name)
 
-	if argoUrl, err := GetArgoURL(tmClient, tr); err != nil {
+	if argoUrl, err := GetArgoURL(tmClient, tr); err == nil {
 		log.Infof("Argo workflow: %s", argoUrl)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

- Fix displaying argoUi url at startup of the testrunnner
- Added testrun name as environment variable `TM_TESTRUN_ID`
- Expose mounted file path of a config as environment variable with the config's name
- Change the level of configuration coming from TestDefinition so that everything in a testrun can overwrite Configuration defined in a TestDefinition

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Fix displaying argoUi url
```
```improvement user
Added testrun name as environment variable `TM_TESTRUN_ID`
```
```improvement user
Expose mounted file path of a config as environment variable with the config's name
```
