### PR TITLE
enables argo workflow controller metrics server for prometheus metrics

### DIFF
--- a/charts/bootstrap_tm_prerequisites/templates/argo.yaml
+++ b/charts/bootstrap_tm_prerequisites/templates/argo.yaml
@@ -31,6 +31,10 @@ data:
                 secretKeySecret:                #omit if accessing via AWS IAM
                     name: {{.Values.objectStorage.secret.name}}
                     key: secretKey
+        metricsConfig:
+          enabled: true
+          path: /metrics
+          port: 80
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
**What this PR does / why we need it**:
Activates the metrics server included in argo's workflow controller at port `80` and path `/metrics`
 so that it can be scraped by a prometheus server running in the same cluster.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```improvement operator
Metrics server of argo's workflow controller is now activated by default.
```
