### PR TITLE
Adjust argo executor resources

### DIFF
--- a/charts/bootstrap_tm_prerequisites/templates/argo.yaml
+++ b/charts/bootstrap_tm_prerequisites/templates/argo.yaml
@@ -19,18 +19,26 @@ metadata:
   namespace: {{.Release.Namespace}}
 data:
     config: |
+        executor:
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "100Mi"
+            limits:
+              cpu: "100m"
+              memory: "150Mi"
         artifactRepository:
-            s3:
-                bucket: {{.Values.objectStorage.bucketName}}
-                keyPrefix: {{ .Values.objectStorage.keyPrefix }}
-                endpoint: "{{ tpl .Values.objectStorage.endpoint . }}"        #AWS => s3.amazonaws.com; GCS => storage.googleapis.com
-                insecure: {{ not .Values.objectStorage.ssl }}                  #omit for S3/GCS. Needed when minio runs without TLS
-                accessKeySecret:                #omit if accessing via AWS IAM
-                    name: {{.Values.objectStorage.secret.name}}
-                    key: accessKey
-                secretKeySecret:                #omit if accessing via AWS IAM
-                    name: {{.Values.objectStorage.secret.name}}
-                    key: secretKey
+          s3:
+            bucket: {{.Values.objectStorage.bucketName}}
+            keyPrefix: {{ .Values.objectStorage.keyPrefix }}
+            endpoint: "{{ tpl .Values.objectStorage.endpoint . }}"        #AWS => s3.amazonaws.com; GCS => storage.googleapis.com
+            insecure: {{ not .Values.objectStorage.ssl }}                  #omit for S3/GCS. Needed when minio runs without TLS
+            accessKeySecret:                #omit if accessing via AWS IAM
+              name: {{.Values.objectStorage.secret.name}}
+              key: accessKey
+            secretKeySecret:                #omit if accessing via AWS IAM
+              name: {{.Values.objectStorage.secret.name}}
+              key: secretKey
         metricsConfig:
           enabled: true
           path: /metrics


### PR DESCRIPTION
**What this PR does / why we need it**:
Add requests and limits to argo executor images (wait, init)
Currently the argo executors getting the same requests and limits as the test pods, which result in too much resources for pods that idle and do not need as much resources as our tests .
New resources:
```yaml
resources:
  requests:
    cpu: "50m"
    memory: "100Mi"
  limits:
    cpu: "100m"
    memory: "150Mi"
```

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Adjust argo executor requests and limits
```
