### PR TITLE
Fix component_descriptore parsing issue

### DIFF
--- a/pkg/testrunner/componentdescriptor/componentdescriptor.go
+++ b/pkg/testrunner/componentdescriptor/componentdescriptor.go
@@ -17,7 +17,7 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 )
 
 // GetComponents returns a list of all git/component dependencies.
@@ -34,7 +34,7 @@ func GetComponents(content []byte) (ComponentList, error) {
 	}
 
 	for _, component := range componentDescriptor.Components {
-		components.add(component.Dependencies.Components)
+		components.add(component.Component)
 	}
 
 	return components.components, nil
@@ -69,7 +69,7 @@ func (c ComponentList) JSON() map[string]ComponentJSON {
 	return components
 }
 
-func (c *components) add(newComponents []Component) {
+func (c *components) add(newComponents ...Component) {
 	for _, item := range newComponents {
 		component := item
 		if !c.has(component) {

--- a/pkg/testrunner/componentdescriptor/testdata/component_descriptor_1
+++ b/pkg/testrunner/componentdescriptor/testdata/component_descriptor_1
@@ -1,5 +1,13 @@
 components:
-- dependencies:
-    components:
-    - {name: github.com/gardener/gardener, version: 0.17.0}
-    - {name: github.com/gardener/dashboard, version: 1.27.0}
+- name: github.com/gardener/gardener
+  version: 0.17.0
+  dependencies:
+      components:
+      - {name: github.com/gardener/gardener, version: 0.17.0}
+      - {name: github.com/gardener/dashboard, version: 1.27.0}
+- name: github.com/gardener/dashboard
+  version: 1.27.0
+  dependencies:
+      components:
+      - {name: github.com/gardener/gardener, version: 0.17.0}
+      - {name: github.com/gardener/dashboard, version: 1.27.0}

--- a/pkg/testrunner/componentdescriptor/testdata/component_descriptor_2
+++ b/pkg/testrunner/componentdescriptor/testdata/component_descriptor_2
@@ -3,6 +3,10 @@ components:
     components:
     - {name: repo1, version: 0.17.0}
     - {name: repo2, version: 1.27.0}
+  name: repo1
+  version: 0.17.0
 - dependencies:
     components:
     - {name: repo1, version: 0.17.0}
+  name: repo2
+  version: 1.27.0

--- a/pkg/testrunner/componentdescriptor/types.go
+++ b/pkg/testrunner/componentdescriptor/types.go
@@ -15,8 +15,8 @@ package componentdescriptor
 
 // Component describes a component consisting of the git repository url and a version.
 type Component struct {
-	Name    string `yaml:"name"`
-	Version string `yaml:"version"`
+	Name    string `json:"name"`
+	Version string `json:"version"`
 }
 
 // ComponentList is a set of multiple components.
@@ -32,14 +32,15 @@ type components struct {
 }
 
 type descriptor struct {
-	Components []dependencies `yaml:"components"`
+	Components []dependencies `json:"components"`
 }
 
 type dependencies struct {
-	Dependencies dependency `yaml:"dependencies"`
+	Component
+	Dependencies dependency `json:"dependencies"`
 }
 
 type dependency struct {
-	Name       string      `yaml:"name"`
-	Components []Component `yaml:"components"`
+	Name       string      `json:"name"`
+	Components []Component `json:"components"`
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix component descriptor parser to also include top level dependency.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
