### PR TITLE
Parse version of component descriptor to return its revision

### DIFF
--- a/pkg/testrunner/template/helper.go
+++ b/pkg/testrunner/template/helper.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/gardener/gardener/pkg/utils"
 	"sort"
+	"strings"
 
 	"github.com/Masterminds/semver"
 
@@ -105,7 +106,7 @@ func addBOMLocationsToTestrun(tr *tmv1beta1.Testrun, locationSetName string, com
 		bomLocations = append(bomLocations, tmv1beta1.TestLocation{
 			Type:     tmv1beta1.LocationTypeGit,
 			Repo:     fmt.Sprintf("https://%s", component.Name),
-			Revision: component.Version,
+			Revision: getRevisionFromVersion(component.Version),
 		})
 	}
 
@@ -131,6 +132,15 @@ func addBOMLocationsToTestrun(tr *tmv1beta1.Testrun, locationSetName string, com
 		},
 	}
 	tr.Spec.TestLocations = nil
+}
+
+// getRevisionFromVersion parses the version of a component and returns its revision if applicable.
+func getRevisionFromVersion(version string) string {
+	if strings.Contains(version, "dev") {
+		splitVersion := strings.Split(version, "-")
+		return splitVersion[len(splitVersion)-1]
+	}
+	return version
 }
 
 func addAnnotationsToTestrun(tr *tmv1beta1.Testrun, annotations map[string]string) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Parse component versions to return the revision(checkout) if the version is a dev version.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
