### PR TITLE
Allow to place argo+tm components on dedicated cluster nodes

### DIFF
--- a/charts/bootstrap_tm_prerequisites/templates/argo.yaml
+++ b/charts/bootstrap_tm_prerequisites/templates/argo.yaml
@@ -71,6 +71,22 @@ spec:
       labels:
         app: argo-ui
     spec:
+      # prefer nodes tainted+labeled with "purpose: tm-control-plane"
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: purpose
+                operator: In
+                values:
+                - tm-control-plane
+            weight: 100
+      tolerations:
+      - effect: NoSchedule
+        key: purpose
+        operator: Equal
+        value: tm-control-plane
       containers:
       - env:
         - name: ARGO_NAMESPACE
@@ -104,6 +120,22 @@ spec:
       labels:
         app: workflow-controller
     spec:
+      # prefer nodes tainted+labeled with "purpose: tm-control-plane"
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: purpose
+                operator: In
+                values:
+                - tm-control-plane
+            weight: 100
+      tolerations:
+      - effect: NoSchedule
+        key: purpose
+        operator: Equal
+        value: tm-control-plane
       containers:
       - args:
         - --configmap

--- a/charts/testmachinery/templates/deployment-tm-controller.yaml
+++ b/charts/testmachinery/templates/deployment-tm-controller.yaml
@@ -36,6 +36,22 @@ spec:
       - name: "{{.Values.controller.imagePullSecretName}}"
 {{end}}
       serviceAccountName: {{ required ".Values.controller.serviceAccountName is required" .Values.controller.serviceAccountName }}
+      # prefer nodes tainted+labeled with "purpose: tm-control-plane"
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: purpose
+                operator: In
+                values:
+                - tm-control-plane
+            weight: 100
+      tolerations:
+      - effect: NoSchedule
+        key: purpose
+        operator: Equal
+        value: tm-control-plane
       containers:
       - name: testmachinery-controller
         image: "{{ .Values.controller.image }}:{{ .Values.controller.tag }}"


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds tolerations and node affinities to argo's ui, workflow-controller and the testmachinery controller.
This allows cluster admins to taint and label nodes with `purpose: tm-control-plane` to achieve that control plane components reside on one set of nodes, while the actual test pods execute on the other nodes.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```improvement operator
Argo's ui, workflow-controller and the testmachinery controller are now deployed with taint tolerations and node affinities for taint/label `purpose: tm-control-plane`.
This allows cluster admins to taint and label nodes with `purpose: tm-control-plane` to achieve that control plane components reside on one set of nodes, while the actual test pods execute on the other nodes.
```
