### PR TITLE
Fix inputsource determination

### DIFF
--- a/pkg/testmachinery/testflow/flow_operations.go
+++ b/pkg/testmachinery/testflow/flow_operations.go
@@ -253,15 +253,16 @@ func getJointNodes(nodes []*node.Node, branches []node.Set, getNext func(*node.N
 		}
 	}
 	if n := findJointNode(branches); n != nil {
-		return n, nil
+		return n, lastNodes
 	}
 
 	return nil, lastNodes
 }
 
 func findJointNode(nodeSets []node.Set) *node.Node {
-	if len(nodeSets) == 1 && len(nodeSets[0]) == 1 {
-		return nodeSets[0].List()[0]
+	if len(nodeSets) == 1 {
+		nodeList := nodeSets[0].List()
+		return nodeList[len(nodeList)-1]
 	}
 
 	alreadyCheckedNodes := make(node.Set)


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue with the new function to determine the input source step that ignores step with `ContinueOnError: true`, where sequential steps with no parallelism are not correctly respected.
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Fix inputsource determination
```
