### PR TITLE
Fix input sources

### DIFF
--- a/pkg/testmachinery/testflow/flow.go
+++ b/pkg/testmachinery/testflow/flow.go
@@ -114,7 +114,7 @@ func (f *Flow) Iterate() <-chan *node.Node {
 	go func() {
 		c <- f.Root
 		for _, step := range f.steps {
-			for n := range step.Nodes {
+			for n := range step.Nodes.Iterate() {
 				c <- n
 			}
 		}

--- a/pkg/testmachinery/testflow/flow_operations_test.go
+++ b/pkg/testmachinery/testflow/flow_operations_test.go
@@ -37,11 +37,11 @@ var _ = Describe("flow operations", func() {
 			}
 			testflow.CreateInitialDAG(steps, rootNode)
 
-			Expect(A.Parents).To(HaveLen(1))
-			Expect(A.Parents).To(HaveKey(rootNode))
+			Expect(A.Parents.List()).To(HaveLen(1))
+			Expect(A.Parents.List()).To(ContainElement(rootNode))
 
-			Expect(rootNode.Children).To(HaveLen(1))
-			Expect(rootNode.Children).To(HaveKey(A))
+			Expect(rootNode.Children.List()).To(HaveLen(1))
+			Expect(rootNode.Children.List()).To(ContainElement(A))
 		})
 
 		It("should set dependent nodes as parents", func() {
@@ -60,11 +60,11 @@ var _ = Describe("flow operations", func() {
 			}
 			testflow.CreateInitialDAG(steps, rootNode)
 
-			Expect(B.Parents).To(HaveLen(1))
-			Expect(B.Parents).To(HaveKey(A))
+			Expect(B.Parents.List()).To(HaveLen(1))
+			Expect(B.Parents.List()).To(ContainElement(A))
 
-			Expect(A.Children).To(HaveLen(1))
-			Expect(A.Children).To(HaveKey(B))
+			Expect(A.Children.List()).To(HaveLen(1))
+			Expect(A.Children.List()).To(ContainElement(B))
 		})
 
 		It("should set multiple dependent nodes as parents", func() {
@@ -93,19 +93,19 @@ var _ = Describe("flow operations", func() {
 			}
 			testflow.CreateInitialDAG(steps, rootNode)
 
-			Expect(A.Children).To(HaveLen(2))
-			Expect(A.Children).To(HaveKey(B))
-			Expect(A.Children).To(HaveKey(C))
+			Expect(A.Children.List()).To(HaveLen(2))
+			Expect(A.Children.List()).To(ContainElement(B))
+			Expect(A.Children.List()).To(ContainElement(C))
 
-			Expect(B.Parents).To(HaveLen(1))
-			Expect(B.Parents).To(HaveKey(A))
+			Expect(B.Parents.List()).To(HaveLen(1))
+			Expect(B.Parents.List()).To(ContainElement(A))
 
-			Expect(C.Parents).To(HaveLen(1))
-			Expect(C.Parents).To(HaveKey(A))
+			Expect(C.Parents.List()).To(HaveLen(1))
+			Expect(C.Parents.List()).To(ContainElement(A))
 
-			Expect(D.Parents).To(HaveLen(2))
-			Expect(D.Parents).To(HaveKey(B))
-			Expect(D.Parents).To(HaveKey(C))
+			Expect(D.Parents.List()).To(HaveLen(2))
+			Expect(D.Parents.List()).To(ContainElement(B))
+			Expect(D.Parents.List()).To(ContainElement(C))
 		})
 
 	})
@@ -119,17 +119,17 @@ var _ = Describe("flow operations", func() {
 
 			Expect(testflow.ReorderChildrenOfNodes(node.NewSet(A))).To(BeNil())
 
-			Expect(A.Children).To(HaveLen(1))
-			Expect(A.Children).To(HaveKey(C))
+			Expect(A.Children.List()).To(HaveLen(1))
+			Expect(A.Children.List()).To(ContainElement(C))
 
-			Expect(C.Children).To(HaveLen(1))
-			Expect(C.Children).To(HaveKey(Bs))
+			Expect(C.Children.List()).To(HaveLen(1))
+			Expect(C.Children.List()).To(ContainElement(Bs))
 
-			Expect(Bs.Children).To(HaveLen(1))
-			Expect(Bs.Children).To(HaveKey(D))
+			Expect(Bs.Children.List()).To(HaveLen(1))
+			Expect(Bs.Children.List()).To(ContainElement(D))
 
-			Expect(D.Parents).To(HaveLen(1))
-			Expect(D.Parents).To(HaveKey(Bs))
+			Expect(D.Parents.List()).To(HaveLen(1))
+			Expect(D.Parents.List()).To(ContainElement(Bs))
 		})
 
 		It("should reorder a DAG with 2 parallel and 2 serial step", func() {
@@ -142,22 +142,22 @@ var _ = Describe("flow operations", func() {
 
 			Expect(testflow.ReorderChildrenOfNodes(node.NewSet(A))).To(BeNil())
 
-			Expect(A.Children).To(HaveLen(2))
-			Expect(A.Children).To(HaveKey(C))
-			Expect(A.Children).To(HaveKey(D))
+			Expect(A.Children.List()).To(HaveLen(2))
+			Expect(A.Children.List()).To(ContainElement(C))
+			Expect(A.Children.List()).To(ContainElement(D))
 
-			Expect(C.Children).To(HaveLen(1))
-			Expect(C.Children).To(Or(HaveKey(Bs), HaveKey(Es)))
-			Expect(D.Children).To(HaveLen(1))
-			Expect(D.Children).To(Or(HaveKey(Bs), HaveKey(Es)))
+			Expect(C.Children.List()).To(HaveLen(1))
+			Expect(C.Children.List()).To(Or(ContainElement(Bs), ContainElement(Es)))
+			Expect(D.Children.List()).To(HaveLen(1))
+			Expect(D.Children.List()).To(Or(ContainElement(Bs), ContainElement(Es)))
 
-			Expect(Bs.Children).To(HaveLen(1))
-			Expect(Bs.Children).To(Or(HaveKey(Es), HaveKey(F)))
-			Expect(Es.Children).To(HaveLen(1))
-			Expect(Es.Children).To(Or(HaveKey(Bs), HaveKey(F)))
+			Expect(Bs.Children.List()).To(HaveLen(1))
+			Expect(Bs.Children.List()).To(Or(ContainElement(Es), ContainElement(F)))
+			Expect(Es.Children.List()).To(HaveLen(1))
+			Expect(Es.Children.List()).To(Or(ContainElement(Bs), ContainElement(F)))
 
-			Expect(F.Parents).To(HaveLen(1))
-			Expect(F.Parents).To(Or(HaveKey(Bs), HaveKey(Es)))
+			Expect(F.Parents.List()).To(HaveLen(1))
+			Expect(F.Parents.List()).To(Or(ContainElement(Bs), ContainElement(Es)))
 		})
 
 		It("should change a reordered DAG", func() {
@@ -169,17 +169,17 @@ var _ = Describe("flow operations", func() {
 			Expect(testflow.ReorderChildrenOfNodes(node.NewSet(A))).To(BeNil())
 			Expect(testflow.ReorderChildrenOfNodes(node.NewSet(A))).To(BeNil())
 
-			Expect(len(A.Children)).To(Equal(1))
-			Expect(A.Children).To(HaveKey(C))
+			Expect(A.Children.Len()).To(Equal(1))
+			Expect(A.Children.List()).To(ContainElement(C))
 
-			Expect(len(C.Children)).To(Equal(1))
-			Expect(C.Children).To(HaveKey(Bs))
+			Expect(C.Children.Len()).To(Equal(1))
+			Expect(C.Children.List()).To(ContainElement(Bs))
 
-			Expect(len(Bs.Children)).To(Equal(1))
-			Expect(Bs.Children).To(HaveKey(D))
+			Expect(Bs.Children.Len()).To(Equal(1))
+			Expect(Bs.Children.List()).To(ContainElement(D))
 
-			Expect(len(D.Parents)).To(Equal(1))
-			Expect(D.Parents).To(HaveKey(Bs))
+			Expect(D.Parents.Len()).To(Equal(1))
+			Expect(D.Parents.List()).To(ContainElement(Bs))
 
 		})
 
@@ -189,10 +189,10 @@ var _ = Describe("flow operations", func() {
 
 			Expect(testflow.ReorderChildrenOfNodes(node.NewSet(A))).To(BeNil())
 
-			Expect(A.Children).To(HaveLen(1))
-			Expect(A.Children).To(HaveKey(Bs))
+			Expect(A.Children.List()).To(HaveLen(1))
+			Expect(A.Children.List()).To(ContainElement(Bs))
 
-			Expect(Bs.Children).To(HaveLen(0))
+			Expect(Bs.Children.List()).To(HaveLen(0))
 
 		})
 	})
@@ -276,13 +276,11 @@ var _ = Describe("flow operations", func() {
 			testDAGStepA.Definition.ContinueOnError = true
 			testDAGStepB := testDAGStep([]string{"A"})
 			testDAGStepB.Definition.ContinueOnError = true
-			testDAGStepC := testDAGStep([]string{"B"})
-			testDAGStepC.Definition.ContinueOnError = true
 
 			rootNode := testNode("root", node.NewSet(), defaultTestDef, testDAGStep([]string{}))
 			A := testNode("A", node.NewSet(rootNode), defaultTestDef, testDAGStepA)
 			B := testNode("B", node.NewSet(A), defaultTestDef, testDAGStepB)
-			C := testNode("C", node.NewSet(B), defaultTestDef, testDAGStepC)
+			C := testNode("C", node.NewSet(B), defaultTestDef, testDAGStep([]string{"B"}))
 			D := testNode("D", node.NewSet(C), defaultTestDef, testDAGStep([]string{"C"}))
 			steps := map[string]*testflow.Step{
 				"A": {
@@ -308,7 +306,41 @@ var _ = Describe("flow operations", func() {
 			Expect(A.GetInputSource()).To(Equal(rootNode))
 			Expect(B.GetInputSource()).To(Equal(rootNode))
 			Expect(C.GetInputSource()).To(Equal(rootNode))
-			Expect(D.GetInputSource()).To(Equal(rootNode))
+			Expect(D.GetInputSource()).To(Equal(C))
+
+		})
+
+		It("should set the rootNote as artifact source when names are not in alphabetical order", func() {
+			testDAGStepA := testDAGStep([]string{})
+			testDAGStepA.Definition.ContinueOnError = true
+			testDAGStepC := testDAGStep([]string{"ZA"})
+			testDAGStepC.Definition.ContinueOnError = true
+
+			rootNode := testNode("AA", node.NewSet(), defaultTestDef, testDAGStep([]string{}))
+			A := testNode("ZA", node.NewSet(rootNode), defaultTestDef, testDAGStepA)
+			C := testNode("ZC", node.NewSet(A), defaultTestDef, testDAGStepC)
+			B := testNode("ZB", node.NewSet(C), defaultTestDef, testDAGStep([]string{"ZC"}))
+			steps := map[string]*testflow.Step{
+				"A": {
+					Info:  A.Step(),
+					Nodes: node.NewSet(A),
+				},
+				"B": {
+					Info:  B.Step(),
+					Nodes: node.NewSet(B),
+				},
+				"C": {
+					Info:  C.Step(),
+					Nodes: node.NewSet(C),
+				},
+			}
+
+			Expect(testflow.ApplyOutputScope(steps)).ToNot(HaveOccurred())
+
+			Expect(A.GetInputSource()).To(Equal(rootNode))
+			Expect(B.GetInputSource()).To(Equal(rootNode))
+			Expect(C.GetInputSource()).To(Equal(rootNode))
+
 		})
 
 	})
@@ -584,24 +616,26 @@ var _ = Describe("flow operations", func() {
 	})
 })
 
-func testNode(name string, parents node.Set, td *testdefinition.TestDefinition, step *v1beta1.DAGStep) *node.Node {
+func testNode(name string, parents *node.Set, td *testdefinition.TestDefinition, step *v1beta1.DAGStep) *node.Node {
 	if parents == nil {
 		parents = node.NewSet()
 	}
 	n := node.NewEmpty(name)
 	n.Parents = parents
 	n.Children = node.NewSet()
-	n.TestDefinition = td
+
+	n.TestDefinition = td.Copy()
+	n.TestDefinition.SetName(name)
 
 	n.SetStep(step)
-	if td != nil {
-		td.SetName(name)
+	if n.TestDefinition != nil {
+		n.TestDefinition.SetName(name)
 		if step != nil {
-			td.AddConfig(config.New(step.Definition.Config, config.LevelStep))
+			n.TestDefinition.AddConfig(config.New(step.Definition.Config, config.LevelStep))
 		}
 	}
 
-	for parent := range parents {
+	for parent := range parents.Iterate() {
 		parent.AddChildren(n)
 	}
 

--- a/pkg/testmachinery/testflow/node/node.go
+++ b/pkg/testmachinery/testflow/node/node.go
@@ -16,6 +16,7 @@ package node
 
 import (
 	"fmt"
+
 	argov1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
 	tmv1beta1 "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
 	"github.com/gardener/test-infra/pkg/testmachinery"
@@ -26,13 +27,13 @@ import (
 )
 
 // CreateNodesFromStep creates new nodes from a step and adds default configuration
-func CreateNodesFromStep(step *tmv1beta1.DAGStep, loc locations.Locations, globalConfig []*config.Element, flowID string) (Set, error) {
+func CreateNodesFromStep(step *tmv1beta1.DAGStep, loc locations.Locations, globalConfig []*config.Element, flowID string) (*Set, error) {
 	testdefinitions, err := loc.GetTestDefinitions(step.Definition)
 	if err != nil {
 		return nil, err
 	}
 
-	nodes := make(Set, 0)
+	nodes := NewSet()
 	for _, td := range testdefinitions {
 		node := NewNode(td, step, flowID)
 		td.AddConfig(config.New(step.Definition.Config, config.LevelStep))
@@ -80,7 +81,7 @@ func (n *Node) RemoveChild(child *Node) {
 
 // ClearChildren removes all children from the current node
 func (n *Node) ClearChildren() {
-	n.Children = make(Set, 0)
+	n.Children = NewSet()
 }
 
 // AddParents adds nodes as parents.
@@ -95,13 +96,13 @@ func (n *Node) RemoveParent(parent *Node) {
 
 // ClearParents removes all parents from the current node
 func (n *Node) ClearParents() {
-	n.Parents = make(Set, 0)
+	n.Parents = NewSet()
 }
 
 // ParentNames returns the names of all parent nodes
 func (n *Node) ParentNames() []string {
 	names := make([]string, 0)
-	for parent := range n.Parents {
+	for parent := range n.Parents.Iterate() {
 		names = append(names, parent.Name())
 	}
 	return names

--- a/pkg/testmachinery/testflow/node/nodelist.go
+++ b/pkg/testmachinery/testflow/node/nodelist.go
@@ -1,94 +1,121 @@
 package node
 
-import "sort"
-
 // NewSet creates a new set of nodes
-func NewSet(nodes ...*Node) Set {
-	set := make(Set, 0)
+func NewSet(nodes ...*Node) *Set {
+	set := Set{
+		set:  make(map[*Node]int, 0),
+		list: make([]*Node, 0),
+	}
 	set.Add(nodes...)
-	return set
+	return &set
 }
 
 // Copy creates a deep copy of the set
-func (s Set) Copy() Set {
-	newSet := make(Set, len(s))
-	for key, val := range s {
+func (s *Set) Copy() *Set {
+	newSet := make(map[*Node]int, len(s.set))
+	for key, val := range s.set {
 		newSet[key] = val
 	}
-	return newSet
+	newList := make([]*Node, len(s.list))
+	for i, v := range s.list {
+		newList[i] = v
+	}
+
+	return &Set{
+		set:  newSet,
+		list: newList,
+	}
 }
 
-func (s Set) Has(n *Node) bool {
-	_, ok := s[n]
+func (s *Set) Iterate() chan *Node {
+	c := make(chan *Node)
+	go func() {
+		for n := range s.set {
+			c <- n
+		}
+		close(c)
+	}()
+	return c
+}
+
+func (s *Set) Len() int {
+	return len(s.set)
+}
+
+func (s *Set) Has(n *Node) bool {
+	_, ok := s.set[n]
 	return ok
 }
 
 // Add adds nodes to the set
-func (s Set) Add(nodes ...*Node) {
+func (s *Set) Add(nodes ...*Node) {
 	for _, n := range nodes {
-		s[n] = empty{}
+		s.set[n] = len(s.list)
+		s.list = append(s.list, n)
 	}
 }
 
 // Removes nodes form the set
-func (s Set) Remove(nodes ...*Node) {
+func (s *Set) Remove(nodes ...*Node) {
 	for _, n := range nodes {
-		delete(s, n)
+		i := s.set[n]
+		delete(s.set, n)
+		s.list = append(s.list[:i], s.list[i+1:]...)
 	}
 }
 
 // AddParents adds nodes as parents.
-func (s Set) AddParents(parents ...*Node) {
-	for node := range s {
+func (s *Set) AddParents(parents ...*Node) {
+	for node := range s.Iterate() {
 		node.AddParents(parents...)
 	}
 }
 
 // RemoveParents removes nodes from parents.
-func (s Set) RemoveParents(parents ...*Node) {
-	for n := range s {
-		for parent := range n.Parents {
+func (s *Set) RemoveParents(parents ...*Node) {
+	for n := range s.Iterate() {
+		for parent := range n.Parents.set {
 			n.RemoveParent(parent)
 		}
 	}
 }
 
 // Clear Parents removes all parents.
-func (s Set) ClearParents() {
-	for node := range s {
+func (s *Set) ClearParents() {
+	for node := range s.Iterate() {
 		node.ClearParents()
 	}
 }
 
 // AddChildren adds nodes as children.
-func (s Set) AddChildren(children ...*Node) {
-	for node := range s {
+func (s *Set) AddChildren(children ...*Node) {
+	for node := range s.Iterate() {
 		node.AddChildren(children...)
 	}
 }
 
 // RemoveChildren removes nodes from children
-func (s Set) RemoveChildren(children ...*Node) {
-	for n := range s {
-		for child := range n.Children {
+func (s *Set) RemoveChildren(children ...*Node) {
+	for n := range s.Iterate() {
+		for child := range n.Children.Iterate() {
 			n.RemoveChild(child)
 		}
 	}
 }
 
 // ClearChildren removes all children.
-func (s Set) ClearChildren() {
-	for node := range s {
+func (s *Set) ClearChildren() {
+	for node := range s.Iterate() {
 		node.ClearChildren()
 	}
 }
 
-// GetParents returns a set of all parents
-func (s Set) GetChildren() Set {
-	children := make(Set)
-	for node := range s {
-		for child := range node.Children {
-			if _, ok := children[child]; !ok {
+// GetChildren returns a set of all children
+func (s *Set) GetChildren() *Set {
+	children := NewSet()
+	for node := range s.Iterate() {
+		for child := range node.Children.Iterate() {
+			if !children.Has(child) {
 				children.Add(child)
 			}
 		}
@@ -97,11 +124,11 @@ func (s Set) GetChildren() Set {
 }
 
 // GetParents returns a set of all parents
-func (s Set) GetParents() Set {
-	parents := make(Set, 0)
-	for node := range s {
-		for parent := range node.Parents {
-			if _, ok := parents[parent]; !ok {
+func (s *Set) GetParents() *Set {
+	parents := NewSet()
+	for node := range s.Iterate() {
+		for parent := range node.Parents.Iterate() {
+			if !parents.Has(parent) {
 				parents.Add(parent)
 			}
 		}
@@ -109,18 +136,12 @@ func (s Set) GetParents() Set {
 	return parents
 }
 
-type sortableSliceOfNodes []*Node
-
-func (s sortableSliceOfNodes) Len() int           { return len(s) }
-func (s sortableSliceOfNodes) Less(i, j int) bool { return s[i].Name() < s[j].Name() }
-func (s sortableSliceOfNodes) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
-
-// Set return all nodes of the set as an array
+// List return all nodes of the set as an array
 func (s Set) List() []*Node {
-	res := make(sortableSliceOfNodes, 0, len(s))
-	for key := range s {
-		res = append(res, key)
-	}
-	sort.Sort(res)
-	return []*Node(res)
+	return s.list
+}
+
+// Set returns map of the set
+func (s Set) Set() map[*Node]int {
+	return s.set
 }

--- a/pkg/testmachinery/testflow/node/types.go
+++ b/pkg/testmachinery/testflow/node/types.go
@@ -6,14 +6,16 @@ import (
 	"github.com/gardener/test-infra/pkg/testmachinery/testdefinition"
 )
 
-type Set map[*Node]empty
-type empty struct{}
+type Set struct {
+	list []*Node
+	set  map[*Node]int
+}
 
 // Node is an object that represents a node of the internal DAG representation
 type Node struct {
 	name     string
-	Parents  Set
-	Children Set
+	Parents  *Set
+	Children *Set
 
 	hasOutput   bool
 	inputSource *Node

--- a/pkg/testmachinery/testflow/types.go
+++ b/pkg/testmachinery/testflow/types.go
@@ -51,5 +51,5 @@ type Flow struct {
 // Step is a StepDefinition with its specific Row and Column in the testflow.
 type Step struct {
 	Info  *tmv1beta1.DAGStep
-	Nodes node.Set
+	Nodes *node.Set
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the sorting of input sources so that we do not sort by node name instead sorting by time added.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Fix node sorting in input sources 
```
