### PR TITLE
Add node affinity & tolerations to workflow pods

### DIFF
--- a/charts/bootstrap_tm_prerequisites/templates/argo.yaml
+++ b/charts/bootstrap_tm_prerequisites/templates/argo.yaml
@@ -71,22 +71,6 @@ spec:
       labels:
         app: argo-ui
     spec:
-      # prefer nodes tainted+labeled with "purpose: tm-control-plane"
-      affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - preference:
-              matchExpressions:
-              - key: purpose
-                operator: In
-                values:
-                - tm-control-plane
-            weight: 100
-      tolerations:
-      - effect: NoSchedule
-        key: purpose
-        operator: Equal
-        value: tm-control-plane
       containers:
       - env:
         - name: ARGO_NAMESPACE
@@ -120,22 +104,6 @@ spec:
       labels:
         app: workflow-controller
     spec:
-      # prefer nodes tainted+labeled with "purpose: tm-control-plane"
-      affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - preference:
-              matchExpressions:
-              - key: purpose
-                operator: In
-                values:
-                - tm-control-plane
-            weight: 100
-      tolerations:
-      - effect: NoSchedule
-        key: purpose
-        operator: Equal
-        value: tm-control-plane
       containers:
       - args:
         - --configmap

--- a/charts/testmachinery/templates/deployment-tm-controller.yaml
+++ b/charts/testmachinery/templates/deployment-tm-controller.yaml
@@ -36,22 +36,6 @@ spec:
       - name: "{{.Values.controller.imagePullSecretName}}"
 {{end}}
       serviceAccountName: {{ required ".Values.controller.serviceAccountName is required" .Values.controller.serviceAccountName }}
-      # prefer nodes tainted+labeled with "purpose: tm-control-plane"
-      affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - preference:
-              matchExpressions:
-              - key: purpose
-                operator: In
-                values:
-                - tm-control-plane
-            weight: 100
-      tolerations:
-      - effect: NoSchedule
-        key: purpose
-        operator: Equal
-        value: tm-control-plane
       containers:
       - name: testmachinery-controller
         image: "{{ .Values.controller.image }}:{{ .Values.controller.tag }}"

--- a/pkg/testmachinery/argo/argo.go
+++ b/pkg/testmachinery/argo/argo.go
@@ -17,12 +17,10 @@ package argo
 import (
 	argov1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
 	argoclientset "github.com/argoproj/argo/pkg/client/clientset/versioned"
+	"github.com/gardener/test-infra/pkg/testmachinery"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/clientcmd"
 )
-
-// the label and taint of the nodes in the worker pool which are reserved for workflow pods
-const workerPoolTaintLabelName = "testload"
 
 // CreateWorkflow takes a name, templates and volumes to generate an argo workflow object.
 func CreateWorkflow(name, namespace, entrypoint, onExitName string, templates []argov1.Template, volumes []corev1.Volume, ttl *int32, pullImageSecretNames []string) (*argov1.Workflow, error) {
@@ -110,7 +108,7 @@ func getWorkflowAffinity() *corev1.Affinity {
 							{
 								Key:      "purpose",
 								Operator: "In",
-								Values:   []string{workerPoolTaintLabelName},
+								Values:   []string{testmachinery.WorkerPoolTaintLabelName},
 							},
 						},
 					},
@@ -126,7 +124,7 @@ func getWorkflowTolerations() []corev1.Toleration {
 		{
 			Key:      "purpose",
 			Operator: "Equal",
-			Value:    workerPoolTaintLabelName,
+			Value:    testmachinery.WorkerPoolTaintLabelName,
 			Effect:   "NoSchedule",
 		},
 	}

--- a/pkg/testmachinery/config.go
+++ b/pkg/testmachinery/config.go
@@ -58,6 +58,9 @@ const (
 
 	// ConfigMapName is the name of the testmachinery configmap in the cluster
 	ConfigMapName = "tm-config"
+
+	// the label and taint of the nodes in the worker pool which are preferably used for workflow pods
+	WorkerPoolTaintLabelName = "testload"
 )
 
 var (


### PR DESCRIPTION
**What this PR does / why we need it**:
Reverses the recently added affinity/tolerations feature, so that workflow pods specify a node preference. This results in having only workflow pods (except daemonsets of course) running on dedicated nodes.
Workflow pods now prefer nodes labeled and tainted with `purpose: testload`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```improvement operator
Workflow pods (aka testload) prefer now nodes that are tainted/labeled with `purpose: testload`.
This reverses and thus removes the previous approach of prefering specific nodes only for testmachinery components (controllers, etc).
```
