### PR TITLE
Use kubetest

### DIFF
--- a/integration-tests/e2e/kubetest/kubetest_runner.go
+++ b/integration-tests/e2e/kubetest/kubetest_runner.go
@@ -106,7 +106,7 @@ func createKubetestArgs(ginkgoFocus string, parallel, dryRun bool, flakeAttempts
 
 func runKubetest(args KubetestArgs) {
 	ginkgoArgs := fmt.Sprintf("--test_args=--ginkgo.flakeAttempts=%o --ginkgo.dryRun=%t %s", args.FlakeAttempts, args.DryRun, args.GinkgoFocus)
-	cmd := exec.Command("go", "run", "hack/e2e.go", "--", "--provider=skeleton", "--deployment=local", "--test", "--check-version-skew=false", args.GinkgoParallel, ginkgoArgs, fmt.Sprintf("--dump=%s", args.LogDir))
+	cmd := exec.Command("kubetest", "--provider=skeleton", "--deployment=local", "--test", "--check-version-skew=false", args.GinkgoParallel, ginkgoArgs, fmt.Sprintf("--dump=%s", args.LogDir))
 	cmd.Dir = config.KubernetesPath
 
 	cmdString := strings.Join(cmd.Args, " ")

--- a/integration-tests/e2e/kubetest/kubetest_runner.go
+++ b/integration-tests/e2e/kubetest/kubetest_runner.go
@@ -142,11 +142,15 @@ func runKubetest(args KubetestArgs) {
 	if err != nil {
 		outStr := out.String()
 		if outStr != "" {
-			stringIndex := out.Len() - 50000
+			stringIndex := len(outStr) - 50000
 			if stringIndex < 0 {
 				stringIndex = 0
 			}
-			log.Info(fmt.Sprintf("... %s", outStr[out.Len() - stringIndex:]))
+			//log.Info(fmt.Sprintf("... %s", outStr[stringIndex:]))
+			scanner := bufio.NewScanner(strings.NewReader(outStr[stringIndex:]))
+			for scanner.Scan() {
+				log.Info("    " + scanner.Text())
+			}
 		}
 		log.Error(errors.Wrapf(err, "kubetest run failed"))
 	} else {

--- a/integration-tests/e2e/kubetest/kubetest_runner.go
+++ b/integration-tests/e2e/kubetest/kubetest_runner.go
@@ -140,6 +140,14 @@ func runKubetest(args KubetestArgs) {
 
 	// kubetest run fails if one of the testcases failes, therefore the execution is still successful and no err needs to be returned
 	if err != nil {
+		outStr := out.String()
+		if outStr != "" {
+			stringIndex := out.Len() - 50000
+			if stringIndex < 0 {
+				stringIndex = 0
+			}
+			log.Info(fmt.Sprintf("... %s", outStr[out.Len() - stringIndex:]))
+		}
 		log.Error(errors.Wrapf(err, "kubetest run failed"))
 	} else {
 		log.Info("kubtest test run successful")

--- a/integration-tests/e2e/kubetest/setup/setup.go
+++ b/integration-tests/e2e/kubetest/setup/setup.go
@@ -1,18 +1,14 @@
 package setup
 
 import (
-	"context"
 	"fmt"
-	"github.com/codeclysm/extract"
 	"github.com/gardener/test-infra/integration-tests/e2e/config"
 	"github.com/gardener/test-infra/integration-tests/e2e/kubetest"
 	"github.com/gardener/test-infra/integration-tests/e2e/util"
 	log "github.com/sirupsen/logrus"
-	"net/http"
 	"os"
 	"path"
 	"path/filepath"
-	"runtime"
 	"strings"
 )
 
@@ -26,16 +22,23 @@ func Setup() error {
 	}
 
 	log.Info("test utilities are not ready. Install...")
-	if err := downloadKubernetes(config.K8sRelease); err != nil {
-		return err
-	}
-	if err := downloadKubectl(config.K8sRelease); err != nil {
-		return err
-	}
-	if err := compileOrGetTestUtilities(config.K8sRelease); err != nil {
+	if err := getKubetestAndUtilities(); err != nil {
 		return err
 	}
 	log.Info("setup finished successfuly. Testutilities ready. Kubetest is ready for usage.")
+	return nil
+}
+
+func getKubetestAndUtilities() error {
+	goModuleOriginValue := os.Getenv("GO111MODULE")
+	_ = os.Setenv("GO111MODULE", "off")
+	if _, err := util.RunCmd("go get k8s.io/test-infra/kubetest", ""); err != nil {
+		return err
+	}
+	_ = os.Setenv("GO111MODULE", goModuleOriginValue)
+	if _, err := util.RunCmd(fmt.Sprintf("kubetest --provider=skeleton --extract=v%s", config.K8sRelease), config.K8sRoot); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -103,126 +106,6 @@ func areTestUtilitiesReady() bool {
 	}
 
 	return true
-}
-
-func downloadKubernetes(k8sVersion string) error {
-	log.Infof("get kubernetes v%s", k8sVersion)
-
-	if _, err := os.Stat(config.KubernetesPath); !os.IsNotExist(err) {
-		if _, err := util.RunCmd("git clean -f -d", config.KubernetesPath); err != nil {
-			log.Errorf("failed to failed to run git clean in %s", config.KubernetesPath, err)
-			return err
-		}
-		if _, err := util.RunCmd("git checkout master", config.KubernetesPath); err != nil {
-			log.Errorf("failed to checkout master branch in %s", config.KubernetesPath, err)
-			return err
-		}
-		if _, err := util.RunCmd("git pull --rebase", config.KubernetesPath); err != nil {
-			log.Errorf("failed to run 'git pull --rebase' in %s", config.KubernetesPath, err)
-			return err
-		}
-	} else if os.IsNotExist(err) {
-		cloneCmd := fmt.Sprintf("git clone --branch=v%s --depth=1 https://github.com/kubernetes/kubernetes %s", config.K8sRelease, config.KubernetesPath)
-		log.Infof("directory %s does not exist. Run %s", config.KubernetesPath, cloneCmd)
-		if out, err := util.RunCmd(cloneCmd, ""); err != nil && !isNoGoFilesErr(out.StdErr) {
-			log.Errorf("failed to %s", cloneCmd, err)
-			return err
-		}
-	} else {
-		return err
-	}
-
-	if _, err := util.RunCmd(fmt.Sprintf("git checkout v%s", k8sVersion), config.KubernetesPath); err != nil {
-		return err
-	}
-	log.Infof("kubernetes v%s successfully installed", k8sVersion)
-	return nil
-}
-
-func downloadKubectl(k8sVersion string) error {
-	log.Info("download corresponding kubectl version")
-	if _, err := util.RunCmd(fmt.Sprintf("curl -LO https://storage.googleapis.com/kubernetes-release/release/v%s/bin/%s/amd64/kubectl", k8sVersion, runtime.GOOS), ""); err != nil {
-		return err
-	}
-	kubectlBinPath := "/usr/local/bin/kubectl"
-	_ = os.Setenv("KUBECTL_PATH", kubectlBinPath)
-	if err := util.MoveFile("./kubectl", kubectlBinPath); err != nil {
-		return err
-	}
-	if err := os.Chmod(kubectlBinPath, 0755); err != nil {
-		return err
-	}
-
-	// verify successful kubectl installation
-	log.Infof("KUBECTL_PATH=%s", os.Getenv("KUBECTL_PATH"))
-	if _, err := util.RunCmd("kubectl version", ""); err != nil {
-		return err
-	} else {
-		log.Info("kubectl successfully installed")
-	}
-	return nil
-}
-
-func compileOrGetTestUtilities(k8sVersion string) error {
-	k8sTestBinariesVersionURL := fmt.Sprintf("https://storage.googleapis.com/kubernetes-release/release/v%s/kubernetes-test-%s-amd64.tar.gz", k8sVersion, runtime.GOOS)
-	resp, err := http.Get(k8sTestBinariesVersionURL)
-
-	if err != nil || resp.StatusCode != http.StatusOK || (runtime.GOOS != "linux" && runtime.GOOS != "darwin") {
-		log.Info("no precompiled kubernetes test binaries available, or operating system is not linux/darwin, build e2e.test and ginkgo")
-		if err := os.RemoveAll(k8sOutputBinDir); err != nil {
-			return err
-		}
-		if _, err = util.RunCmd("make WHAT=test/e2e/e2e.test", config.KubernetesPath); err != nil {
-			return err
-		}
-		if _, err = util.RunCmd("make WHAT=vendor/github.com/onsi/ginkgo/ginkgo", config.KubernetesPath); err != nil {
-			return err
-		}
-	} else if resp.StatusCode == http.StatusOK {
-		log.Infof("precompiled kubernetes test binaries available, download kubernetes-test-linux-amd64 for kubernetes v%s", k8sVersion)
-		k8sTestBinariesTarPath, err := util.DownloadFile(k8sTestBinariesVersionURL, config.DownloadsDir)
-		if err != nil {
-			return err
-		}
-
-		archiveFile, err := os.Open(k8sTestBinariesTarPath)
-		shiftFile := func(path string) string {
-			parts := strings.Split(path, string(filepath.Separator))
-			parts = parts[2:]
-			return strings.Join(parts, string(filepath.Separator))
-		}
-		if err := extract.Gz(context.Background(), archiveFile, filepath.Dir(k8sOutputBinDir), shiftFile); err != nil {
-			return err
-		}
-
-		if runtime.GOOS == "linux" {
-			err = installGlibC()
-		}
-	}
-
-	log.Info("get k8s examples")
-	if out, err := util.RunCmd("go get -u k8s.io/examples", ""); err != nil && !isNoGoFilesErr(out.StdErr) {
-		return err
-	}
-	return nil
-}
-
-func installGlibC() error {
-	log.Info("Install glibc to run precompiled ginkgo and e2e.test binaries")
-	var err error
-	if _, err = util.RunCmd("apk --no-cache add ca-certificates wget", ""); err != nil {
-		return err
-	}
-	if _, err = util.RunCmd("wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub", ""); err != nil {
-		return err
-	}
-	if _, err = util.RunCmd("wget --quiet https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.29-r0/glibc-2.29-r0.apk", ""); err != nil {
-		return err
-	}
-	if _, err = util.RunCmd("apk add glibc-2.29-r0.apk", ""); err != nil {
-		return err
-	}
-	return nil
 }
 
 func isNoGoFilesErr(s string) bool {

--- a/integration-tests/e2e/kubetest/setup/setup.go
+++ b/integration-tests/e2e/kubetest/setup/setup.go
@@ -5,19 +5,18 @@ import (
 	"github.com/gardener/test-infra/integration-tests/e2e/config"
 	"github.com/gardener/test-infra/integration-tests/e2e/kubetest"
 	"github.com/gardener/test-infra/integration-tests/e2e/util"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"os"
 	"path"
 	"path/filepath"
-	"strings"
 )
-
-var k8sOutputBinDir string = filepath.Join(config.KubernetesPath, "_output/bin")
 
 func Setup() error {
 	cleanUpPreviousRuns()
 	if areTestUtilitiesReady() {
 		log.Info("all test utilities were already ready")
+		log.Info("setup finished successfuly. Testutilities ready. Kubetest is ready for usage.")
 		return nil
 	}
 
@@ -25,7 +24,12 @@ func Setup() error {
 	if err := getKubetestAndUtilities(); err != nil {
 		return err
 	}
-	log.Info("setup finished successfuly. Testutilities ready. Kubetest is ready for usage.")
+
+	if areTestUtilitiesReady() {
+		log.Info("setup finished successfuly. Testutilities ready. Kubetest is ready for usage.")
+		return nil
+	}
+	log.Fatal("Couldn't prepare kubetest utilities")
 	return nil
 }
 
@@ -79,38 +83,28 @@ func PostRunCleanFiles() error {
 
 func areTestUtilitiesReady() bool {
 	log.Info("checking whether any test utility is not ready")
-	if _, err := util.RunCmd("which kubectl", ""); err != nil {
-		log.Warn("kubectl not installed")
-		return false
-	}
-	if out, err := util.RunCmd("kubectl version", ""); err != nil || !strings.Contains(out.StdOut, fmt.Sprintf("v%s", config.K8sRelease)) {
-		log.Warn("kubectl version doesn't match kubernetes version")
-		return false
-	}
-	e2eTestPath := path.Join(k8sOutputBinDir, "e2e.test")
-	if _, err := os.Stat(e2eTestPath); os.IsNotExist(err) {
-		log.Warnf("test utility not ready: %s doesn't exist", e2eTestPath)
-		return false // path does not exist
-	}
-	ginkgoPath := path.Join(k8sOutputBinDir, "ginkgo")
-	if _, err := os.Stat(ginkgoPath); os.IsNotExist(err) {
-		log.Warnf("test utility not ready: %s doesn't exist", ginkgoPath)
-		return false // path does not exist
-	}
-	if out, err := util.RunCmd("git describe", config.KubernetesPath); err != nil {
-		log.Warnf("failed to run 'git describe' in %s", config.KubernetesPath, err)
-		return false
-	} else if strings.TrimSpace(out.StdOut) != fmt.Sprintf("v%s", config.K8sRelease) {
-		log.Infof("test utility not ready: current k8s release version is %s, but the requested version is v%s", out.StdOut, config.K8sRelease)
-		return false
-	}
 
-	return true
-}
-
-func isNoGoFilesErr(s string) bool {
-	if strings.Contains(s, "no Go files in") {
-		return true
+	testUtilitiesReady := true
+	if !util.CommandExists("kubetest") {
+		log.Warn("kubetest not installed")
+		testUtilitiesReady = false
 	}
-	return false
+	log.Info("kubetest binary available")
+
+	// check if required directories exist
+	requiredPaths := [...]string{
+		path.Join(config.K8sRoot, "kubernetes/hack"),
+		path.Join(config.K8sRoot, "kubernetes/cluster"),
+		path.Join(config.K8sRoot, "kubernetes/test"),
+		path.Join(config.K8sRoot, "kubernetes/client"),
+		path.Join(config.K8sRoot, "kubernetes/server")}
+	for _, requiredPath := range requiredPaths {
+		if _, err := os.Stat(requiredPath); err != nil {
+			log.Warn(errors.Wrapf(err, "dir %s does not exist: ", requiredPath))
+			testUtilitiesReady = false
+		} else {
+			log.Info(fmt.Sprintf("%s dir exists", requiredPath))
+		}
+	}
+	return testUtilitiesReady
 }

--- a/integration-tests/e2e/util/util.go
+++ b/integration-tests/e2e/util/util.go
@@ -145,3 +145,12 @@ func MoveFile(sourcePath, destPath string) error {
 	}
 	return nil
 }
+
+
+/*
+	CommandExists checks whether the given command executable exists and returns a boolean result value
+ */
+func CommandExists(cmd string) bool {
+	_, err := exec.LookPath(cmd)
+	return err == nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Use kubetest instead of hack/e2e.go for e2e test runs. Also leverage kubetest`s extract feature, which downloads all necessary precompiled test utilities and untars them. Return last log lines of kubetest in case of failing kubetest run. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```
Use kubetest instead of hack/e2e.go for e2e test runs

```
