### PR TITLE
Add support for multiple cloudprovider shoots in gardener scheduler

### DIFF
--- a/.test-defs/scheduler-lock-gardener.yaml
+++ b/.test-defs/scheduler-lock-gardener.yaml
@@ -39,5 +39,5 @@ spec:
   command: [bash, -c]
   args:
   - >-
-    go run -mod=vendor ./cmd/hostscheduler lock gardener --id=$TM_TESTRUN_ID --kubeconfig=/tmp/secrets/gardener-service-account.kubeconfig
+    go run -mod=vendor ./cmd/hostscheduler lock gardener --id=$TM_TESTRUN_ID --kubeconfig=/tmp/secrets/gardener-service-account.kubeconfig --cloudprovider=$HOST_CLOUDPROVIDER
   image: golang:1.12.7

--- a/pkg/hostscheduler/gardenerscheduler/scheduler.go
+++ b/pkg/hostscheduler/gardenerscheduler/scheduler.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 	"flag"
+	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/test-infra/pkg/hostscheduler"
 	"github.com/sirupsen/logrus"
@@ -24,12 +25,14 @@ import (
 )
 
 const (
-	Name = "gardener"
+	Name                                         = "gardener"
+	CloudProviderAll gardenv1beta1.CloudProvider = "all"
 )
 
 var (
-	kubeconfigPath string
-	id             string
+	kubeconfigPath    string
+	cloudproviderName string
+	id                string
 )
 
 var Register hostscheduler.Register = func(m hostscheduler.Registrations) {
@@ -44,6 +47,7 @@ var Register hostscheduler.Register = func(m hostscheduler.Registrations) {
 
 var registerFlags hostscheduler.RegisterFlagsFunc = func(fs *flag.FlagSet) {
 	fs.StringVar(&kubeconfigPath, "kubeconfig", "", "Path to the gardener cluster kubeconfigPath")
+	fs.StringVar(&cloudproviderName, "cloudprovider", "", "Specify teh cloudprovider of the shoot that should be taken from the pool")
 	fs.StringVar(&id, "id", "", "Unique id to identify the cluster")
 }
 
@@ -52,12 +56,18 @@ var registerScheduler hostscheduler.RegisterInterfaceFromArgsFunc = func(ctx con
 	if kubeconfigPath == "" {
 		return nil, errors.New("no kubeconfig is specified")
 	}
-	logger.Debugf("Kubeconig path: %s", kubeconfigPath)
+	if cloudproviderName == "" {
+		cloudproviderName = string(gardenv1beta1.CloudProviderGCP)
+	}
 
-	return New(ctx, logger, id, kubeconfigPath)
+	logger.Debugf("Kubeconfig path: %s", kubeconfigPath)
+	logger.Debugf("CloudProvider: %s", cloudproviderName)
+	logger.Debugf("ID: %s", id)
+
+	return New(ctx, logger, id, kubeconfigPath, gardenv1beta1.CloudProvider(cloudproviderName))
 }
 
-func New(_ context.Context, logger *logrus.Logger, id, kubeconfigPath string) (*gardenerscheduler, error) {
+func New(_ context.Context, logger *logrus.Logger, id, kubeconfigPath string, cloudprovider gardenv1beta1.CloudProvider) (*gardenerscheduler, error) {
 
 	k8sClient, err := kubernetes.NewClientFromFile("", kubeconfigPath, client.Options{
 		Scheme: kubernetes.GardenScheme,
@@ -71,10 +81,11 @@ func New(_ context.Context, logger *logrus.Logger, id, kubeconfigPath string) (*
 		return nil, err
 	}
 	return &gardenerscheduler{
-		client:    k8sClient,
-		logger:    logger,
-		id:        id,
-		namespace: namespace,
+		client:        k8sClient,
+		logger:        logger,
+		id:            id,
+		namespace:     namespace,
+		cloudprovider: cloudprovider,
 	}, nil
 }
 

--- a/pkg/hostscheduler/gardenerscheduler/scheduler.go
+++ b/pkg/hostscheduler/gardenerscheduler/scheduler.go
@@ -47,7 +47,7 @@ var Register hostscheduler.Register = func(m hostscheduler.Registrations) {
 
 var registerFlags hostscheduler.RegisterFlagsFunc = func(fs *flag.FlagSet) {
 	fs.StringVar(&kubeconfigPath, "kubeconfig", "", "Path to the gardener cluster kubeconfigPath")
-	fs.StringVar(&cloudproviderName, "cloudprovider", "", "Specify teh cloudprovider of the shoot that should be taken from the pool")
+	fs.StringVar(&cloudproviderName, "cloudprovider", "", "Specify the cloudprovider of the shoot that should be taken from the pool")
 	fs.StringVar(&id, "id", "", "Unique id to identify the cluster")
 }
 

--- a/pkg/hostscheduler/gardenerscheduler/types.go
+++ b/pkg/hostscheduler/gardenerscheduler/types.go
@@ -15,7 +15,8 @@ package gardenerscheduler
 
 import (
 	"fmt"
-	"github.com/gardener/gardener/pkg/apis/garden/v1beta1"
+
+	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/sirupsen/logrus"
 )
@@ -40,10 +41,11 @@ type gardenerscheduler struct {
 	logger *logrus.Logger
 	id     string
 
-	namespace string
+	namespace     string
+	cloudprovider gardenv1beta1.CloudProvider
 }
 
-func isFree(shoot *v1beta1.Shoot) bool {
+func isFree(shoot *gardenv1beta1.Shoot) bool {
 	val, ok := shoot.Labels[ShootLabelStatus]
 	if !ok {
 		return false
@@ -52,7 +54,7 @@ func isFree(shoot *v1beta1.Shoot) bool {
 	return val == ShootStatusFree
 }
 
-func isLocked(shoot *v1beta1.Shoot) bool {
+func isLocked(shoot *gardenv1beta1.Shoot) bool {
 	val, ok := shoot.Labels[ShootLabelStatus]
 	if !ok {
 		return false


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support to specify the cloudprovider that the gardener scheduler should select

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Add support to specify the cloudprovider of the shoot to be selected by the gardener scheduler
```
