### PR TITLE
Add support for value files in the testrunner templates

### DIFF
--- a/cmd/testrunner/cmd/rungardenertemplate/run_template.go
+++ b/cmd/testrunner/cmd/rungardenertemplate/run_template.go
@@ -56,6 +56,7 @@ var (
 	gardenerUpgradedVersion  string
 	gardenerUpgradedRevision string
 	setValues                string
+	fileValues               []string
 )
 
 // AddCommand adds run-testrun to a command.
@@ -118,6 +119,7 @@ var runCmd = &cobra.Command{
 			ComponentDescriptorPath:         componentDescriptorPath,
 			UpgradedComponentDescriptorPath: upgradedComponentDescriptorPath,
 			SetValues:                       setValues,
+			FileValues:                      fileValues,
 		}
 
 		metadata := &testrunner.Metadata{
@@ -187,4 +189,5 @@ func init() {
 	runCmd.Flags().StringVar(&gardenerUpgradedRevision, "gardener-upgraded-revision", "", "Set current revision of gardener. This will result in the helm value {{ .Values.gardener.upgraded.revision }}")
 
 	runCmd.Flags().StringVar(&setValues, "set", "", "setValues additional helm values")
+	runCmd.Flags().StringArrayVarP(&fileValues, "values", "f", make([]string, 0), "yaml value files to override template values")
 }

--- a/cmd/testrunner/cmd/runtemplate/run_template.go
+++ b/cmd/testrunner/cmd/runtemplate/run_template.go
@@ -66,7 +66,8 @@ var (
 	loadbalancerProvider     string
 	componenetDescriptorPath string
 
-	setValues string
+	setValues  string
+	fileValues []string
 )
 
 // AddCommand adds run-testrun to a command.
@@ -252,4 +253,5 @@ func init() {
 	runCmd.Flags().StringVar(&landscape, "landscape", "", "Current gardener landscape.")
 
 	runCmd.Flags().StringVar(&setValues, "set", "", "setValues additional helm values")
+	runCmd.Flags().StringArrayVarP(&fileValues, "values", "f", make([]string, 0), "yaml value files to override template values")
 }

--- a/integration-tests/e2e/util/util.go
+++ b/integration-tests/e2e/util/util.go
@@ -147,10 +147,9 @@ func MoveFile(sourcePath, destPath string) error {
 	return nil
 }
 
-
 /*
 	CommandExists checks whether the given command executable exists and returns a boolean result value
- */
+*/
 func CommandExists(cmd string) bool {
 	_, err := exec.LookPath(cmd)
 	return err == nil

--- a/pkg/testrunner/template/helper.go
+++ b/pkg/testrunner/template/helper.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/gardener/gardener/pkg/utils"
+	"io/ioutil"
 	"sort"
 	"strings"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/gardener/test-infra/pkg/testrunner/componentdescriptor"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	yaml "sigs.k8s.io/yaml"
 )
 
 // getK8sVersions returns all K8s version that should be rendered by the chart
@@ -160,4 +162,20 @@ func getGardenerVersionFromComponentDescriptor(componentDescriptor componentdesc
 		}
 	}
 	return ""
+}
+
+func readFileValues(files []string) (map[string]interface{}, error) {
+	values := make(map[string]interface{})
+	for _, file := range files {
+		newValues := make(map[string]interface{})
+		data, err := ioutil.ReadFile(file)
+		if err != nil {
+			return nil, err
+		}
+		if err := yaml.Unmarshal(data, newValues); err != nil {
+			return nil, err
+		}
+		values = utils.MergeMaps(values, newValues)
+	}
+	return values, nil
 }

--- a/pkg/testrunner/template/types.go
+++ b/pkg/testrunner/template/types.go
@@ -41,6 +41,7 @@ type ShootTestrunParameters struct {
 
 	GardenerVersion string
 	SetValues       string
+	FileValues      []string
 }
 
 type GardenerTestrunParameters struct {
@@ -56,7 +57,8 @@ type GardenerTestrunParameters struct {
 	GardenerUpgradedVersion  string
 	GardenerUpgradedRevision string
 
-	SetValues string
+	SetValues  string
+	FileValues []string
 }
 
 // TestrunFile is the internal representation of a rendered testrun chart with metadata information


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support defining helm style value files for `testrunner run-gardener` and `testrunner run`.
These files can be defined by `--values` or `-f`.

e.g `testrunner run --values path/to/values1 --values path/to/values2`This is needed to provide more flexibility when defining templates.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Add support for value files in the testrunner templates
```
