### PR TITLE
Add testdefinition to fetch logs from gardener components

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -29,9 +29,9 @@ test-infra:
               tag_as_latest: true
     ti_test_steps: &ti_test_steps
       check:
-        image: 'golang:1.12.7'
+        image: 'golang:1.12.9'
       test:
-        image: 'golang:1.12.7'
+        image: 'golang:1.12.9'
 
   jobs:
     head-update:

--- a/.test-defs/allE2eTestgrid.yaml
+++ b/.test-defs/allE2eTestgrid.yaml
@@ -52,4 +52,4 @@ spec:
     export E2E_EXPORT_PATH=$TM_EXPORT_PATH &&
     export E2E_KUBECONFIG_PATH=$TM_KUBECONFIG_PATH/shoot.config &&
     go run --mod=vendor ./integration-tests/e2e -cleanUpAfterwards=true
-  image: golang:1.12.7
+  image: golang:1.12.9

--- a/.test-defs/cleanGardener.yaml
+++ b/.test-defs/cleanGardener.yaml
@@ -33,4 +33,4 @@ spec:
   args:
   - >-
     go run -mod=vendor ./cmd/cleanup/gardener --kubeconfig=$TM_KUBECONFIG_PATH/gardener.config --debug=true
-  image: golang:1.12.7
+  image: golang:1.12.9

--- a/.test-defs/conformanceTestgrid.yaml
+++ b/.test-defs/conformanceTestgrid.yaml
@@ -55,4 +55,4 @@ spec:
     export E2E_EXPORT_PATH=$TM_EXPORT_PATH &&
     export E2E_KUBECONFIG_PATH=$TM_KUBECONFIG_PATH/shoot.config &&
     go run -mod=vendor ./integration-tests/e2e -cleanUpAfterwards=true
-  image: golang:1.12.7
+  image: golang:1.12.9

--- a/.test-defs/e2eFast.yaml
+++ b/.test-defs/e2eFast.yaml
@@ -39,4 +39,4 @@ spec:
     export E2E_EXPORT_PATH=$TM_EXPORT_PATH &&
     export E2E_KUBECONFIG_PATH=$TM_KUBECONFIG_PATH/shoot.config &&
     go run -mod=vendor ./integration-tests/e2e -cleanUpAfterwards=true
-  image: golang:1.12.7
+  image: golang:1.12.9

--- a/.test-defs/e2eSlow.yaml
+++ b/.test-defs/e2eSlow.yaml
@@ -40,4 +40,4 @@ spec:
     export E2E_EXPORT_PATH=$TM_EXPORT_PATH &&
     export E2E_KUBECONFIG_PATH=$TM_KUBECONFIG_PATH/shoot.config &&
     go run -mod=vendor ./integration-tests/e2e -cleanUpAfterwards=true
-  image: golang:1.12.7
+  image: golang:1.12.9

--- a/.test-defs/e2eUntracked.yaml
+++ b/.test-defs/e2eUntracked.yaml
@@ -46,4 +46,4 @@ spec:
     export E2E_EXPORT_PATH=$TM_EXPORT_PATH &&
     export E2E_KUBECONFIG_PATH=$TM_KUBECONFIG_PATH/shoot.config &&
     go run -mod=vendor ./integration-tests/e2e -cleanUpAfterwards=true
-  image: golang:1.12.7
+  image: golang:1.12.9

--- a/.test-defs/logGardener.yaml
+++ b/.test-defs/logGardener.yaml
@@ -14,30 +14,23 @@
 
 kind: TestDefinition
 metadata:
-  name: tm-scheduler-lock-gardener
+  name: log-gardener
 spec:
   owner: gardener-oq@listserv.sap.com
   recipientsOnFailure:
   - gardener-oq@listserv.sap.com
 
-  description: Wake up a shoot as host from a given cluster pool
+  description: Fetches all logs from gardener components and writes them to the export path
 
-  activeDeadlineSeconds: 10800
+  activeDeadlineSeconds: 2400
 
   config:
   - name: GO111MODULE
     value: "on"
     type: env
-  - type: file
-    name: GARDENER_SERVICE_ACCOUNT
-    path: /tmp/secrets/gardener-service-account.kubeconfig
-    valueFrom:
-      secretKeyRef:
-        name: tm-hosts-gardener
-        key: kubeconfig
 
   command: [bash, -c]
   args:
   - >-
-    go run -mod=vendor ./cmd/hostscheduler lock gardener --id=$TM_TESTRUN_ID --kubeconfig=/tmp/secrets/gardener-service-account.kubeconfig --cloudprovider=$HOST_CLOUDPROVIDER
+    go run -mod=vendor ./cmd/logging --kubeconfig=$TM_KUBECONFIG_PATH/host.config --output=$TM_EXPORT_PATH
   image: golang:1.12.9

--- a/.test-defs/scheduler-lock.yaml
+++ b/.test-defs/scheduler-lock.yaml
@@ -52,4 +52,4 @@ spec:
   args:
   - >-
     go run -mod=vendor ./cmd/hostscheduler lock gke --id=$TM_TESTRUN_ID  --key=/tmp/secrets/gcloud.json --project=$PROJECT --zone=$ZONE
-  image: golang:1.12.7
+  image: golang:1.12.9

--- a/.test-defs/scheduler-release-gardener.yaml
+++ b/.test-defs/scheduler-release-gardener.yaml
@@ -40,4 +40,4 @@ spec:
   args:
   - >-
     go run -mod=vendor ./cmd/hostscheduler release gardener --kubeconfig=/tmp/secrets/gardener-service-account.kubeconfig --clean=$CLEAN
-  image: golang:1.12.7
+  image: golang:1.12.9

--- a/.test-defs/scheduler-release.yaml
+++ b/.test-defs/scheduler-release.yaml
@@ -52,4 +52,4 @@ spec:
   args:
   - >-
     go run -mod=vendor ./cmd/hostscheduler release gke --key=/tmp/secrets/gcloud.json --project=$PROJECT --zone=$ZONE --clean=$CLEAN
-  image: golang:1.12.7
+  image: golang:1.12.9

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 #############      builder       #############
-FROM golang:1.12.0 AS builder
+FROM golang:1.12.9 AS builder
 
 WORKDIR /go/src/github.com/gardener/test-infra
 COPY . .

--- a/cmd/logging/main.go
+++ b/cmd/logging/main.go
@@ -1,0 +1,141 @@
+// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"path"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
+
+	"github.com/gardener/gardener/pkg/operation/common"
+	corev1 "k8s.io/api/core/v1"
+	kubernetesclientset "k8s.io/client-go/kubernetes"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	kubeconfigPath string
+	namespace      string
+	output         string
+)
+
+var (
+	GardenerComponentLabels = map[string]string{
+		"app": "gardener",
+	}
+)
+
+func init() {
+	// configuration flags
+	flag.StringVar(&kubeconfigPath, "kubeconfig", "", "Path to the host cluster kubeconfigPath")
+	flag.StringVar(&namespace, "namespace", common.GardenNamespace, "Namespace of the gardener deployments")
+	flag.StringVar(&output, "output", "", "Logs output directory path")
+}
+
+func main() {
+	flag.Parse()
+	ctx := context.Background()
+	defer ctx.Done()
+
+	if kubeconfigPath == "" {
+		if os.Getenv("KUBECONFIG") == "" {
+			fmt.Println("Kubeconfig is neither defined by commandline --kubeconfig neither by environment variable 'KUBECONFIG'")
+			os.Exit(1)
+		}
+		kubeconfigPath = os.Getenv("KUBECONFIG")
+	}
+
+	// if file does not exist we exit with 0 as this means that gardener wasn't deployed
+	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
+		fmt.Printf("host kubeconfig at %s does not exists\n", kubeconfigPath)
+		os.Exit(1)
+	}
+
+	k8sClient, err := kubernetes.NewClientFromFile("", kubeconfigPath, client.Options{
+		Scheme: kubernetes.ShootScheme,
+	})
+	if err != nil {
+		log.Fatalf("cannot build config from path %s: %s", kubeconfigPath, err.Error())
+	}
+
+	pods := &corev1.PodList{}
+	if err := k8sClient.Client().List(ctx, pods, client.InNamespace(namespace), client.MatchingLabels(GardenerComponentLabels)); err != nil {
+		fmt.Printf("unable to list pods in %s: %s\n", namespace, err.Error())
+		os.Exit(1)
+	}
+
+	var result *multierror.Error
+	for _, pod := range pods.Items {
+		logs, err := getPodLogs(k8sClient.Kubernetes(), pod)
+		if err != nil {
+			result = multierror.Append(result, err)
+			continue
+		}
+
+		fmt.Printf("[%s]\n", pod.Name)
+		fmt.Print(string(logs))
+		fmt.Println("---------------------------------")
+
+		if err := writePodLogs(pod.Name, output, logs); err != nil {
+			result = multierror.Append(result, err)
+		}
+	}
+
+	if result.ErrorOrNil() != nil {
+		fmt.Println(result.Error())
+		os.Exit(1)
+	}
+	fmt.Println("Successfully fetched all logs")
+}
+
+func getPodLogs(client kubernetesclientset.Interface, pod corev1.Pod) ([]byte, error) {
+	req := client.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{})
+	logs, err := req.Stream()
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to get logs from pod %s in namespace %s", pod.Name, pod.Namespace)
+	}
+	defer logs.Close()
+
+	buf := bytes.NewBuffer([]byte{})
+	_, err = io.Copy(buf, logs)
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func writePodLogs(podName, outputPath string, logs []byte) error {
+	if outputPath == "" {
+		return nil
+	}
+	if err := os.MkdirAll(outputPath, os.ModePerm); err != nil {
+		return err
+	}
+	fileName := fmt.Sprintf("%s.log", podName)
+
+	return ioutil.WriteFile(path.Join(outputPath, fileName), logs, os.ModePerm)
+}

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/google/uuid v1.1.0 // indirect
 	github.com/h2non/filetype v1.0.8 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
-	github.com/hashicorp/go-multierror v0.0.0-20180717150148-3d5d8f294aa0 // indirect
+	github.com/hashicorp/go-multierror v0.0.0-20180717150148-3d5d8f294aa0
 	github.com/huandu/xstrings v1.2.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/joho/godotenv v1.3.0

--- a/hack/images/golang/Dockerfile
+++ b/hack/images/golang/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.6 AS ginkgo
+FROM golang:1.12.9 AS ginkgo
 
 RUN  \
   apt-get update \

--- a/pkg/testrunner/result/ingest.go
+++ b/pkg/testrunner/result/ingest.go
@@ -69,7 +69,7 @@ func MarkTestrunsAsIngested(tmClient kubernetes.Interface, tr *tmv1beta1.Testrun
 	tr.Status.Ingested = true
 	err := tmClient.Client().Update(ctx, tr)
 	if err != nil {
-		return fmt.Errorf("Cannot update status off testrun %s in namespace %s: %s", tr.Name, tr.Namespace, err.Error())
+		return fmt.Errorf("unable to update status of testrun %s in namespace %s: %s", tr.Name, tr.Namespace, err.Error())
 	}
 	log.Debugf("Successfully updated status of testrun %s in namespace %s", tr.Name, tr.Namespace)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Added testDefinition to dump logs of gardener system components.
The corresponding pods are chosen by the gardener label `app: gardener`.

Every pod log is then written to a separate file into the `$TM_EXPORT_PATH`

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Added TestDefinition to dump logs of gardener system components.
```
```improvement operator
Updated golang version of TestDefinition to 1.12.9
```
```improvement operator
Updated golang version of Test Machinery to 1.12.9
```