### PR TITLE
Improve testrunner error handling

### DIFF
--- a/cmd/testrunner/cmd/runtestrun/run_testrun.go
+++ b/cmd/testrunner/cmd/runtestrun/run_testrun.go
@@ -87,25 +87,25 @@ var runTestrunCmd = &cobra.Command{
 			log.Fatalf("Testrunner execution disrupted: %s", err.Error())
 		}
 
-		run := []*testrunner.Run{
+		run := testrunner.RunList{
 			{
 				Testrun:  &tr,
 				Metadata: &testrunner.Metadata{},
 			},
 		}
 
-		finishedRuns, err := testrunner.ExecuteTestrun(config, run, testrunNamePrefix)
-		if err != nil {
-			log.Fatalf("Testrunner execution disrupted: %s", err.Error())
+		testrunner.ExecuteTestruns(config, run, testrunNamePrefix)
+		if run.HasErrors() {
+			log.Fatalf("Testrunner execution disrupted")
 		}
 
-		if finishedRuns[0].Testrun.Status.Phase == tmv1beta1.PhaseStatusSuccess {
+		if run[0].Testrun.Status.Phase == tmv1beta1.PhaseStatusSuccess {
 			log.Info("Testrunner successfully finished.")
 		} else {
-			log.Errorf("Testrunner finished with phase %s", finishedRuns[0].Testrun.Status.Phase)
+			log.Errorf("Testrunner finished with phase %s", run[0].Testrun.Status.Phase)
 		}
 
-		fmt.Print(util.PrettyPrintStruct(finishedRuns[0].Testrun.Status))
+		fmt.Print(util.PrettyPrintStruct(run[0].Testrun.Status))
 	},
 }
 

--- a/pkg/testrunner/error/error.go
+++ b/pkg/testrunner/error/error.go
@@ -1,0 +1,80 @@
+// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors
+
+// testrunner specific error reasons
+type TestrunnerReason string
+
+const (
+	// testrunner error is not clear
+	TestrunnerReasonUnknown = ""
+
+	// testrunner ran into a timeout
+	TestrunnerReasonTimeout = "Timeout"
+
+	// testrunner was unable to create the testrun
+	TestrunnerReasonNotCreated = "NotCreated"
+)
+
+type TestrunnerError struct {
+	message string
+	reason  TestrunnerReason
+}
+
+var _ error = &TestrunnerError{}
+
+// Error implements the error interface
+func (e *TestrunnerError) Error() string {
+	return e.message
+}
+
+// New returns a new testrunner error
+func New(reason TestrunnerReason, message string) error {
+	return &TestrunnerError{
+		message: message,
+		reason:  reason,
+	}
+}
+
+// NewTimeoutError returns an error indicating that a timeout occurred
+// during execution of a testrun.
+func NewTimeoutError(message string) error {
+	return New(TestrunnerReasonTimeout, message)
+}
+
+// NewNotCreatedError returns an error indicating that a testrun could not be created
+func NewNotCreatedError(message string) error {
+	return New(TestrunnerReasonNotCreated, message)
+}
+
+// IsTimeout determines if the error indicates a timeout
+func IsTimeout(err error) bool {
+	return reasonForError(err) == TestrunnerReasonTimeout
+}
+
+// IsNotCreated indicates if the error indicates that
+// a testrun could not be created.
+func IsNotCreated(err error) bool {
+	return reasonForError(err) == TestrunnerReasonNotCreated
+}
+
+// reasonForError returns the testrunner reason for a particular error.
+func reasonForError(err error) TestrunnerReason {
+	switch t := err.(type) {
+	case *TestrunnerError:
+		return t.reason
+	}
+	return TestrunnerReasonUnknown
+}

--- a/pkg/testrunner/types.go
+++ b/pkg/testrunner/types.go
@@ -42,6 +42,7 @@ type Config struct {
 type Run struct {
 	Testrun  *tmv1beta1.Testrun
 	Metadata *Metadata
+	Error    error
 }
 
 // RunList represents a list of Runs.

--- a/test/testrunner/run/testrunner_run_test.go
+++ b/test/testrunner/run/testrunner_run_test.go
@@ -82,24 +82,24 @@ var _ = Describe("Testrunner execution tests", func() {
 	Context("testrun", func() {
 		It("should run a single testrun", func() {
 			tr := resources.GetBasicTestrun(namespace, commitSha)
-			run := []*testrunner.Run{
+			run := testrunner.RunList{
 				{
 					Testrun:  tr,
 					Metadata: &testrunner.Metadata{},
 				},
 			}
-			finishedTr, err := testrunner.ExecuteTestrun(&testrunConfig, run, "test-")
-			defer utils.DeleteTestrun(tmClient, finishedTr[0].Testrun)
-			Expect(err).ToNot(HaveOccurred())
+			testrunner.ExecuteTestruns(&testrunConfig, run, "test-")
+			defer utils.DeleteTestrun(tmClient, run[0].Testrun)
+			Expect(run.HasErrors()).To(BeFalse())
 
-			Expect(len(finishedTr)).To(Equal(1))
-			Expect(finishedTr[0].Testrun.Status.Phase).To(Equal(tmv1beta1.PhaseStatusSuccess))
+			Expect(len(run)).To(Equal(1))
+			Expect(run[0].Testrun.Status.Phase).To(Equal(tmv1beta1.PhaseStatusSuccess))
 		})
 
 		It("should run 2 testruns", func() {
 			tr := resources.GetBasicTestrun(namespace, commitSha)
 			tr2 := resources.GetBasicTestrun(namespace, commitSha)
-			run := []*testrunner.Run{
+			run := testrunner.RunList{
 				{
 					Testrun:  tr,
 					Metadata: &testrunner.Metadata{},
@@ -109,14 +109,14 @@ var _ = Describe("Testrunner execution tests", func() {
 					Metadata: &testrunner.Metadata{},
 				},
 			}
-			finishedTr, err := testrunner.ExecuteTestrun(&testrunConfig, run, "test-")
-			defer utils.DeleteTestrun(tmClient, finishedTr[0].Testrun)
-			defer utils.DeleteTestrun(tmClient, finishedTr[1].Testrun)
-			Expect(err).ToNot(HaveOccurred())
+			testrunner.ExecuteTestruns(&testrunConfig, run, "test-")
+			defer utils.DeleteTestrun(tmClient, run[0].Testrun)
+			defer utils.DeleteTestrun(tmClient, run[1].Testrun)
+			Expect(run.HasErrors()).To(BeFalse())
 
-			Expect(len(finishedTr)).To(Equal(2))
-			Expect(finishedTr[0].Testrun.Status.Phase).To(Equal(tmv1beta1.PhaseStatusSuccess))
-			Expect(finishedTr[1].Testrun.Status.Phase).To(Equal(tmv1beta1.PhaseStatusSuccess))
+			Expect(len(run)).To(Equal(2))
+			Expect(run[0].Testrun.Status.Phase).To(Equal(tmv1beta1.PhaseStatusSuccess))
+			Expect(run[1].Testrun.Status.Phase).To(Equal(tmv1beta1.PhaseStatusSuccess))
 		})
 
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
Improves the error handling of testrunner by introducing a own testrunner error struct where the testrunner is now able to decide whether the execution fails due to a execution error or test error.

Therefore, the testrunner only tries to collect results from testruns that are successful or run into a timeout.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Improve error handling of testrunner
```
