### PR TITLE
Flags for machine's image and image version added to run command

### DIFF
--- a/cmd/testrunner/cmd/runtemplate/run_template.go
+++ b/cmd/testrunner/cmd/runtemplate/run_template.go
@@ -16,8 +16,9 @@ package runtemplate
 
 import (
 	"fmt"
-	"github.com/gardener/test-infra/pkg/util"
 	"os"
+
+	"github.com/gardener/test-infra/pkg/util"
 
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/test-infra/pkg/testmachinery"
@@ -60,6 +61,8 @@ var (
 	zone                     string
 	k8sVersion               string
 	machineType              string
+	machineImage             string
+	machineImageVersion      string
 	autoscalerMin            string
 	autoscalerMax            string
 	floatingPoolName         string
@@ -138,6 +141,8 @@ var runCmd = &cobra.Command{
 			Zone:                    zone,
 			K8sVersion:              k8sVersion,
 			MachineType:             machineType,
+			MachineImage:            machineImage,
+			MachineImageVersion:     machineImageVersion,
 			AutoscalerMin:           autoscalerMin,
 			AutoscalerMax:           autoscalerMax,
 			FloatingPoolName:        floatingPoolName,
@@ -245,6 +250,8 @@ func init() {
 	runCmd.Flags().StringVar(&zone, "zone", "", "Zone of the shoot worker nodes. Not required for azure shoots.")
 	runCmd.Flags().StringVar(&k8sVersion, "k8s-version", "", "Kubernetes version of the shoot.")
 	runCmd.Flags().StringVar(&machineType, "machinetype", "", "Machinetype of the shoot's worker nodes.")
+	runCmd.Flags().StringVar(&machineImage, "machine-image", "", "Image of the OS running on the machine")
+	runCmd.Flags().StringVar(&machineImageVersion, "machine-image-version", "", "The version of the machine image")
 	runCmd.Flags().StringVar(&autoscalerMin, "autoscaler-min", "", "Min number of worker nodes.")
 	runCmd.Flags().StringVar(&autoscalerMax, "autoscaler-max", "", "Max number of worker nodes.")
 	runCmd.Flags().StringVar(&floatingPoolName, "floating-pool-name", "", "Floating pool name where the cluster is created. Only needed for Openstack.")

--- a/docs/Testrunner.md
+++ b/docs/Testrunner.md
@@ -8,7 +8,7 @@ Testrunner is an additional component of the Test Machinery that abstracts templ
     - [Component Descriptor](#component-descriptor)
   - [run-template cmd](#run-template)
   - [run-gardener-template cmd](#run-template)
- 
+
 
 <p align="center">
   <img alt= "testrunner overview" src="https://github.com/gardener/test-infra/raw/master/docs/testrunner_overview.png">
@@ -103,6 +103,8 @@ components:
 | zone | | Zone of the shoot workers. <br>:warning: Note that currently only 1 workerpool is supported for testing. | x |
 | k8s-version | | Kubernetes version of the created shoot. | x |
 | machinetype | | Machinetype of the first worker pool. |  |
+| machine-image | | Image of the OS running on the machine. |  |
+| machine-image-version | | The version of the machine image. |  |
 | autoscaler-min | | Minimum number of worker nodes of the first worker pool. | |
 | autoscaler-max | | Maximum number of worker nodes of the first worker pool. | |
 | floating-pool-name | | Floating pool name of the created cluster. Needed for Openstack. | Only required for Openstack clusters|
@@ -170,10 +172,20 @@ spec:
         - name: ZONE
           type: env
           value: {{ .Values.shoot.zone }}
-        {{ if .Values.shoot.machinetype }}
+        {{ if .Values.shoot.machine.type }}
         - name: MACHINE_TYPE
           type: env
-          value: {{ .Values.shoot.machinetype }}
+          value: {{ .Values.shoot.machine.type }}
+        {{ end }}
+        {{ if .Values.shoot.machine.image }}
+        - name: MACHINE_IMAGE
+          type: env
+          value: {{ .Values.shoot.machine.image }}
+        {{ end }}
+        {{ if .Values.shoot.machine.imageVersion }}
+        - name: MACHINE_IMAGE_VERSION
+          type: env
+          value: {{ .Values.shoot.machine.imageVersion }}
         {{ end }}
         {{ if .Values.shoot.autoscalerMin }}
         - name: AUTOSCALER_MIN
@@ -185,7 +197,7 @@ spec:
           type: env
           value: {{ .Values.shoot.autoscalerMax }}
         {{ end }}
-  
+
     - name: tests
       dependsOn: [ create-shoot ]
       definition:
@@ -195,7 +207,7 @@ spec:
       dependsOn: [ tests ]
       definition:
         name: delete-shoot
-  
+
   onExit:
     - name: delete-shoot
       definition:
@@ -260,7 +272,7 @@ metadata:
 spec:
 
   ttlSecondsAfterFinished: 172800 # 2 days
-    
+
   locationSets:
     - name: default
       default: true
@@ -274,7 +286,7 @@ spec:
       - type: git
         repo: https://github.com/gardener/garden-setup.git
         revision: master
-  
+
     - name: upgraded
       locations:
       - type: git

--- a/docs/testrunner/testrunner_run-template.md
+++ b/docs/testrunner/testrunner_run-template.md
@@ -30,6 +30,8 @@ testrunner run-template [flags]
       --landscape string                   Current gardener landscape.
       --loadbalancer-provider string       LoadBalancer Provider like haproxy. Only applicable for Openstack.
       --machinetype string                 Machinetype of the shoot's worker nodes.
+      --machine-image string               Image of the OS running on the machine
+      --machine-image-version string       The version of the machine image
   -n, --namespace string                   Namesapce where the testrun should be deployed. (default "default")
       --output-dir-path string             The filepath where the summary should be written to. (default "./testout")
       --project-name string                Gardener project name of the shoot

--- a/pkg/testrunner/template/render.go
+++ b/pkg/testrunner/template/render.go
@@ -2,13 +2,14 @@ package template
 
 import (
 	"fmt"
+	"io/ioutil"
+
 	"github.com/gardener/gardener/pkg/chartrenderer"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/test-infra/pkg/util"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-	"io/ioutil"
 	"k8s.io/helm/pkg/strvals"
 )
 
@@ -41,15 +42,19 @@ func RenderChart(tmClient kubernetes.Interface, parameters *ShootTestrunParamete
 func RenderSingleChart(renderer chartrenderer.Interface, parameters *ShootTestrunParameters, gardenKubeconfig []byte, version string) ([]*TestrunFile, error) {
 	values := map[string]interface{}{
 		"shoot": map[string]interface{}{
-			"name":                 fmt.Sprintf("%s-%s", parameters.ShootName, util.RandomString(5)),
-			"projectNamespace":     fmt.Sprintf("garden-%s", parameters.ProjectName),
-			"cloudprovider":        parameters.Cloudprovider,
-			"cloudprofile":         parameters.Cloudprofile,
-			"secretBinding":        parameters.SecretBinding,
-			"region":               parameters.Region,
-			"zone":                 parameters.Zone,
-			"k8sVersion":           version,
-			"machinetype":          parameters.MachineType,
+			"name":             fmt.Sprintf("%s-%s", parameters.ShootName, util.RandomString(5)),
+			"projectNamespace": fmt.Sprintf("garden-%s", parameters.ProjectName),
+			"cloudprovider":    parameters.Cloudprovider,
+			"cloudprofile":     parameters.Cloudprofile,
+			"secretBinding":    parameters.SecretBinding,
+			"region":           parameters.Region,
+			"zone":             parameters.Zone,
+			"k8sVersion":       version,
+			"machine": map[string]interface{}{
+				"type":         parameters.MachineType,
+				"image":        parameters.MachineImage,
+				"imageVersion": parameters.MachineImageVersion,
+			},
 			"autoscalerMin":        parameters.AutoscalerMin,
 			"autoscalerMax":        parameters.AutoscalerMax,
 			"floatingPoolName":     parameters.FloatingPoolName,

--- a/pkg/testrunner/template/types.go
+++ b/pkg/testrunner/template/types.go
@@ -33,6 +33,8 @@ type ShootTestrunParameters struct {
 	Zone                    string
 	K8sVersion              string
 	MachineType             string
+	MachineImage            string
+	MachineImageVersion     string
 	AutoscalerMin           string
 	AutoscalerMax           string
 	FloatingPoolName        string


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable users of testrunner template to specify machine image and version trough flags for gardener shoots.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator

```
