### PR TITLE
Keep only versions with newest patch version in getK8sVersionsFromCloudprofile

### DIFF
--- a/pkg/testrunner/template/helper_test.go
+++ b/pkg/testrunner/template/helper_test.go
@@ -1,0 +1,55 @@
+// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package template
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("helper test", func() {
+
+	Context("kubernetes versions", func() {
+		It("should remove old 1.14 version and keep everything else", func() {
+			versions := []string{
+				"1.13.5",
+				"1.14.3",
+				"1.14.4",
+				"1.15.0",
+			}
+
+			Expect(filterPatchVersions(versions)).To(ConsistOf(
+				"1.13.5",
+				"1.14.4",
+				"1.15.0",
+			))
+		})
+
+		It("should remove old 1.14 and 1.13 version", func() {
+			versions := []string{
+				"1.13.0",
+				"1.13.5",
+				"1.14.3",
+				"1.14.4",
+			}
+
+			Expect(filterPatchVersions(versions)).To(ConsistOf(
+				"1.13.5",
+				"1.14.4",
+			))
+		})
+	})
+})
+

--- a/pkg/testrunner/template/template_suite_test.go
+++ b/pkg/testrunner/template/template_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package template
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestTestrunnerTemplate(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Testrunner Template Test Suite")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
If all-k8s-versions is used, run only tests for newest patch version, instead of considering all versions that are listed in cloud profiles.

**Special notes for your reviewer**:
Mainly based on https://github.com/gardener/test-infra/pull/132. 
Thanks to @OlegLoewen for his work on this issue.
Just fixed some minor issue and added unit tests

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Duplicated Minor versions are now filtered.
```
