### PR TITLE
adjust makefile to use new commandline args

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,11 +93,11 @@ mount-local:
 
 .PHONY: run-local
 run-local:
-	@TM_NAMESPACE=${NS} go run cmd/testmachinery-controller/main.go -kubeconfig=${KUBECONFIG} -insecure=true -local=true --dev
+	@TM_NAMESPACE=${NS} go run cmd/testmachinery-controller/main.go --kubeconfig=${KUBECONFIG} --insecure=true --local=true --dev -v=3
 
 .PHONY: run-controller
 run-controller:
-	@TM_NAMESPACE=${NS} TESTDEF_PATH=test/.test-defs go run cmd/testmachinery-controller/main.go -kubeconfig=${KUBECONFIG} -insecure=true --dev
+	@TM_NAMESPACE=${NS} TESTDEF_PATH=test/.test-defs go run cmd/testmachinery-controller/main.go --kubeconfig=${KUBECONFIG} --insecure=true --dev -v=3
 
 .PHONY: install-controller-local
 install-controller-local:


### PR DESCRIPTION
**What this PR does / why we need it*
Adjust makefile to new commandline args.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
