### PR TITLE
Update es index for default exports and fix image urls

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -42,7 +42,7 @@ test-infra:
       steps:
         <<: *ti_test_steps
         integration:
-          image: 'eu.gcr.io/gardener-project/cc/job-image-golang:0.8.0'
+          image: 'eu.gcr.io/gardener-project/cc/job-image-golang:0.10.0'
           depends:
           - publish
     pull-request:
@@ -59,7 +59,7 @@ test-infra:
           execute:
           - ./it-prepare.py
         integration:
-          image: 'eu.gcr.io/gardener-project/cc/job-image-golang:0.8.0'
+          image: 'eu.gcr.io/gardener-project/cc/job-image-golang:0.10.0'
           depends:
           - prepare-test
           - publish

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Test Machinery
 [![Go Report Card](https://goreportcard.com/badge/github.com/gardener/test-infra)](https://goreportcard.com/report/github.com/gardener/test-infra)
 
-![testmachinery diagram overview](https://github.com/gardener/test-infra/raw/master/docs/test_machinary_overview.png)
+![testmachinery diagram overview](docs/testmachinery/test_machinary_overview.png)
 
 
 The Test Machinery is the test infrastructure for the gardener project.

--- a/docs/testmachinery/README.md
+++ b/docs/testmachinery/README.md
@@ -12,7 +12,7 @@
   - [Testrunner](#testrunner)
 - [Local TestMachinery development](#local-testmachinery-development)
 
-![testmachinery diagram overview](https://github.com/gardener/test-infra/raw/master/docs/test_machinary_overview.png)
+![testmachinery diagram overview](test_machinary_overview.png)
 
 
 ## Concept

--- a/pkg/testrunner/elasticsearch/testdata/bulk_no_meta_output
+++ b/pkg/testrunner/elasticsearch/testdata/bulk_no_meta_output
@@ -1,4 +1,4 @@
-{"index":{"_index":"TestDef","_type":"_doc"}}
+{"index":{"_index":"tm-TestDef","_type":"_doc"}}
 {"tm":{"tm_id":"testId"},"test": "bulk_no_1"}
-{"index":{"_index":"TestDef","_type":"_doc"}}
+{"index":{"_index":"tm-TestDef","_type":"_doc"}}
 {"tm":{"tm_id":"testId"},"test": 2}

--- a/pkg/testrunner/elasticsearch/testdata/json_output
+++ b/pkg/testrunner/elasticsearch/testdata/json_output
@@ -1,2 +1,2 @@
-{"index":{"_index":"TestDef","_type":"_doc"}}
+{"index":{"_index":"tm-TestDef","_type":"_doc"}}
 {"tm":{"tm_id":"testId"},"test":"json"}

--- a/test/testrunner/output/testrunner_output_execution_test.go
+++ b/test/testrunner/output/testrunner_output_execution_test.go
@@ -136,7 +136,7 @@ var _ = Describe("Testrunner execution tests", func() {
 		Expect(jsonBody["tm"]).ToNot(BeNil())
 		Expect(jsonBody["tm"].(map[string]interface{})["tr"].(map[string]interface{})["id"]).To(Equal(tr.Name))
 
-		Expect(documents[len(documents)-2]["index"].(map[string]interface{})["_index"]).To(Equal("integration-testdef"))
+		Expect(documents[len(documents)-2]["index"].(map[string]interface{})["_index"]).To(Equal("tm-integration-testdef"))
 	})
 
 	It("should add environment configuration to step metadata", func() {
@@ -185,7 +185,7 @@ var _ = Describe("Testrunner execution tests", func() {
 		Expect(jsonBody["tm"]).ToNot(BeNil())
 		Expect(jsonBody["tm"].(map[string]interface{})["tr"].(map[string]interface{})["id"]).To(Equal(tr.Name))
 
-		Expect(documents[len(documents)-2]["index"].(map[string]interface{})["_index"]).To(Equal("integration-testdef"))
+		Expect(documents[len(documents)-2]["index"].(map[string]interface{})["_index"]).To(Equal("tm-integration-testdef"))
 	})
 
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
The default index for exported json documents that are ingested to ElasticSearch is updated to be now prefixed with `tm-`
```
