### PR TITLE
Refactor gardener test rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,6 @@ temp/
 tmp/
 venv
 
-# Generated testlogs
-tests
-
 # Generated secrets
 assets
 

--- a/README.md
+++ b/README.md
@@ -31,3 +31,5 @@ See [here](docs/testmachinery/GetStarted.md) how new tests can be easily added.
   When the cluster is not needed anymore, the host scheduler cleans and releases the cluster.
 - [**Shoot Telemetry**](cmd/shoot-telemetry)<br>
   A telemetry controller to get granular insights of Shoot apiserver and etcd availability.
+- [**Tests**](docs/tests)
+  Testruns that are rendered by the testrunner or github app

--- a/cmd/testrunner/cmd/cmd.go
+++ b/cmd/testrunner/cmd/cmd.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"github.com/gardener/test-infra/cmd/testrunner/cmd/collect"
 	"github.com/gardener/test-infra/cmd/testrunner/cmd/docs"
+	"github.com/gardener/test-infra/cmd/testrunner/cmd/rungardener"
 	"github.com/gardener/test-infra/cmd/testrunner/cmd/rungardenertemplate"
 	"github.com/gardener/test-infra/cmd/testrunner/cmd/runtemplate"
 	"github.com/gardener/test-infra/cmd/testrunner/cmd/runtestrun"
@@ -57,6 +58,7 @@ func init() {
 	runtemplate.AddCommand(rootCmd)
 	runtestrun.AddCommand(rootCmd)
 	rungardenertemplate.AddCommand(rootCmd)
+	rungardener.AddCommand(rootCmd)
 	collectcmd.AddCommand(rootCmd)
 	docs.AddCommand(rootCmd)
 	versioncmd.AddCommand(rootCmd)

--- a/cmd/testrunner/cmd/rungardener/run.go
+++ b/cmd/testrunner/cmd/rungardener/run.go
@@ -166,7 +166,7 @@ func init() {
 
 	runCmd.Flags().StringVar(&defaultConfig.Shoots.Namespace, "project-namespace", "garden-core", "Specify the shoot namespace where the shoots should be created")
 	runCmd.Flags().StringArrayVar(&defaultConfig.Shoots.KubernetesVersions, "kubernetes-version", []string{}, "Specify the kubernetes version to test")
-	runCmd.Flags().VarP(cmdvalues.NewCloudProviderArrayValue(&defaultConfig.Shoots.CloudProviders), "cloudprovider", "p", "Specify the cloudproviders to test. Must be one of xxx")
+	runCmd.Flags().VarP(cmdvalues.NewCloudProviderArrayValue(&defaultConfig.Shoots.CloudProviders, v1beta1.CloudProviderGCP, v1beta1.CloudProviderGCP, v1beta1.CloudProviderAWS, v1beta1.CloudProviderAzure), "cloudprovider", "p", "Specify the cloudproviders to test. Must be one of xxx")
 
 	runCmd.Flags().StringVarP(&testLabel, "label", "l", string(testmachinery.TestLabelDefault), "Specify test label that should be fetched by the testmachinery")
 	runCmd.Flags().BoolVar(&hibernation, "hibernation", false, "test hibernation")

--- a/cmd/testrunner/cmd/rungardener/run.go
+++ b/cmd/testrunner/cmd/rungardener/run.go
@@ -168,7 +168,7 @@ func init() {
 	runCmd.Flags().StringArrayVar(&defaultConfig.Shoots.KubernetesVersions, "kubernetes-version", []string{}, "Specify the kubernetes version to test")
 	runCmd.Flags().VarP(cmdvalues.NewCloudProviderArrayValue(&defaultConfig.Shoots.CloudProviders), "cloudprovider", "p", "Specify the cloudproviders to test. Must be one of xxx")
 
-	runCmd.Flags().StringVarP(&testLabel, "label", "l", string(testmachinery.TestLabelDefault), "Specify test label tht should be fetched by the testmachinery")
+	runCmd.Flags().StringVarP(&testLabel, "label", "l", string(testmachinery.TestLabelDefault), "Specify test label that should be fetched by the testmachinery")
 	runCmd.Flags().BoolVar(&hibernation, "hibernation", false, "test hibernation")
 
 }

--- a/cmd/testrunner/cmd/rungardener/run.go
+++ b/cmd/testrunner/cmd/rungardener/run.go
@@ -54,7 +54,7 @@ var (
 	hibernation             bool
 )
 
-// AddCommand adds run-testrun to a command.
+// AddCommand adds run-gardener to a command.
 func AddCommand(cmd *cobra.Command) {
 	cmd.AddCommand(runCmd)
 }

--- a/cmd/testrunner/cmd/rungardener/run.go
+++ b/cmd/testrunner/cmd/rungardener/run.go
@@ -166,7 +166,7 @@ func init() {
 
 	runCmd.Flags().StringVar(&defaultConfig.Shoots.Namespace, "project-namespace", "garden-core", "Specify the shoot namespace where the shoots should be created")
 	runCmd.Flags().StringArrayVar(&defaultConfig.Shoots.KubernetesVersions, "kubernetes-version", []string{}, "Specify the kubernetes version to test")
-	runCmd.Flags().VarP(cmdvalues.NewCloudProviderArrayValue(&defaultConfig.Shoots.CloudProviders, v1beta1.CloudProviderGCP, v1beta1.CloudProviderGCP, v1beta1.CloudProviderAWS, v1beta1.CloudProviderAzure), "cloudprovider", "p", "Specify the cloudproviders to test. Must be one of xxx")
+	runCmd.Flags().VarP(cmdvalues.NewCloudProviderArrayValue(&defaultConfig.Shoots.CloudProviders, v1beta1.CloudProviderGCP, v1beta1.CloudProviderGCP, v1beta1.CloudProviderAWS, v1beta1.CloudProviderAzure), "cloudprovider", "p", "Specify the cloudproviders to test.")
 
 	runCmd.Flags().StringVarP(&testLabel, "label", "l", string(testmachinery.TestLabelDefault), "Specify test label that should be fetched by the testmachinery")
 	runCmd.Flags().BoolVar(&hibernation, "hibernation", false, "test hibernation")

--- a/cmd/testrunner/cmd/rungardener/run.go
+++ b/cmd/testrunner/cmd/rungardener/run.go
@@ -61,7 +61,7 @@ func AddCommand(cmd *cobra.Command) {
 
 var runCmd = &cobra.Command{
 	Use:   "run-gardener",
-	Short: "Run the testrunner with a helm template containing testruns",
+	Short: "Run the testrunner with the default gardener test",
 	Aliases: []string{
 		"gardener",
 	},

--- a/cmd/testrunner/cmd/rungardener/run.go
+++ b/cmd/testrunner/cmd/rungardener/run.go
@@ -1,0 +1,174 @@
+// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rungardener
+
+import (
+	"fmt"
+	"github.com/gardener/gardener/pkg/apis/garden/v1beta1"
+	"github.com/gardener/test-infra/pkg/hostscheduler/gardenerscheduler"
+	"github.com/gardener/test-infra/pkg/testmachinery/testrun"
+	"github.com/gardener/test-infra/pkg/testrunner/componentdescriptor"
+	"github.com/gardener/test-infra/pkg/testrunner/renderer"
+	_default "github.com/gardener/test-infra/pkg/testrunner/renderer/default"
+	"github.com/gardener/test-infra/pkg/testrunner/renderer/templates"
+	"github.com/gardener/test-infra/pkg/util/cmdvalues"
+	"os"
+	"time"
+
+	"github.com/gardener/test-infra/pkg/logger"
+	"github.com/gardener/test-infra/pkg/util"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/test-infra/pkg/testmachinery"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/test-infra/pkg/testrunner"
+	"github.com/gardener/test-infra/pkg/testrunner/result"
+	"github.com/spf13/cobra"
+)
+
+var testrunnerConfig = testrunner.Config{}
+var collectConfig = result.Config{}
+
+var defaultConfig = _default.Config{}
+
+var (
+	tmKubeconfigPath string
+	failOnError      bool
+
+	testrunNamePrefix       string
+	componentDescriptorPath string
+	testLabel               string
+	hibernation             bool
+)
+
+// AddCommand adds run-testrun to a command.
+func AddCommand(cmd *cobra.Command) {
+	cmd.AddCommand(runCmd)
+}
+
+var runCmd = &cobra.Command{
+	Use:   "run-gardener",
+	Short: "Run the testrunner with a helm template containing testruns",
+	Aliases: []string{
+		"gardener",
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		var err error
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+		logger.Log.Info("Start testmachinery testrunner")
+
+		components, err := componentdescriptor.GetComponentsFromFile(componentDescriptorPath)
+		if err != nil {
+			logger.Log.Error(err, "unable to render default testrun")
+			os.Exit(1)
+		}
+
+		defaultConfig.Components = components
+		defaultConfig.Namespace = testrunnerConfig.Namespace
+		defaultConfig.Shoots.DefaultTest = templates.TestWithLabels(testLabel)
+		if hibernation {
+			defaultConfig.Shoots.Tests = []renderer.TestsFunc{templates.HibernationLifecycle}
+		}
+
+		tr, err := _default.Render(&defaultConfig)
+		if err != nil {
+			logger.Log.Error(err, "unable to render default testrun")
+			os.Exit(1)
+		}
+
+		runs := testrunner.RunList{
+			&testrunner.Run{
+				Testrun:  tr,
+				Metadata: nil,
+				Error:    nil,
+			},
+		}
+
+		if dryRun {
+			fmt.Print(util.PrettyPrintStruct(tr))
+			if err := testrun.Validate(logger.Log.WithName("validation"), tr); err != nil {
+				fmt.Println(err.Error())
+			}
+			os.Exit(0)
+		}
+
+		testrunnerConfig.TmClient, err = kubernetes.NewClientFromFile("", tmKubeconfigPath, kubernetes.WithClientOptions(client.Options{
+			Scheme: testmachinery.TestMachineryScheme,
+		}))
+		if err != nil {
+			logger.Log.Error(err, "unable to build kubernetes client", "file", tmKubeconfigPath)
+			os.Exit(1)
+		}
+
+		testrunName := fmt.Sprintf("%s-", testrunNamePrefix)
+
+		testrunner.ExecuteTestruns(logger.Log.WithName("Execute"), &testrunnerConfig, runs, testrunName)
+		failed, err := result.Collect(logger.Log.WithName("Collect"), &collectConfig, testrunnerConfig.TmClient, testrunnerConfig.Namespace, runs)
+		if err != nil {
+			logger.Log.Error(err, "unable to collect results")
+			os.Exit(1)
+		}
+
+		result.GenerateNotificationConfigForAlerting(runs.GetTestruns(), collectConfig.ConcourseOnErrorDir)
+
+		logger.Log.Info("Testrunner finished")
+		// Fail when one testrun is failed and we should fail on failed testruns.
+		// Otherwise only fail when the testrun execution is erroneous.
+		if runs.HasErrors() {
+			os.Exit(1)
+		}
+		if failOnError && failed {
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	// configuration flags
+	runCmd.Flags().StringVar(&tmKubeconfigPath, "kubeconfig", os.Getenv("KUBECONFIG"), "Path to the testmachinery cluster kubeconfig")
+	if err := runCmd.MarkFlagFilename("kubeconfig"); err != nil {
+		logger.Log.Error(err, "mark flag filename", "flag", "kubeconfig")
+	}
+	runCmd.Flags().StringVar(&testrunNamePrefix, "testrun-prefix", "default-", "Testrun name prefix which is used to generate a unique testrun name.")
+	runCmd.Flags().StringVarP(&testrunnerConfig.Namespace, "namespace", "n", "default", "Namespace where the testrun should be deployed.")
+	runCmd.Flags().Var(cmdvalues.NewDurationValue(&testrunnerConfig.Timeout, time.Hour), "timeout", "Timout the testrunner to wait for the complete testrun to finish. Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'.")
+	runCmd.Flags().Var(cmdvalues.NewDurationValue(&testrunnerConfig.Interval, 20*time.Second), "interval", "Poll interval of the testrunner to poll for the testrun status. Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'.")
+	runCmd.Flags().BoolVar(&failOnError, "fail-on-error", true, "Testrunners exits with 1 if one testruns failed.")
+
+	runCmd.Flags().StringVar(&collectConfig.OutputDir, "output-dir-path", "./testout", "The filepath where the summary should be written to.")
+	runCmd.Flags().StringVar(&collectConfig.ESConfigName, "es-config-name", "sap_internal", "The elasticsearch secret-server config name.")
+	runCmd.Flags().StringVar(&collectConfig.S3Endpoint, "s3-endpoint", os.Getenv("S3_ENDPOINT"), "S3 endpoint of the testmachinery cluster.")
+	runCmd.Flags().BoolVar(&collectConfig.S3SSL, "s3-ssl", false, "S3 has SSL enabled.")
+	runCmd.Flags().StringVar(&collectConfig.ConcourseOnErrorDir, "concourse-onError-dir", os.Getenv("ON_ERROR_DIR"), "On error dir which is used by Concourse.")
+
+	runCmd.Flags().StringVar(&componentDescriptorPath, "component-descriptor-path", "", "Path to the component descriptor (BOM) of the current landscape.")
+
+	runCmd.Flags().Var(cmdvalues.NewHostProviderValue(&defaultConfig.HostProvider, gardenerscheduler.Name), "hostprovider", "Specify the provider for selecting the base cluster")
+	runCmd.Flags().StringVar(&defaultConfig.GardenSetupRevision, "garden-setup-version", "master", "Specify the garden setup version to setup gardener")
+	runCmd.Flags().Var(cmdvalues.NewCloudProviderValue(&defaultConfig.BaseClusterCloudprovider, v1beta1.CloudProviderGCP, v1beta1.CloudProviderGCP, v1beta1.CloudProviderAWS, v1beta1.CloudProviderAzure),
+		"host-cloudprovider", "Specify the cloudprovider of the host cluster. Optional and only affect gardener base cluster")
+	runCmd.Flags().StringVar(&defaultConfig.Gardener.Version, "gardener-version", "", "Specify the gardener to be deployed by garden setup")
+	runCmd.Flags().StringVar(&defaultConfig.Gardener.ImageTag, "gardener-image", "", "Specify the gardener image tag to be deployed by garden setup")
+	runCmd.Flags().StringVar(&defaultConfig.Gardener.Commit, "gardener-commit", "", "Specify the gardener commit that is deployed by garden setup")
+
+	runCmd.Flags().StringVar(&defaultConfig.Shoots.Namespace, "project-namespace", "garden-core", "Specify the shoot namespace where the shoots should be created")
+	runCmd.Flags().StringArrayVar(&defaultConfig.Shoots.KubernetesVersions, "kubernetes-version", []string{}, "Specify the kubernetes version to test")
+	runCmd.Flags().VarP(cmdvalues.NewCloudProviderArrayValue(&defaultConfig.Shoots.CloudProviders), "cloudprovider", "p", "Specify the cloudproviders to test. Must be one of xxx")
+
+	runCmd.Flags().StringVarP(&testLabel, "label", "l", string(testmachinery.TestLabelDefault), "Specify test label tht should be fetched by the testmachinery")
+	runCmd.Flags().BoolVar(&hibernation, "hibernation", false, "test hibernation")
+
+}

--- a/cmd/testrunner/cmd/rungardenertemplate/run_template.go
+++ b/cmd/testrunner/cmd/rungardenertemplate/run_template.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gardener/test-infra/pkg/logger"
 	"github.com/gardener/test-infra/pkg/util"
 	"os"
+	"time"
 
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/test-infra/pkg/testmachinery"
@@ -68,7 +69,6 @@ var runCmd = &cobra.Command{
 	Short: "Run the testrunner with a helm template containing testruns",
 	Aliases: []string{
 		"run-full",
-		"run-gardener",
 		"run-tmpl-full",
 	},
 	Run: func(cmd *cobra.Command, args []string) {
@@ -87,8 +87,8 @@ var runCmd = &cobra.Command{
 		config := &testrunner.Config{
 			TmClient:  tmClient,
 			Namespace: namespace,
-			Timeout:   timeout,
-			Interval:  interval,
+			Timeout:   time.Duration(timeout) * time.Second,
+			Interval:  time.Duration(interval) * time.Second,
 		}
 
 		rsConfig := &result.Config{

--- a/cmd/testrunner/cmd/runtemplate/run_template.go
+++ b/cmd/testrunner/cmd/runtemplate/run_template.go
@@ -17,6 +17,7 @@ package runtemplate
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/gardener/test-infra/pkg/logger"
 
@@ -100,8 +101,8 @@ var runCmd = &cobra.Command{
 		config := &testrunner.Config{
 			TmClient:  tmClient,
 			Namespace: namespace,
-			Timeout:   timeout,
-			Interval:  interval,
+			Timeout:   time.Duration(timeout) * time.Second,
+			Interval:  time.Duration(interval) * time.Second,
 		}
 
 		rsConfig := &result.Config{
@@ -251,7 +252,7 @@ func init() {
 	runCmd.Flags().StringVar(&autoscalerMin, "autoscaler-min", "", "Min number of worker nodes.")
 	runCmd.Flags().StringVar(&autoscalerMax, "autoscaler-max", "", "Max number of worker nodes.")
 	runCmd.Flags().StringVar(&floatingPoolName, "floating-pool-name", "", "Floating pool name where the cluster is created. Only needed for Openstack.")
-	runCmd.Flags().StringVar(&loadbalancerProvider, "loadbalancer-provider", "", "LoadBalancer Provider like haproxy. Only applicable for Openstack.")
+	runCmd.Flags().StringVar(&loadbalancerProvider, "loadbalancer-provider", "", "LoadBalancer provider like haproxy. Only applicable for Openstack.")
 	runCmd.Flags().StringVar(&componenetDescriptorPath, "component-descriptor-path", "", "Path to the component descriptor (BOM) of the current landscape.")
 	runCmd.Flags().StringVar(&landscape, "landscape", "", "Current gardener landscape.")
 

--- a/cmd/testrunner/cmd/runtestrun/run_testrun.go
+++ b/cmd/testrunner/cmd/runtestrun/run_testrun.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gardener/test-infra/pkg/logger"
 	"github.com/pkg/errors"
 	"os"
+	"time"
 
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/test-infra/pkg/testmachinery"
@@ -72,8 +73,8 @@ var runTestrunCmd = &cobra.Command{
 		config := &testrunner.Config{
 			TmClient:  tmClient,
 			Namespace: namespace,
-			Timeout:   timeout,
-			Interval:  interval,
+			Timeout:   time.Duration(timeout) * time.Second,
+			Interval:  time.Duration(interval) * time.Second,
 		}
 
 		tr, err := util.ParseTestrunFromFile(testrunPath)

--- a/docs/tests/README.md
+++ b/docs/tests/README.md
@@ -1,0 +1,3 @@
+# Tests
+
+- Gardener default test [here](gardener-default.md)

--- a/docs/tests/gardener-default.md
+++ b/docs/tests/gardener-default.md
@@ -1,12 +1,12 @@
 # Default Gardener Test
 
-The default gardener tests a new gardener release or specifc commit.
+The default gardener test tests a new gardener release or specifc commit.
 
 The Testrun is generated in Golang by this [render function](../../pkg/testrunner/renderer/default/default.go).
 This function is used by the testrunner and the github bot to create and run the test.
 
-Th default test consists of the following steps:
-- select a host cluster
+The default test consists of the following steps:
+- select and lock a host cluster
 - create a gardener
 - test shoots
   - create shoot
@@ -16,7 +16,7 @@ Th default test consists of the following steps:
 - release host cluster
 
 This tesflow can be configured to test different shoot flavors and test scenarios.
-The configuration is wrapped by the testrunner and github bot to ease the configuration and set necessecary defaults for specific instlaltions and use cases.
+The configuration is wrapped by the testrunner and github bot to ease the configuration and set necessecary defaults for specific installations and use cases.
 ```golang
 // Config is used to render a default gardener test
 type Config struct {
@@ -62,7 +62,7 @@ type ShootsConfig struct {
 	// Kubernetes versions to test
 	KubernetesVersions []string
 
-	// Cloiudproviders to test
+	// Cloudproviders to test
 	CloudProviders     []gardenv1beta1.CloudProvider
 }
 ```

--- a/docs/tests/gardener-default.md
+++ b/docs/tests/gardener-default.md
@@ -1,0 +1,90 @@
+# Default Gardener Test
+
+The default gardener tests a new gardener release or specifc commit.
+
+The Testrun is generated in Golang by this [render function](../../pkg/testrunner/renderer/default/default.go).
+This function is used by the testrunner and the github bot to create and run the test.
+
+Th default test consists of the following steps:
+- select a host cluster
+- create a gardener
+- test shoots
+  - create shoot
+  - test shoot
+  - delete shoot
+- delete gardener
+- release host cluster
+
+This tesflow can be configured to test different shoot flavors and test scenarios.
+The configuration is wrapped by the testrunner and github bot to ease the configuration and set necessecary defaults for specific instlaltions and use cases.
+```golang
+// Config is used to render a default gardener test
+type Config struct {
+	// Namespace of the testrun
+	Namespace string
+
+	// Provider where the host clusters are selected from
+	HostProvider hostscheduler.Provider
+
+	// CloudProvider of the base cluster (has to be specified to install the correct credentials and cloudprofiles for the soil/seeds)
+	BaseClusterCloudprovider gardenv1beta1.CloudProvider
+
+	// Revision for the gardensetup repo that i sused to install gardener
+	GardenSetupRevision string
+
+	// List of components (by default read from a component_descriptor) that are added as locations
+	Components componentdescriptor.ComponentList
+
+	// Gardener specific configuration
+	Gardener templates.GardenerConfig
+
+	// Gardener tests that do not depend on shoots and run after the shoot tests
+	Tests renderer.TestsFunc
+
+	// Shoot test flavor configuration
+	Shoots ShootsConfig
+}
+
+// ShootsConfig describes the flavors of the shoots that are created by the test.
+// The resulting shoot test matrix consists of
+// - shoot tests for all specified cloudproviders with all specified kubernets with the default test
+// - shoot tests for all specified cloudproviders for all specified tests
+type ShootsConfig struct {
+	// Shoot/Project namespace where the shoots are created
+	Namespace          string
+
+	// Default test that is used for all cloudprovider and kubernetes flavors.
+	DefaultTest        renderer.TestsFunc
+
+	// Specific tests that get their own shoot per cloudprovider and run in parallel to the default tests
+	Tests              []renderer.TestsFunc
+
+	// Kubernetes versions to test
+	KubernetesVersions []string
+
+	// Cloiudproviders to test
+	CloudProviders     []gardenv1beta1.CloudProvider
+}
+```
+
+<img src='https://g.gravizo.com/svg?
+ digraph G {
+    node [shape=record];
+    getHost [label="lock host", fillcolor=darkolivegreen1, style=filled];
+    releaseHost [label="release host", fillcolor=darkolivegreen1, style=filled];
+    createGardener [label="create gardener", fillcolor=darkolivegreen1, style=filled];
+    deleteGardener [label="delete gardener", fillcolor=darkolivegreen1, style=filled];
+    createShoot [label="create shoot"];
+    deleteShoot [label="delete shoot"];
+    createHibernatedShoot [label="create shoot"];
+    deleteHibernatedShoot [label="delete shoot"];
+    wakeup [label="wake up"];
+    hibernate1 [label="hibernate"];
+    hibernate2 [label="hibernate"];
+    gardenerIT [label="gardener integration tests"];
+    getHost -> createGardener;
+    createGardener -> createShoot -> "test" -> deleteShoot -> gardenerIT;
+    createGardener -> createHibernatedShoot -> hibernate1 -> wakeup -> hibernate2 -> deleteHibernatedShoot -> gardenerIT;
+    gardenerIT -> deleteGardener -> releaseHost
+ }
+'/>

--- a/pkg/hostscheduler/cmd.go
+++ b/pkg/hostscheduler/cmd.go
@@ -59,7 +59,7 @@ func copyCommand(cmd cobra.Command) *cobra.Command {
 // CommandFromRegistration generates the command of a scheduler registration with all its subcommands.
 func CommandFromRegistration(r Registration) (*cobra.Command, error) {
 	cmd := &cobra.Command{
-		Use:   r.Name(),
+		Use:   string(r.Name()),
 		Short: r.Description(),
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			if cmd.Parent() != nil && cmd.Parent().PersistentPreRun != nil {

--- a/pkg/hostscheduler/gardenerscheduler/registration.go
+++ b/pkg/hostscheduler/gardenerscheduler/registration.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	Name                                         = "gardener"
+	Name             hostscheduler.Provider      = "gardener"
 	CloudProviderAll gardenv1beta1.CloudProvider = "all"
 )
 
@@ -41,7 +41,7 @@ var Register hostscheduler.Register = func(m *hostscheduler.Registrations) {
 	})
 }
 
-func (r *registration) Name() string {
+func (r *registration) Name() hostscheduler.Provider {
 	return Name
 }
 func (r *registration) Description() string {
@@ -59,7 +59,7 @@ func (r *registration) RegisterFlags(flagset *flag.FlagSet) {
 }
 
 func (r *registration) PreRun(cmd *cobra.Command, args []string) error {
-	r.scheduler.log = logger.Log.WithName(r.Name())
+	r.scheduler.log = logger.Log.WithName(string(r.Name()))
 
 	if r.kubeconfigPath == "" {
 		return errors.New("No kubeconfig defined")

--- a/pkg/hostscheduler/gkescheduler/registration.go
+++ b/pkg/hostscheduler/gkescheduler/registration.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	Name = "gke"
+	Name hostscheduler.Provider = "gke"
 )
 
 var Register hostscheduler.Register = func(m *hostscheduler.Registrations) {
@@ -38,7 +38,7 @@ var Register hostscheduler.Register = func(m *hostscheduler.Registrations) {
 	})
 }
 
-func (r *registration) Name() string {
+func (r *registration) Name() hostscheduler.Provider {
 	return Name
 }
 func (r *registration) Description() string {
@@ -59,7 +59,7 @@ func (r *registration) RegisterFlags(flagset *flag.FlagSet) {
 }
 
 func (r *registration) PreRun(cmd *cobra.Command, args []string) error {
-	r.scheduler.log = logger.Log.WithName(r.Name())
+	r.scheduler.log = logger.Log.WithName(string(r.Name()))
 
 	if r.gcloudkeyFile == "" {
 		return errors.New("No gcloud key file defined")

--- a/pkg/hostscheduler/types.go
+++ b/pkg/hostscheduler/types.go
@@ -19,6 +19,8 @@ import (
 	flag "github.com/spf13/pflag"
 )
 
+type Provider string
+
 // Interface is the hostscheduler interface.
 // Hostscheduler functions are designed to register their function scoped flags
 // and return a SchedulerFunc that is executed with corresponding subcommand.
@@ -36,7 +38,7 @@ type SchedulerFunc = func(ctx context.Context) error
 
 // Registration represents the registration with metadata of a hostscheduler
 type Registration interface {
-	Name() string
+	Name() Provider
 	Description() string
 	PreRun(cmd *cobra.Command, args []string) error
 	RegisterFlags(flagset *flag.FlagSet)

--- a/pkg/testmachinery/labels.go
+++ b/pkg/testmachinery/labels.go
@@ -1,0 +1,32 @@
+// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testmachinery
+
+type TestLabel string
+
+const (
+	// TestLabelDefault are tests that are graduated to GA but are not a release blocker
+	TestLabelShoot TestLabel = "shoot"
+
+	// TestLabelDefault are tests that are graduated to GA but are not a release blocker
+	TestLabelDefault TestLabel = "default"
+
+	// TestLabelRelease are tests that are graduated GA and release blocker
+	TestLabelRelease TestLabel = "release"
+
+	// TestLabelBeta are tests that are in beta which means that they are currently unstable
+	// but will be promoted to GA someday
+	TestLabelBeta TestLabel = "beta"
+)

--- a/pkg/testmachinery/labels.go
+++ b/pkg/testmachinery/labels.go
@@ -17,8 +17,11 @@ package testmachinery
 type TestLabel string
 
 const (
-	// TestLabelDefault are tests that are graduated to GA but are not a release blocker
+	// TestLabelShoot are tests that are meant to test a shoot
 	TestLabelShoot TestLabel = "shoot"
+
+	// TestLabelGardener are tests that are meant to test gardener and do not rely on a shoot.
+	TestLabelGardener TestLabel = "gardener"
 
 	// TestLabelDefault are tests that are graduated to GA but are not a release blocker
 	TestLabelDefault TestLabel = "default"

--- a/pkg/testrunner/renderer/default/default.go
+++ b/pkg/testrunner/renderer/default/default.go
@@ -62,19 +62,19 @@ type Config struct {
 // - shoot tests for all specified cloudproviders for all specified tests
 type ShootsConfig struct {
 	// Shoot/Project namespace where the shoots are created
-	Namespace          string
+	Namespace string
 
 	// Default test that is used for all cloudprovider and kubernetes flavors.
-	DefaultTest        renderer.TestsFunc
+	DefaultTest renderer.TestsFunc
 
 	// Specific tests that get their own shoot per cloudprovider and run in parallel to the default tests
-	Tests              []renderer.TestsFunc
+	Tests []renderer.TestsFunc
 
 	// Kubernetes versions to test
 	KubernetesVersions []string
 
 	// Cloiudproviders to test
-	CloudProviders     []gardenv1beta1.CloudProvider
+	CloudProviders []gardenv1beta1.CloudProvider
 }
 
 // Render renders a gardener default test which consists of

--- a/pkg/testrunner/renderer/default/default.go
+++ b/pkg/testrunner/renderer/default/default.go
@@ -1,0 +1,160 @@
+// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package _default
+
+import (
+	"fmt"
+	"github.com/Masterminds/semver"
+	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
+	"github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
+	"github.com/gardener/test-infra/pkg/hostscheduler"
+	"github.com/gardener/test-infra/pkg/hostscheduler/gkescheduler"
+	"github.com/gardener/test-infra/pkg/testrunner/componentdescriptor"
+	"github.com/gardener/test-infra/pkg/testrunner/renderer"
+	"github.com/gardener/test-infra/pkg/testrunner/renderer/templates"
+	"github.com/gardener/test-infra/pkg/util"
+	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
+)
+
+// Config is used to render a default gardener test
+type Config struct {
+	// Namespace of the testrun
+	Namespace string
+
+	// Provider where the host clusters are selected from
+	HostProvider hostscheduler.Provider
+
+	// CloudProvider of the base cluster (has to be specified to install the correct credentials and cloudprofiles for the soil/seeds)
+	BaseClusterCloudprovider gardenv1beta1.CloudProvider
+
+	// Revision for the gardensetup repo that i sused to install gardener
+	GardenSetupRevision string
+
+	// List of components (by default read from a component_descriptor) that are added as locations
+	Components componentdescriptor.ComponentList
+
+	// Gardener specific configuration
+	Gardener templates.GardenerConfig
+
+	// Gardener tests that do not depend on shoots and run after the shoot tests
+	Tests renderer.TestsFunc
+
+	// Shoot test flavor configuration
+	Shoots ShootsConfig
+}
+
+// ShootsConfig describes the flavors of the shoots that are created by the test.
+// The resulting shoot test matrix consists of
+// - shoot tests for all specified cloudproviders with all specified kubernets with the default test
+// - shoot tests for all specified cloudproviders for all specified tests
+type ShootsConfig struct {
+	// Shoot/Project namespace where the shoots are created
+	Namespace          string
+
+	// Default test that is used for all cloudprovider and kubernetes flavors.
+	DefaultTest        renderer.TestsFunc
+
+	// Specific tests that get their own shoot per cloudprovider and run in parallel to the default tests
+	Tests              []renderer.TestsFunc
+
+	// Kubernetes versions to test
+	KubernetesVersions []string
+
+	// Cloiudproviders to test
+	CloudProviders     []gardenv1beta1.CloudProvider
+}
+
+// Render renders a gardener default test which consists of
+// - lock host
+// - create gardener (with garden-setup)
+// - create shoots in different flavors (cloudprovider, k8s versions)
+// - test shoots with different tests that can be specified by a tests function
+// - delete shoots
+// - delete gardener
+// - release host
+func Render(cfg *Config) (*v1beta1.Testrun, error) {
+	if cfg.HostProvider == gkescheduler.Name {
+		cfg.BaseClusterCloudprovider = gardenv1beta1.CloudProviderGCP
+	}
+
+	shoots := make([]*shoot, 0)
+	for _, cp := range cfg.Shoots.CloudProviders {
+		for _, v := range cfg.Shoots.KubernetesVersions {
+			version, err := semver.NewVersion(v)
+			if err != nil {
+				return nil, err
+			}
+			shoots = append(shoots, &shoot{
+				Type:      cp,
+				Suffix:    fmt.Sprintf("%s-%d", cp, version.Minor()),
+				TestsFunc: cfg.Shoots.DefaultTest,
+				Config: &templates.CreateShootConfig{
+					ShootName:  fmt.Sprintf("%s-%s", cp, util.RandomString(3)),
+					Namespace:  cfg.Shoots.Namespace,
+					K8sVersion: v,
+				},
+			})
+		}
+		for _, test := range cfg.Shoots.Tests {
+			shoots = append(shoots, &shoot{
+				Type:      cp,
+				Suffix:    fmt.Sprintf("%s-%s", cp, util.RandomString(3)),
+				TestsFunc: test,
+				Config: &templates.CreateShootConfig{
+					ShootName:  fmt.Sprintf("%s-%s", cp, util.RandomString(3)),
+					Namespace:  cfg.Shoots.Namespace,
+					K8sVersion: cfg.Shoots.KubernetesVersions[0],
+				},
+			})
+		}
+	}
+
+	tr, err := testrun(cfg, shoots)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := renderer.AddBOMLocationsToTestrun(tr, "default", cfg.Components, true); err != nil {
+		return nil, err
+	}
+	return tr, nil
+}
+
+// Validate validates the testrun render config for the default template
+func Validate(cfg *Config) error {
+	if cfg == nil {
+		return errors.New("config needs to be defined")
+	}
+
+	var result *multierror.Error
+	if cfg.HostProvider == "" {
+		result = multierror.Append(result, errors.New("a host provider needs to be provided"))
+	}
+	if cfg.BaseClusterCloudprovider == "" {
+		result = multierror.Append(result, errors.New("the cloudprovider of the hostcluster needs to be defined"))
+	}
+	if cfg.Shoots.DefaultTest == nil {
+		result = multierror.Append(result, errors.New("a default test needs to be defined"))
+	}
+	if len(cfg.Shoots.KubernetesVersions) == 0 {
+		result = multierror.Append(result, errors.New("at least one kubernetes version has to be defined"))
+	}
+	if cfg.Shoots.Namespace == "" {
+		result = multierror.Append(result, errors.New("the shoot project namespace has to be defined"))
+	}
+
+	return util.ReturnMultiError(result)
+}

--- a/pkg/testrunner/renderer/default/default.go
+++ b/pkg/testrunner/renderer/default/default.go
@@ -64,7 +64,7 @@ type ShootsConfig struct {
 	// Shoot/Project namespace where the shoots are created
 	Namespace string
 
-	// Default test that is used for all cloudprovider and kubernetes flavors.
+	// Default test that is used for all cloudproviders and kubernetes flavors.
 	DefaultTest renderer.TestsFunc
 
 	// Specific tests that get their own shoot per cloudprovider and run in parallel to the default tests

--- a/pkg/testrunner/renderer/default/testrun.go
+++ b/pkg/testrunner/renderer/default/testrun.go
@@ -1,0 +1,107 @@
+// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package _default
+
+import (
+	"fmt"
+	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
+	"github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
+	"github.com/gardener/test-infra/pkg/testrunner/renderer"
+	"github.com/gardener/test-infra/pkg/testrunner/renderer/templates"
+	"github.com/gardener/test-infra/pkg/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type shoot struct {
+	Type      gardenv1beta1.CloudProvider
+	Suffix    string
+	Config    *templates.CreateShootConfig
+	TestsFunc renderer.TestsFunc
+}
+
+func testrun(cfg *Config, shoots []*shoot) (*v1beta1.Testrun, error) {
+	gsLocationName := "gs"
+	prepareHostCluster := templates.GetStepLockHost(cfg.HostProvider, cfg.BaseClusterCloudprovider)
+	createGardener, err := templates.GetStepCreateGardener(gsLocationName, []string{prepareHostCluster.Name}, cfg.BaseClusterCloudprovider, cfg.Shoots.KubernetesVersions, cfg.Gardener)
+	if err != nil {
+		return nil, err
+	}
+
+	tr := &v1beta1.Testrun{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: cfg.Namespace,
+		},
+
+		Spec: v1beta1.TestrunSpec{
+			LocationSets: []v1beta1.LocationSet{
+				templates.TestInfraLocation,
+				templates.GetGardenSetupLocation(gsLocationName, cfg.GardenSetupRevision),
+			},
+			Config: []v1beta1.ConfigElement{
+				templates.GetConfigGardenerPrefix(),
+			},
+			TestFlow: v1beta1.TestFlow{
+				&prepareHostCluster,
+				&createGardener,
+			},
+		},
+	}
+
+	deps := make([]string, len(shoots))
+	for i, shootConfig := range shoots {
+		steps, err := GetShootTest(shootConfig, []string{createGardener.Name})
+		if err != nil {
+			return nil, err
+		}
+
+		tr.Spec.TestFlow = append(tr.Spec.TestFlow, steps...)
+		deps[i] = steps[len(steps)-1].Name
+	}
+
+	// add gardener tests
+	if cfg.Tests != nil {
+		var gardenerIntegrationTests []*v1beta1.DAGStep
+		gardenerIntegrationTests, deps, err = cfg.Tests(fmt.Sprintf("gardener-it-%s-", util.RandomString(3)), deps)
+		if err != nil {
+			return nil, err
+		}
+		tr.Spec.TestFlow = append(tr.Spec.TestFlow, gardenerIntegrationTests...)
+	}
+
+	deleteGardener := templates.GetStepDeleteGardener(&createGardener, gsLocationName, deps)
+	releaseHostCluster := templates.GetStepReleaseHost(cfg.HostProvider, []string{deleteGardener.Name}, false)
+	tr.Spec.TestFlow = append(tr.Spec.TestFlow, &deleteGardener, &releaseHostCluster)
+
+	tr.Spec.OnExit = templates.GetExitTestFlow(cfg.HostProvider, gsLocationName, &createGardener)
+
+	return tr, nil
+}
+
+// GetShootTest creates one shoot test for a config.
+// This test consists of these test steps:
+// - create-shoot
+// - tests
+// - delete-shoot
+func GetShootTest(config *shoot, dependencies []string) ([]*v1beta1.DAGStep, error) {
+	createShootStep, err := templates.GetStepCreateShoot(config.Type, fmt.Sprintf("create-%s", config.Suffix), dependencies, config.Config)
+	if err != nil {
+		return nil, err
+	}
+	//defaultTestStep := templates.GetTestStepWithLabels(fmt.Sprintf("tests-%s", config.Suffix), []string{createShootStep.Name}, config.TestLabel, string(testmachinery.TestLabelShoot))
+	tests, testDep, err := config.TestsFunc(fmt.Sprintf("tests-%s", config.Suffix), []string{createShootStep.Name})
+	deleteShootStep := templates.GetStepDeleteShoot(fmt.Sprintf("delete-%s", config.Suffix), createShootStep.Name, config.Config.ShootName, testDep)
+
+	return append([]*v1beta1.DAGStep{&createShootStep, &deleteShootStep}, tests...), nil
+}

--- a/pkg/testrunner/renderer/renderer.go
+++ b/pkg/testrunner/renderer/renderer.go
@@ -1,0 +1,74 @@
+// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package renderer
+
+import (
+	"fmt"
+	tmv1beta1 "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
+	"github.com/gardener/test-infra/pkg/testrunner/componentdescriptor"
+	"github.com/pkg/errors"
+	"strings"
+)
+
+// AddBOMLocationsToTestrun adds component descriptor repositories as location to location sets
+func AddBOMLocationsToTestrun(tr *tmv1beta1.Testrun, locationSetName string, components []*componentdescriptor.Component, useAsDefault bool) error {
+	if tr == nil || components == nil {
+		return nil
+	}
+
+	bomLocations := make([]tmv1beta1.TestLocation, 0)
+	for _, component := range components {
+		bomLocations = append(bomLocations, tmv1beta1.TestLocation{
+			Type:     tmv1beta1.LocationTypeGit,
+			Repo:     fmt.Sprintf("https://%s", component.Name),
+			Revision: GetRevisionFromVersion(component.Version),
+		})
+	}
+
+	// check if the locationSet already exists
+	for i, set := range tr.Spec.LocationSets {
+		if set.Name == locationSetName {
+			set.Locations = append(bomLocations, set.Locations...)
+			tr.Spec.LocationSets[i] = set
+			tr.Spec.TestLocations = nil
+			return nil
+		}
+		if useAsDefault && set.Default {
+			return errors.New("a default location is already defined")
+		}
+	}
+
+	// if old locations exist we migrate them to the new locationSet form
+	existingLocations := tr.Spec.TestLocations
+	tr.Spec.LocationSets = append(tr.Spec.LocationSets,
+		tmv1beta1.LocationSet{
+			Name:      locationSetName,
+			Default:   useAsDefault,
+			Locations: append(bomLocations, existingLocations...),
+		},
+	)
+	tr.Spec.TestLocations = nil
+
+	return nil
+}
+
+// GetRevisionFromVersion parses the version of a component and returns its revision if applicable.
+func GetRevisionFromVersion(version string) string {
+	if strings.Contains(version, "dev") {
+		splitVersion := strings.Split(version, "-")
+		return splitVersion[len(splitVersion)-1]
+	}
+	return version
+}

--- a/pkg/testrunner/renderer/templates/configs.go
+++ b/pkg/testrunner/renderer/templates/configs.go
@@ -1,0 +1,29 @@
+// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package templates
+
+import (
+	"github.com/gardener/test-infra/pkg/util"
+
+	"github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
+)
+
+func GetConfigGardenerPrefix() v1beta1.ConfigElement {
+	return v1beta1.ConfigElement{
+		Type:  v1beta1.ConfigTypeEnv,
+		Name:  "GARDENER_PREFIX",
+		Value: util.RandomString(5),
+	}
+}

--- a/pkg/testrunner/renderer/templates/gardensetup.go
+++ b/pkg/testrunner/renderer/templates/gardensetup.go
@@ -1,0 +1,219 @@
+// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package templates
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
+	"github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
+	"github.com/gardener/test-infra/pkg/util/strconf"
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+)
+
+const (
+	GardenCredentialsSecretName = "garden-test"
+)
+
+type GardenerConfig struct {
+	Version string
+
+	ImageTag string
+	Commit   string
+}
+
+func GetStepCreateGardener(locationSet string, dependencies []string, baseClusterCloudprovider gardenv1beta1.CloudProvider, kubernetesVersions []string, cfg GardenerConfig) (v1beta1.DAGStep, error) {
+	stepConfig, err := AppendGardenerConfig(GetCreateGardenerConfig(baseClusterCloudprovider), cfg)
+	if err != nil {
+		return v1beta1.DAGStep{}, err
+	}
+	stepConfig, err = AppendKubernetesVersionConfig(stepConfig, kubernetesVersions)
+	if err != nil {
+		return v1beta1.DAGStep{}, err
+	}
+	return v1beta1.DAGStep{
+		Name: "create-garden",
+		Definition: v1beta1.StepDefinition{
+			Name:        "create-garden",
+			LocationSet: &locationSet,
+			Config:      stepConfig,
+		},
+		UseGlobalArtifacts: false,
+		DependsOn:          dependencies,
+	}, nil
+}
+
+func GetStepDeleteGardener(createGardenStep *v1beta1.DAGStep, locationSet string, dependencies []string) v1beta1.DAGStep {
+	return v1beta1.DAGStep{
+		Name: "delete-garden",
+		Definition: v1beta1.StepDefinition{
+			Name:        "delete-garden",
+			LocationSet: &locationSet,
+			Config:      createGardenStep.Definition.Config,
+		},
+		UseGlobalArtifacts: false,
+		ArtifactsFrom:      createGardenStep.Name,
+		DependsOn:          dependencies,
+	}
+}
+
+func AppendGardenerConfig(stepConfig []v1beta1.ConfigElement, cfg GardenerConfig) ([]v1beta1.ConfigElement, error) {
+	if cfg.Version == "" && cfg.ImageTag == "" && cfg.Commit == "" {
+		return stepConfig, nil
+	}
+
+	if cfg.Version != "" {
+		return append(stepConfig, v1beta1.ConfigElement{
+			Type:  v1beta1.ConfigTypeEnv,
+			Name:  "GARDENER_VERSION",
+			Value: cfg.Version,
+		}), nil
+	}
+
+	if cfg.ImageTag != "" && cfg.Commit == "" {
+		return nil, errors.New("gardener commit has to be defined")
+	}
+	if cfg.ImageTag == "" && cfg.Commit != "" {
+		return nil, errors.New("gardener image has to be defined")
+	}
+
+	return append(stepConfig, v1beta1.ConfigElement{
+		Type:  v1beta1.ConfigTypeEnv,
+		Name:  "GARDENER_IMAGE_TAG",
+		Value: cfg.ImageTag,
+	},
+		v1beta1.ConfigElement{
+			Type:  v1beta1.ConfigTypeEnv,
+			Name:  "GARDENER_COMMIT",
+			Value: cfg.Commit,
+		}), nil
+
+}
+
+func AppendKubernetesVersionConfig(stepConfig []v1beta1.ConfigElement, versions []string) ([]v1beta1.ConfigElement, error) {
+	private := true
+	kubernetesConstraint := gardenv1beta1.KubernetesConstraints{
+		OfferedVersions: make([]gardenv1beta1.KubernetesVersion, len(versions)),
+	}
+	for i, version := range versions {
+		kubernetesConstraint.OfferedVersions[i] = gardenv1beta1.KubernetesVersion{
+			Version: version,
+		}
+	}
+
+	rawVersions, err := json.Marshal(kubernetesConstraint)
+	if err != nil {
+		return nil, err
+	}
+	b64Versions := base64.RawStdEncoding.EncodeToString(rawVersions)
+
+	return append(stepConfig, v1beta1.ConfigElement{
+		Type:    v1beta1.ConfigTypeFile,
+		Name:    "K8S_VERSIONS",
+		Path:    "/tm/gs/kubernetes_versions.json",
+		Value:   b64Versions,
+		Private: &private,
+	}), nil
+}
+
+func GetCreateGardenerConfig(cloudprovider gardenv1beta1.CloudProvider) []v1beta1.ConfigElement {
+	private := true
+	return []v1beta1.ConfigElement{
+		{
+			Type:  v1beta1.ConfigTypeEnv,
+			Name:  "BASE_CLOUDPROVIDER",
+			Value: string(cloudprovider),
+		},
+		{
+			Type:    v1beta1.ConfigTypeFile,
+			Name:    "gcloud",
+			Private: &private,
+			Path:    "/tmp/garden/gcloud.json",
+			ValueFrom: &strconf.ConfigSource{
+				SecretKeyRef: &v1.SecretKeySelector{
+					LocalObjectReference: v1.LocalObjectReference{Name: GardenCredentialsSecretName},
+					Key:                  "gcloud.json",
+				},
+			},
+		},
+		{
+			Type:    v1beta1.ConfigTypeEnv,
+			Name:    "ACCESS_KEY_ID",
+			Private: &private,
+			ValueFrom: &strconf.ConfigSource{
+				SecretKeyRef: &v1.SecretKeySelector{
+					LocalObjectReference: v1.LocalObjectReference{Name: GardenCredentialsSecretName},
+					Key:                  "accessKeyID",
+				},
+			},
+		},
+		{
+			Type:    v1beta1.ConfigTypeEnv,
+			Name:    "SECRET_ACCESS_KEY_ID",
+			Private: &private,
+			ValueFrom: &strconf.ConfigSource{
+				SecretKeyRef: &v1.SecretKeySelector{
+					LocalObjectReference: v1.LocalObjectReference{Name: GardenCredentialsSecretName},
+					Key:                  "secretAccessKey",
+				},
+			},
+		},
+		{
+			Type:    v1beta1.ConfigTypeEnv,
+			Name:    "AZ_CLIENT_ID",
+			Private: &private,
+			ValueFrom: &strconf.ConfigSource{
+				SecretKeyRef: &v1.SecretKeySelector{
+					LocalObjectReference: v1.LocalObjectReference{Name: GardenCredentialsSecretName},
+					Key:                  "clientID",
+				},
+			},
+		},
+		{
+			Type:    v1beta1.ConfigTypeEnv,
+			Name:    "AZ_CLIENT_SECRET",
+			Private: &private,
+			ValueFrom: &strconf.ConfigSource{
+				SecretKeyRef: &v1.SecretKeySelector{
+					LocalObjectReference: v1.LocalObjectReference{Name: GardenCredentialsSecretName},
+					Key:                  "clientSecret",
+				},
+			},
+		},
+		{
+			Type:    v1beta1.ConfigTypeEnv,
+			Name:    "AZ_SUBSCRIPTION_ID",
+			Private: &private,
+			ValueFrom: &strconf.ConfigSource{
+				SecretKeyRef: &v1.SecretKeySelector{
+					LocalObjectReference: v1.LocalObjectReference{Name: GardenCredentialsSecretName},
+					Key:                  "subscriptionID",
+				},
+			},
+		},
+		{
+			Type:    v1beta1.ConfigTypeEnv,
+			Name:    "AZ_TENANT_ID",
+			Private: &private,
+			ValueFrom: &strconf.ConfigSource{
+				SecretKeyRef: &v1.SecretKeySelector{
+					LocalObjectReference: v1.LocalObjectReference{Name: GardenCredentialsSecretName},
+					Key:                  "tenantID",
+				},
+			},
+		},
+	}
+}

--- a/pkg/testrunner/renderer/templates/shoots.go
+++ b/pkg/testrunner/renderer/templates/shoots.go
@@ -1,0 +1,211 @@
+// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package templates
+
+import (
+	"fmt"
+	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
+	"github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
+)
+
+const (
+	ConfigSeedName  = "SEED"
+	ConfigSeedValue = "base"
+
+	ConfigShootName            = "SHOOT_NAME"
+	ConfigProjectNamespaceName = "PROJECT_NAMESPACE"
+	ConfigK8sVersionName       = "K8S_VERSION"
+	ConfigCloudproviderName    = "CLOUDPROVIDER"
+	ConfigCloudprofileName     = "CLOUDPROFILE"
+	ConfigSecretBindingName    = "SECRET_BINDING"
+	ConfigRegionName           = "REGION"
+	ConfigZoneName             = "ZONE"
+)
+
+// CreateShootConfig describes the configuration for a create-shoot step
+type CreateShootConfig struct {
+	ShootName  string
+	Namespace  string
+	K8sVersion string
+}
+
+// GetStepCreateShoot generates the shoot creation step for a specific cloudprovider
+func GetStepCreateShoot(cloudprovider gardenv1beta1.CloudProvider, name string, dependencies []string, cfg *CreateShootConfig) (v1beta1.DAGStep, error) {
+	stepConfig := defaultShootConfig(cfg)
+	switch cloudprovider {
+	case gardenv1beta1.CloudProviderAWS:
+		if name == "" {
+			name = "create-shoot-aws"
+		}
+		stepConfig = AWSShootConfig(stepConfig)
+		break
+	case gardenv1beta1.CloudProviderGCP:
+		if name == "" {
+			name = "create-shoot-gcp"
+		}
+		stepConfig = GCPShootConfig(stepConfig)
+		break
+	case gardenv1beta1.CloudProviderAzure:
+		if name == "" {
+			name = "create-shoot-azure"
+		}
+		stepConfig = AzureShootConfig(stepConfig)
+		break
+	default:
+		return v1beta1.DAGStep{}, fmt.Errorf("unsupported cloudprovider %s", cloudprovider)
+	}
+
+	return v1beta1.DAGStep{
+		Name: name,
+		Definition: v1beta1.StepDefinition{
+			Name:   "create-shoot",
+			Config: stepConfig,
+		},
+		UseGlobalArtifacts: false,
+		DependsOn:          dependencies,
+		ArtifactsFrom:      "",
+		Annotations:        nil,
+	}, nil
+}
+
+func defaultShootConfig(cfg *CreateShootConfig) []v1beta1.ConfigElement {
+	return []v1beta1.ConfigElement{
+		{
+			Type:  v1beta1.ConfigTypeEnv,
+			Name:  ConfigShootName,
+			Value: cfg.ShootName,
+		},
+		{
+			Type:  v1beta1.ConfigTypeEnv,
+			Name:  ConfigProjectNamespaceName,
+			Value: cfg.Namespace,
+		},
+		{
+			Type:  v1beta1.ConfigTypeEnv,
+			Name:  ConfigK8sVersionName,
+			Value: cfg.K8sVersion,
+		},
+		{
+			Type:  v1beta1.ConfigTypeEnv,
+			Name:  ConfigSeedName,
+			Value: ConfigSeedValue,
+		},
+	}
+}
+
+func GCPShootConfig(cfg []v1beta1.ConfigElement) []v1beta1.ConfigElement {
+	return append(cfg, []v1beta1.ConfigElement{
+		{
+			Type:  v1beta1.ConfigTypeEnv,
+			Name:  ConfigCloudproviderName,
+			Value: "gcp",
+		},
+		{
+			Type:  v1beta1.ConfigTypeEnv,
+			Name:  ConfigCloudprofileName,
+			Value: "gcp",
+		},
+		{
+			Type:  v1beta1.ConfigTypeEnv,
+			Name:  ConfigSecretBindingName,
+			Value: "core-gcp-gcp",
+		},
+		{
+			Type:  v1beta1.ConfigTypeEnv,
+			Name:  ConfigRegionName,
+			Value: "europe-west1",
+		},
+		{
+			Type:  v1beta1.ConfigTypeEnv,
+			Name:  ConfigZoneName,
+			Value: "europe-west1-b",
+		},
+	}...)
+}
+
+func AWSShootConfig(cfg []v1beta1.ConfigElement) []v1beta1.ConfigElement {
+	return append(cfg, []v1beta1.ConfigElement{
+		{
+			Type:  v1beta1.ConfigTypeEnv,
+			Name:  ConfigCloudproviderName,
+			Value: "aws",
+		},
+		{
+			Type:  v1beta1.ConfigTypeEnv,
+			Name:  ConfigCloudprofileName,
+			Value: "aws",
+		},
+		{
+			Type:  v1beta1.ConfigTypeEnv,
+			Name:  ConfigSecretBindingName,
+			Value: "core-aws-aws",
+		},
+		{
+			Type:  v1beta1.ConfigTypeEnv,
+			Name:  ConfigRegionName,
+			Value: "eu-west-1",
+		},
+		{
+			Type:  v1beta1.ConfigTypeEnv,
+			Name:  ConfigZoneName,
+			Value: "eu-west-1b",
+		},
+	}...)
+}
+
+func AzureShootConfig(cfg []v1beta1.ConfigElement) []v1beta1.ConfigElement {
+	return append(cfg, []v1beta1.ConfigElement{
+		{
+			Type:  v1beta1.ConfigTypeEnv,
+			Name:  ConfigCloudproviderName,
+			Value: "azure",
+		},
+		{
+			Type:  v1beta1.ConfigTypeEnv,
+			Name:  ConfigCloudprofileName,
+			Value: "azure",
+		},
+		{
+			Type:  v1beta1.ConfigTypeEnv,
+			Name:  ConfigSecretBindingName,
+			Value: "core-azure-azure",
+		},
+		{
+			Type:  v1beta1.ConfigTypeEnv,
+			Name:  ConfigRegionName,
+			Value: "westeurope",
+		},
+	}...)
+}
+
+func GetStepDeleteShoot(name, createShootStepName, shootName string, dependencies []string) v1beta1.DAGStep {
+	return v1beta1.DAGStep{
+		Name: name,
+		Definition: v1beta1.StepDefinition{
+			Name: "delete-shoot",
+			Config: []v1beta1.ConfigElement{
+				{
+					Type:  v1beta1.ConfigTypeEnv,
+					Name:  ConfigShootName,
+					Value: shootName,
+				},
+			},
+		},
+		UseGlobalArtifacts: false,
+		DependsOn:          dependencies,
+		ArtifactsFrom:      createShootStepName,
+		Annotations:        nil,
+	}
+}

--- a/pkg/testrunner/renderer/templates/steps.go
+++ b/pkg/testrunner/renderer/templates/steps.go
@@ -1,0 +1,61 @@
+// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package templates
+
+import (
+	"fmt"
+
+	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
+	"github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
+	"github.com/gardener/test-infra/pkg/hostscheduler"
+)
+
+func GetStepLockHost(provider hostscheduler.Provider, cloudprovider gardenv1beta1.CloudProvider) v1beta1.DAGStep {
+	return v1beta1.DAGStep{
+		Name: "prepare-host",
+		Definition: v1beta1.StepDefinition{
+			Name:        fmt.Sprintf("tm-scheduler-lock-%s", provider),
+			LocationSet: &TestInfraLocationName,
+			Config: []v1beta1.ConfigElement{
+				{
+					Type:  v1beta1.ConfigTypeEnv,
+					Name:  "HOST_CLOUDPROVIDER",
+					Value: string(cloudprovider),
+				},
+			},
+		},
+	}
+}
+
+func GetStepReleaseHost(provider hostscheduler.Provider, dependencies []string, clean bool) v1beta1.DAGStep {
+	step := v1beta1.DAGStep{
+		Name: "release-host",
+		Definition: v1beta1.StepDefinition{
+			Name:        fmt.Sprintf("tm-scheduler-release-%s", provider),
+			LocationSet: &TestInfraLocationName,
+		},
+		DependsOn: dependencies,
+	}
+	if clean {
+		step.Definition.Config = []v1beta1.ConfigElement{
+			{
+				Type:  v1beta1.ConfigTypeEnv,
+				Name:  "CLEAN",
+				Value: "true",
+			},
+		}
+	}
+	return step
+}

--- a/pkg/testrunner/renderer/templates/templates.go
+++ b/pkg/testrunner/renderer/templates/templates.go
@@ -1,0 +1,97 @@
+// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package templates
+
+import (
+	"github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
+	"github.com/gardener/test-infra/pkg/hostscheduler"
+)
+
+const (
+	TestInfraRepo   = "https://github.com/gardener/test-infra.git"
+	GardenSetupRepo = "https://github.com/schrodit/garden-setup.git"
+)
+
+var TestInfraLocationName = "tm"
+var DefaultLocationSetName = "default"
+
+var TestInfraLocation = v1beta1.LocationSet{
+	Name:    TestInfraLocationName,
+	Default: false,
+	Locations: []v1beta1.TestLocation{
+		{
+			Type:     v1beta1.LocationTypeGit,
+			Repo:     TestInfraRepo,
+			Revision: "master",
+		},
+	},
+}
+
+// GetGardenSetupLocation returns the location set for test machinery steps like lock and release the hostcluster, or fetching of logs, etc.
+func GetGardenSetupLocation(name, revision string) v1beta1.LocationSet {
+	return v1beta1.LocationSet{
+		Name:    name,
+		Default: false,
+		Locations: []v1beta1.TestLocation{
+			{
+				Type:     v1beta1.LocationTypeGit,
+				Repo:     GardenSetupRepo,
+				Revision: revision,
+			},
+		},
+	}
+}
+
+// GetExitTestFlow returns the default exit handler for gardener tests.
+// The testflow consists of the following flow
+// - fetch logs from all gardener components
+// - delete all shoots that may be left in the gardener
+// - delete gardener
+// - cleanup and release the host cluster
+func GetExitTestFlow(hostprovider hostscheduler.Provider, gsLocationSet string, createGardenerStep *v1beta1.DAGStep) v1beta1.TestFlow {
+	deleteGardener := GetStepDeleteGardener(createGardenerStep, gsLocationSet, []string{"clean-gardener"})
+	deleteGardener.ArtifactsFrom = ""
+	deleteGardener.UseGlobalArtifacts = true
+	deleteGardener.Definition.Condition = v1beta1.ConditionTypeError
+
+	releaseHostCluster := GetStepReleaseHost(hostprovider, []string{deleteGardener.Name}, true)
+	releaseHostCluster.UseGlobalArtifacts = true
+	releaseHostCluster.Definition.Condition = v1beta1.ConditionTypeError
+	return v1beta1.TestFlow{
+		{
+			Name: "fetch-logs",
+			Definition: v1beta1.StepDefinition{
+				Name:            "log-gardener",
+				Condition:       v1beta1.ConditionTypeError,
+				ContinueOnError: true,
+				LocationSet:     &TestInfraLocationName,
+			},
+			UseGlobalArtifacts: true,
+		},
+		{
+			Name: "clean-gardener",
+			Definition: v1beta1.StepDefinition{
+				Name:            "clean-gardener",
+				Condition:       v1beta1.ConditionTypeError,
+				ContinueOnError: true,
+				LocationSet:     &TestInfraLocationName,
+			},
+			UseGlobalArtifacts: true,
+			DependsOn:          []string{"fetch-logs"},
+		},
+		&deleteGardener,
+		&releaseHostCluster,
+	}
+}

--- a/pkg/testrunner/renderer/templates/tests.go
+++ b/pkg/testrunner/renderer/templates/tests.go
@@ -1,0 +1,79 @@
+// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package templates
+
+import (
+	"fmt"
+	"github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
+	"github.com/gardener/test-infra/pkg/testrunner/renderer"
+	"github.com/gardener/test-infra/pkg/util"
+	"strings"
+)
+
+// TestWithLabels creates tests functions that render test steps executed in serial.
+func TestWithLabels(labels ...string) renderer.TestsFunc {
+	return func(suffix string, parents []string) ([]*v1beta1.DAGStep, []string, error) {
+		steps := make([]*v1beta1.DAGStep, len(labels))
+		previous := parents
+		for i, l := range labels {
+			step := GetTestStepWithLabels(fmt.Sprintf("tests-%s-%s", suffix, util.RandomString(3)), previous, l)
+			steps[i] = &step
+			previous = []string{step.Name}
+		}
+
+		return steps, []string{steps[len(steps)-1].Name}, nil
+	}
+}
+
+// HibernationLifecycle returns a testcase that tests
+// - the hibernation of a shoot
+// - waking up of a shoot
+// - rehibernation of a shoot
+func HibernationLifecycle(suffix string, parents []string) ([]*v1beta1.DAGStep, []string, error) {
+	hibernate := GetTestStepWithName(fmt.Sprintf("hibernate-%s", suffix), "hibernate-shoot", parents)
+	wakeup := GetTestStepWithName(fmt.Sprintf("wakeup-%s", suffix), "wakeup-shoot", []string{hibernate.Name})
+	hibernateAgain := GetTestStepWithName(fmt.Sprintf("hibernate-again-%s", suffix), "hibernate-shoot", []string{wakeup.Name})
+	return []*v1beta1.DAGStep{&hibernate, &wakeup, &hibernateAgain}, []string{hibernateAgain.Name}, nil
+}
+
+// GetTestStepWithName returns a default test step for a specific testdefinition
+func GetTestStepWithName(name, testName string, dependencies []string) v1beta1.DAGStep {
+	if name == "" {
+		name = "tests"
+	}
+	return v1beta1.DAGStep{
+		Name: name,
+		Definition: v1beta1.StepDefinition{
+			Name: testName,
+		},
+		UseGlobalArtifacts: false,
+		DependsOn:          dependencies,
+	}
+}
+
+// GetTestStepWithLabels returns a default test step for all testdefinitions with a specific label
+func GetTestStepWithLabels(name string, dependencies []string, labels ...string) v1beta1.DAGStep {
+	if name == "" {
+		name = "tests"
+	}
+	return v1beta1.DAGStep{
+		Name: name,
+		Definition: v1beta1.StepDefinition{
+			Label: strings.Join(labels, ","),
+		},
+		UseGlobalArtifacts: false,
+		DependsOn:          dependencies,
+	}
+}

--- a/pkg/testrunner/renderer/tests.go
+++ b/pkg/testrunner/renderer/tests.go
@@ -1,0 +1,38 @@
+// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package renderer
+
+import "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
+
+// WithTests connects mumtiple test functions to one
+func WithTests(funcs ...TestsFunc) TestsFunc {
+	return func(suffix string, parents []string) ([]*v1beta1.DAGStep, []string, error) {
+		steps := make([]*v1beta1.DAGStep, 0)
+		dependencies := parents
+		for _, f := range funcs {
+			var (
+				testSteps []*v1beta1.DAGStep
+				err       error
+			)
+			testSteps, dependencies, err = f(suffix, dependencies)
+			if err != nil {
+				return nil, nil, err
+			}
+			steps = append(steps, testSteps...)
+		}
+
+		return steps, dependencies, nil
+	}
+}

--- a/pkg/testrunner/renderer/types.go
+++ b/pkg/testrunner/renderer/types.go
@@ -1,0 +1,21 @@
+// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package renderer
+
+import "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
+
+// TestsFunc generates tests that adds the parents as dependencies and return the generated steps
+// and the names of the last steps that should be used as dependencies for subsequent steps.
+type TestsFunc = func(suffix string, parents []string) ([]*v1beta1.DAGStep, []string, error)

--- a/pkg/testrunner/run.go
+++ b/pkg/testrunner/run.go
@@ -25,8 +25,6 @@ import (
 	"k8s.io/api/extensions/v1beta1"
 	"net/url"
 	"path"
-	"time"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener/pkg/client/kubernetes"
@@ -86,9 +84,7 @@ func runTestrun(log logr.Logger, tmClient kubernetes.Interface, tr *tmv1beta1.Te
 	}
 
 	testrunPhase := tmv1beta1.PhaseStatusInit
-	interval := time.Duration(pollIntervalSeconds) * time.Second
-	timeout := time.Duration(maxWaitTimeSeconds) * time.Second
-	err = wait.PollImmediate(interval, timeout, func() (bool, error) {
+	err = wait.PollImmediate(pollInterval, maxWaitTime, func() (bool, error) {
 		testrun := &tmv1beta1.Testrun{}
 		err := tmClient.Client().Get(ctx, client.ObjectKey{Namespace: namespace, Name: tr.Name}, testrun)
 		if err != nil {
@@ -106,7 +102,7 @@ func runTestrun(log logr.Logger, tmClient kubernetes.Interface, tr *tmv1beta1.Te
 		return util.Completed(testrunPhase), nil
 	})
 	if err != nil {
-		return nil, trerrors.NewTimeoutError(fmt.Sprintf("maximum wait time of %d is exceeded by Testrun %s", maxWaitTimeSeconds, name))
+		return nil, trerrors.NewTimeoutError(fmt.Sprintf("maximum wait time of %d is exceeded by Testrun %s", maxWaitTime, name))
 	}
 
 	return tr, nil

--- a/pkg/testrunner/template/gardener.go
+++ b/pkg/testrunner/template/gardener.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gardener/test-infra/pkg/testrunner"
 	"github.com/gardener/test-infra/pkg/testrunner/componentdescriptor"
 	errors "github.com/gardener/test-infra/pkg/testrunner/error"
+	"github.com/gardener/test-infra/pkg/testrunner/renderer"
 	"github.com/gardener/test-infra/pkg/util"
 	"github.com/go-logr/logr"
 )
@@ -84,8 +85,14 @@ func RenderGardenerTestrun(log logr.Logger, tmClient kubernetes.Interface, param
 
 		// Add all repositories defined in the component descriptor to the testrun locations.
 		// This gives us all dependent repositories as well as there deployed version.
-		addBOMLocationsToTestrun(&tr, "default", componentDescriptor)
-		addBOMLocationsToTestrun(&tr, "upgraded", upgradedComponentDescriptor)
+		if err := renderer.AddBOMLocationsToTestrun(&tr, "default", componentDescriptor, true); err != nil {
+			log.Info(fmt.Sprintf("cannot add bom locations: %s", err.Error()))
+			continue
+		}
+		if err := renderer.AddBOMLocationsToTestrun(&tr, "upgraded", upgradedComponentDescriptor, false); err != nil {
+			log.Info(fmt.Sprintf("cannot add bom locations: %s", err.Error()))
+			continue
+		}
 
 		// Add runtime annotations to the testrun
 		addAnnotationsToTestrun(&tr, metadata.CreateAnnotations())

--- a/pkg/testrunner/template/helper.go
+++ b/pkg/testrunner/template/helper.go
@@ -17,12 +17,10 @@ package template
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
-	"sort"
-	"strings"
-
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/pkg/errors"
+	"io/ioutil"
+	"sort"
 
 	"github.com/Masterminds/semver"
 
@@ -139,53 +137,6 @@ func getCloudproviderVersions(profile *gardenv1beta1.CloudProfile, cloudprovider
 	default:
 		return nil, fmt.Errorf("Unsupported cloudprovider %s", cloudprovider)
 	}
-}
-
-func addBOMLocationsToTestrun(tr *tmv1beta1.Testrun, locationSetName string, components []*componentdescriptor.Component) {
-	if tr == nil || components == nil {
-		return
-	}
-
-	bomLocations := make([]tmv1beta1.TestLocation, 0)
-	for _, component := range components {
-		bomLocations = append(bomLocations, tmv1beta1.TestLocation{
-			Type:     tmv1beta1.LocationTypeGit,
-			Repo:     fmt.Sprintf("https://%s", component.Name),
-			Revision: getRevisionFromVersion(component.Version),
-		})
-	}
-
-	// check if the locationSet already exists
-	for i, set := range tr.Spec.LocationSets {
-		if set.Name == locationSetName {
-			set.Locations = append(bomLocations, set.Locations...)
-			tr.Spec.LocationSets[i] = set
-			tr.Spec.TestLocations = nil
-			return
-		}
-	}
-
-	// if old locations exist we migrate them to the new locationSet form
-	if len(tr.Spec.TestLocations) == 0 {
-		return
-	}
-	existingLocations := tr.Spec.TestLocations
-	tr.Spec.LocationSets = []tmv1beta1.LocationSet{
-		{
-			Name:      locationSetName,
-			Locations: append(bomLocations, existingLocations...),
-		},
-	}
-	tr.Spec.TestLocations = nil
-}
-
-// getRevisionFromVersion parses the version of a component and returns its revision if applicable.
-func getRevisionFromVersion(version string) string {
-	if strings.Contains(version, "dev") {
-		splitVersion := strings.Split(version, "-")
-		return splitVersion[len(splitVersion)-1]
-	}
-	return version
 }
 
 func addAnnotationsToTestrun(tr *tmv1beta1.Testrun, annotations map[string]string) {

--- a/pkg/testrunner/template/shoot.go
+++ b/pkg/testrunner/template/shoot.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"github.com/gardener/test-infra/pkg/testrunner"
 	errors "github.com/gardener/test-infra/pkg/testrunner/error"
+	"github.com/gardener/test-infra/pkg/testrunner/renderer"
 	"github.com/go-logr/logr"
 	"os"
 
@@ -62,7 +63,10 @@ func RenderShootTestrun(log logr.Logger, tmClient kubernetes.Interface, paramete
 
 		// Add all repositories defined in the component descriptor to the testrun locations.
 		// This gives us all dependent repositories as well as there deployed version.
-		addBOMLocationsToTestrun(&tr, "default", componentDescriptor)
+		if err := renderer.AddBOMLocationsToTestrun(&tr, "default", componentDescriptor, true); err != nil {
+			log.Info(fmt.Sprintf("cannot add bom locations: %s", err.Error()))
+			continue
+		}
 
 		// Add runtime annotations to the testrun
 		addAnnotationsToTestrun(&tr, metadata.CreateAnnotations())

--- a/pkg/testrunner/testrunner.go
+++ b/pkg/testrunner/testrunner.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"github.com/go-logr/logr"
 	"sync"
+	"time"
 
 	trerrors "github.com/gardener/test-infra/pkg/testrunner/error"
 
@@ -28,15 +29,15 @@ import (
 )
 
 var (
-	maxWaitTimeSeconds  int64 = 3600
-	pollIntervalSeconds int64 = 60
+	maxWaitTime  = 1 * time.Hour
+	pollInterval = 1 * time.Minute
 )
 
 // ExecuteTestruns deploys it to a testmachinery cluster and waits for the testruns results
 func ExecuteTestruns(log logr.Logger, config *Config, runs RunList, testrunNamePrefix string) {
 	log.V(3).Info(fmt.Sprintf("Config: %+v", util.PrettyPrintStruct(config)))
-	maxWaitTimeSeconds = config.Timeout
-	pollIntervalSeconds = config.Interval
+	maxWaitTime = config.Timeout
+	pollInterval = config.Interval
 
 	runs.Run(log.WithValues("namespace", config.Namespace), config.TmClient, config.Namespace, testrunNamePrefix)
 }

--- a/pkg/testrunner/types.go
+++ b/pkg/testrunner/types.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	tmv1beta1 "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"time"
 )
 
 // Config are configuration of the evironment like the testmachinery cluster or S3 store
@@ -31,10 +32,10 @@ type Config struct {
 	Namespace string
 
 	// Max wait time for a testrun to finish.
-	Timeout int64
+	Timeout time.Duration
 
 	// Poll intervall to check the testrun status
-	Interval int64
+	Interval time.Duration
 }
 
 // Run describes a testrun that is executed by the testrunner.

--- a/pkg/util/cmdvalues/cloudprovider.go
+++ b/pkg/util/cmdvalues/cloudprovider.go
@@ -1,0 +1,56 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmdvalues
+
+import (
+	"fmt"
+	"github.com/gardener/gardener/pkg/apis/garden/v1beta1"
+	"github.com/spf13/pflag"
+)
+
+type CloudProviderValue struct {
+	allowedProvider map[v1beta1.CloudProvider]bool
+	cloudprovider   *v1beta1.CloudProvider
+}
+
+func NewCloudProviderValue(value *v1beta1.CloudProvider, defaultValue v1beta1.CloudProvider, allowed ...v1beta1.CloudProvider) pflag.Value {
+	*value = defaultValue
+	cpvalue := &CloudProviderValue{
+		allowedProvider: make(map[v1beta1.CloudProvider]bool),
+		cloudprovider:   value,
+	}
+	for _, cp := range allowed {
+		cpvalue.allowedProvider[cp] = true
+	}
+	return cpvalue
+}
+
+var _ pflag.Value = &CloudProviderValue{}
+
+func (v *CloudProviderValue) String() string {
+	return string(*v.cloudprovider)
+}
+
+func (v *CloudProviderValue) Type() string {
+	return "CloudProvider"
+}
+
+func (v *CloudProviderValue) Set(value string) error {
+	provider := v1beta1.CloudProvider(value)
+	if _, ok := v.allowedProvider[provider]; len(v.allowedProvider) != 0 && !ok {
+		return fmt.Errorf("unsupported cloudprovider %s", provider)
+	}
+	*v.cloudprovider = provider
+	return nil
+}

--- a/pkg/util/cmdvalues/cloudproviderarray.go
+++ b/pkg/util/cmdvalues/cloudproviderarray.go
@@ -39,6 +39,8 @@ func NewCloudProviderArrayValue(value *[]v1beta1.CloudProvider, allowed ...v1bet
 }
 
 func (v *CloudProviderArrayValue) String() string {
+	// won't be implemented as we cannot user strings.Join() and
+	// would need to construct the csv of casted cloudproviders ourselves
 	return ""
 }
 

--- a/pkg/util/cmdvalues/cloudproviderarray.go
+++ b/pkg/util/cmdvalues/cloudproviderarray.go
@@ -1,0 +1,68 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmdvalues
+
+import (
+	"fmt"
+	"github.com/gardener/gardener/pkg/apis/garden/v1beta1"
+	"github.com/spf13/pflag"
+)
+
+type CloudProviderArrayValue struct {
+	allowedProvider map[v1beta1.CloudProvider]bool
+	cloudproviders  map[v1beta1.CloudProvider]bool
+	value           *[]v1beta1.CloudProvider
+	changed         bool
+}
+
+func NewCloudProviderArrayValue(value *[]v1beta1.CloudProvider, allowed ...v1beta1.CloudProvider) pflag.Value {
+	cpvalue := &CloudProviderArrayValue{
+		cloudproviders: make(map[v1beta1.CloudProvider]bool),
+		value:          value,
+		changed:        false,
+	}
+	for _, cp := range allowed {
+		cpvalue.allowedProvider[cp] = true
+	}
+	return cpvalue
+}
+
+func (v *CloudProviderArrayValue) String() string {
+	return ""
+}
+
+func (v *CloudProviderArrayValue) Type() string {
+	return "CloudProviderArray"
+}
+
+func (v *CloudProviderArrayValue) Set(value string) error {
+	provider := v1beta1.CloudProvider(value)
+	if _, ok := v.allowedProvider[provider]; len(v.allowedProvider) != 0 && !ok {
+		return fmt.Errorf("unsupported cloudprovider %s", provider)
+	}
+
+	if _, ok := v.cloudproviders[provider]; ok {
+		return fmt.Errorf("duplicated cloudprovider %s", provider)
+	}
+
+	if !v.changed {
+		*v.value = []v1beta1.CloudProvider{provider}
+		v.changed = true
+	} else {
+		*v.value = append(*v.value, provider)
+	}
+
+	v.cloudproviders[provider] = true
+	return nil
+}

--- a/pkg/util/cmdvalues/duration.go
+++ b/pkg/util/cmdvalues/duration.go
@@ -1,0 +1,45 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmdvalues
+
+import (
+	"github.com/spf13/pflag"
+	"time"
+)
+
+type DurationValue struct {
+	duration *time.Duration
+}
+
+func NewDurationValue(value *time.Duration, defaultValue time.Duration) pflag.Value {
+	*value = defaultValue
+	return &DurationValue{duration: value}
+}
+
+func (v *DurationValue) String() string {
+	return v.duration.String()
+}
+
+func (v *DurationValue) Type() string {
+	return "duration"
+}
+
+func (v *DurationValue) Set(value string) error {
+	duration, err := time.ParseDuration(value)
+	if err != nil {
+		return err
+	}
+	*v.duration = duration
+	return nil
+}

--- a/pkg/util/cmdvalues/hostprovider.go
+++ b/pkg/util/cmdvalues/hostprovider.go
@@ -1,0 +1,49 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmdvalues
+
+import (
+	"github.com/gardener/test-infra/pkg/hostscheduler"
+	"github.com/gardener/test-infra/pkg/hostscheduler/gardenerscheduler"
+	"github.com/spf13/pflag"
+)
+
+type HostProviderValue struct {
+	provider *hostscheduler.Provider
+}
+
+func NewHostProviderValue(value *hostscheduler.Provider, defaultValue hostscheduler.Provider) pflag.Value {
+	*value = defaultValue
+	return &HostProviderValue{provider: value}
+}
+
+var _ pflag.Value = &HostProviderValue{}
+
+func (v *HostProviderValue) String() string {
+	if v.provider == nil {
+		return string(gardenerscheduler.Name)
+	}
+	return string(*v.provider)
+}
+
+func (v *HostProviderValue) Type() string {
+	return "HostProvider"
+}
+
+func (v *HostProviderValue) Set(value string) error {
+	provider := hostscheduler.Provider(value)
+	// add validation
+	*v.provider = provider
+	return nil
+}

--- a/test/testrunner/run/testrunner_run_test.go
+++ b/test/testrunner/run/testrunner_run_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gardener/test-infra/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"time"
 )
 
 var _ = Describe("Testrunner execution tests", func() {
@@ -33,8 +34,8 @@ var _ = Describe("Testrunner execution tests", func() {
 		testrunConfig = testrunner.Config{
 			TmClient:  operation.Client(),
 			Namespace: operation.TestNamespace(),
-			Timeout:   int64(InitializationTimeout),
-			Interval:  5,
+			Timeout:   InitializationTimeout,
+			Interval:  5 * time.Second,
 		}
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the default gardener test rendered in go ti the test-infra repo.

Currently only the testrunner implements this new tests in a new subcommand.
In the future the gardener template testrunner command will removed in favor of golang rendered testruns.

The default shoot helm based rendering will stay as is.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Add default gardener test rendered in go
```
