### PR TITLE
Enhance authorization

### DIFF
--- a/pkg/tm-bot/github/client.go
+++ b/pkg/tm-bot/github/client.go
@@ -159,7 +159,7 @@ func (c *client) isOrgAdmin(event *GenericRequestEvent) bool {
 	return false
 }
 
-// isInRequestedTeam checks if the author is in the organization
+// isInOrganization checks if the author is in the organization
 func (c *client) isInOrganization(event *GenericRequestEvent) bool {
 	membership, _, err := c.client.Organizations.GetOrgMembership(context.TODO(), event.GetAuthorName(), event.GetOwnerName())
 	if err != nil {

--- a/pkg/tm-bot/github/types.go
+++ b/pkg/tm-bot/github/types.go
@@ -27,7 +27,7 @@ type Manager interface {
 
 // Client is the github client interface
 type Client interface {
-	IsAuthorized(event *GenericRequestEvent) bool
+	IsAuthorized(authorizationType AuthorizationType, event *GenericRequestEvent) bool
 
 	GetConfig(name string) (json.RawMessage, error)
 	ResolveConfigValue(event *GenericRequestEvent, value *ghval.GitHubValue) (string, error)
@@ -63,6 +63,15 @@ type client struct {
 	client *github.Client
 }
 
+// AuthorizationType represents the usergroup that is allowed to do the action
+type AuthorizationType string
+
+const (
+	AuthorizationAll  AuthorizationType = "all"
+	AuthorizationOrg  AuthorizationType = "org"
+	AuthorizationTeam AuthorizationType = "team"
+)
+
 // EventActionType represents the action type of a github event
 type EventActionType string
 
@@ -89,4 +98,20 @@ const (
 	StateFailure State = "failure"
 	StatePending State = "pending"
 	StateSuccess State = "success"
+)
+
+// MembershipRole represents the membership role of organizations and teams
+type MembershipRole string
+
+const (
+	MembershipRoleAdmin      MembershipRole = "admin"
+	MembershipRoleMember     MembershipRole = "member"
+	MembershipRoleMaintainer MembershipRole = "maintainer"
+)
+
+// MembershipStatus represents the current membership status of a user
+type MembershipStatus string
+
+const (
+	MembershipStatusActive MembershipStatus = "active"
 )

--- a/pkg/tm-bot/hook/handler.go
+++ b/pkg/tm-bot/hook/handler.go
@@ -115,12 +115,6 @@ func (h *Handler) handleGenericEvent(w http.ResponseWriter, event *ghutils.Gener
 		return
 	}
 
-	if !client.IsAuthorized(event) {
-		h.log.V(3).Info("user not authorized", "user", event.GetAuthorName())
-		http.Error(w, "unauthorized user", http.StatusUnauthorized)
-		return
-	}
-
 	if err := plugins.HandleRequest(client, event); err != nil {
 		h.log.Error(err, "")
 		http.Error(w, "unable to handle request", http.StatusInternalServerError)

--- a/pkg/tm-bot/plugins/echo/echo.go
+++ b/pkg/tm-bot/plugins/echo/echo.go
@@ -34,15 +34,19 @@ func (e *echo) New(runID string) plugins.Plugin {
 	return &echo{runID: runID}
 }
 
-func (e *echo) Command() string {
+func (_ *echo) Command() string {
 	return "echo"
 }
 
-func (e *echo) Description() string {
+func (_ *echo) Authorization() github.AuthorizationType {
+	return github.AuthorizationAll
+}
+
+func (_ *echo) Description() string {
 	return "Prints the provided value"
 }
 
-func (e *echo) Example() string {
+func (_ *echo) Example() string {
 	return "/echo --val \"text to echo\""
 }
 

--- a/pkg/tm-bot/plugins/plugins.go
+++ b/pkg/tm-bot/plugins/plugins.go
@@ -31,14 +31,9 @@ type Plugin interface {
 	// Command returns the unique matching command for the plugin
 	Command() string
 
-	// Flags return command line style flags for the command
-	Flags() *pflag.FlagSet
-
-	// Run runs the command with the parsed flags (flag.Parse()) and the event that triggered the command
-	Run(fs *pflag.FlagSet, client github.Client, event *github.GenericRequestEvent) error
-
-	// resume the plugin execution from a persisted state
-	ResumeFromState(client github.Client, event *github.GenericRequestEvent, state string) error
+	// Authorization returns the authorization type of the plugin.
+	// Defines who is allowed to call the plugin
+	Authorization() github.AuthorizationType
 
 	// Description returns a short description of the plugin
 	Description() string
@@ -46,8 +41,17 @@ type Plugin interface {
 	// Example returns an example for the command
 	Example() string
 
+	// Flags return command line style flags for the command
+	Flags() *pflag.FlagSet
+
 	// Create a deep copy of the plugin
 	New(runID string) Plugin
+
+	// Run runs the command with the parsed flags (flag.Parse()) and the event that triggered the command
+	Run(fs *pflag.FlagSet, client github.Client, event *github.GenericRequestEvent) error
+
+	// resume the plugin execution from a persisted state
+	ResumeFromState(client github.Client, event *github.GenericRequestEvent, state string) error
 }
 
 // Persistence describes the interface for persisting plugin states

--- a/pkg/tm-bot/plugins/request.go
+++ b/pkg/tm-bot/plugins/request.go
@@ -46,6 +46,11 @@ func (p *plugins) runPlugin(client github.Client, event *github.GenericRequestEv
 		return
 	}
 
+	if !client.IsAuthorized(plugin.Authorization(), event) {
+		p.log.V(3).Info("user not authorized", "user", event.GetAuthorName(), "plugin", plugin.Command())
+		return
+	}
+
 	p.initState(plugin, runID, event)
 
 	fs := plugin.Flags()

--- a/pkg/tm-bot/plugins/tests/test.go
+++ b/pkg/tm-bot/plugins/tests/test.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	_default "github.com/gardener/test-infra/pkg/testrunner/renderer/default"
+	"github.com/gardener/test-infra/pkg/tm-bot/github"
 	"github.com/gardener/test-infra/pkg/tm-bot/plugins"
 	"github.com/go-logr/logr"
 	"time"
@@ -57,6 +58,10 @@ func (t *test) New(runID string) plugins.Plugin {
 
 func (t *test) Command() string {
 	return "test"
+}
+
+func (_ *test) Authorization() github.AuthorizationType {
+	return github.AuthorizationOrg
 }
 
 func (t *test) Description() string {

--- a/pkg/tm-bot/plugins/xkcd/xkcd.go
+++ b/pkg/tm-bot/plugins/xkcd/xkcd.go
@@ -56,6 +56,10 @@ func (_ *xkcd) Command() string {
 	return "xkcd"
 }
 
+func (_ *xkcd) Authorization() github.AuthorizationType {
+	return github.AuthorizationAll
+}
+
 func (_ *xkcd) Description() string {
 	return "Adds an random image of xkcd"
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Enhances the authorization mechanism of the github bot.
It is now possible for every plugin to define its own authorization level
- `all`: everyone is allowed to call the plugin
- `org`: only org members are allowed to call the plugin
- `team`: only the requested team is allowed to call the plugin

org admins are always allowed.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Enhanced the authorization of the github bot
```
