### PR TITLE
Enhance authorization of plugins and add skip plugin

### DIFF
--- a/charts/tm-bot/templates/deployment.yaml
+++ b/charts/tm-bot/templates/deployment.yaml
@@ -50,6 +50,7 @@ spec:
         - --github-app-id=$(GITHUB_APP_ID)
         - --github-key-file=/etc/tm-bot/srv/github/key.pem
         - --webhook-secret-token=$(WEBHOOK_SECRET_TOKEN)
+        - --github-default-team={{ .Values.bot.defaultTeamName }}
         - -v=2
         {{ if .Values.bot.configFilePath }}
         - --config-file-path={{ .Values.bot.configFilePath }}

--- a/charts/tm-bot/values.yaml
+++ b/charts/tm-bot/values.yaml
@@ -22,6 +22,7 @@ bot:
   imagePullSecretName: ""
 
   configFilePath: ""
+  defaultTeamName: "core"
   verbosity: 2
 
   serviceAccountName: tm-bot

--- a/cmd/tm-bot/README.md
+++ b/cmd/tm-bot/README.md
@@ -52,7 +52,7 @@ Flags: --num int
 ```
 
 #### skip
-Skipped all required testmachinery github status by setting it to success with the description `skipped`.
+Skips all required testmachinery github status by setting it to success with the description `skipped`.
 ```
 Command: skip
 ```

--- a/cmd/tm-bot/README.md
+++ b/cmd/tm-bot/README.md
@@ -51,6 +51,12 @@ Command: xkcd
 Flags: --num int
 ```
 
+#### skip
+Skipped all required testmachinery github status by setting it to success with the description `skipped`.
+```
+Command: skip
+```
+
 #### test
 Runs a default testrun with the given default configuration and provided flags.<br>
 Detailed testrun information can be found [here](../../docs/tests/gardener-default.md).
@@ -75,6 +81,7 @@ Usage:
       --namespace string                   Testrun namespace (default "default")
       --project-namespace string           Specify the shoot namespace where the shoots should be created (default "garden-core")
 ```
+
 
 **Default Configuration**<br>
 Note: all values are optional and can be manually overwritten by specifying the according flag.

--- a/pkg/testrunner/renderer/templates/steps.go
+++ b/pkg/testrunner/renderer/templates/steps.go
@@ -16,6 +16,7 @@ package templates
 
 import (
 	"fmt"
+	"strconv"
 
 	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
@@ -45,17 +46,15 @@ func GetStepReleaseHost(provider hostscheduler.Provider, dependencies []string, 
 		Definition: v1beta1.StepDefinition{
 			Name:        fmt.Sprintf("tm-scheduler-release-%s", provider),
 			LocationSet: &TestInfraLocationName,
+			Config: []v1beta1.ConfigElement{
+				{
+					Type:  v1beta1.ConfigTypeEnv,
+					Name:  "CLEAN",
+					Value: strconv.FormatBool(clean),
+				},
+			},
 		},
 		DependsOn: dependencies,
-	}
-	if clean {
-		step.Definition.Config = []v1beta1.ConfigElement{
-			{
-				Type:  v1beta1.ConfigTypeEnv,
-				Name:  "CLEAN",
-				Value: "true",
-			},
-		}
 	}
 	return step
 }

--- a/pkg/tm-bot/github/client.go
+++ b/pkg/tm-bot/github/client.go
@@ -159,7 +159,7 @@ func (c *client) isOrgAdmin(event *GenericRequestEvent) bool {
 	return false
 }
 
-// isInRequestedTeam checks if the author is in the organization
+// isInOrganization checks if the author is in the organization
 func (c *client) isInOrganization(event *GenericRequestEvent) bool {
 	membership, _, err := c.client.Organizations.GetOrgMembership(context.TODO(), event.GetAuthorName(), event.GetOwnerName())
 	if err != nil {

--- a/pkg/tm-bot/github/manager.go
+++ b/pkg/tm-bot/github/manager.go
@@ -26,7 +26,7 @@ import (
 	"github.com/google/go-github/v27/github"
 )
 
-func NewManager(log logr.Logger, apiURL string, appID int, keyFile, configFile string) (Manager, error) {
+func NewManager(log logr.Logger, apiURL string, appID int, keyFile, configFile, defaultTeam string) (Manager, error) {
 	return &manager{
 		log:        log,
 		configFile: configFile,
@@ -48,7 +48,7 @@ func (m *manager) GetClient(event *GenericRequestEvent) (Client, error) {
 		return nil, err
 	}
 
-	return NewClient(m.log, ghClient, config)
+	return NewClient(m.log, ghClient, event.GetOwnerName(), m.defaultTeam, config)
 }
 
 func (m *manager) getConfig(c *github.Client, repo, owner, revision string) (map[string]json.RawMessage, error) {

--- a/pkg/tm-bot/github/types.go
+++ b/pkg/tm-bot/github/types.go
@@ -51,16 +51,20 @@ type manager struct {
 	log        logr.Logger
 	configFile string
 
-	apiURL  string
-	appId   int
-	keyFile string
-	clients map[int64]*github.Client
+	apiURL      string
+	appId       int
+	keyFile     string
+	clients     map[int64]*github.Client
+	defaultTeam string
 }
 
 type client struct {
 	log    logr.Logger
 	config map[string]json.RawMessage
 	client *github.Client
+
+	owner       string
+	defaultTeam *github.Team
 }
 
 // AuthorizationType represents the usergroup that is allowed to do the action

--- a/pkg/tm-bot/github/types.go
+++ b/pkg/tm-bot/github/types.go
@@ -27,7 +27,7 @@ type Manager interface {
 
 // Client is the github client interface
 type Client interface {
-	IsAuthorized(event *GenericRequestEvent) bool
+	IsAuthorized(authorizationType AuthorizationType, event *GenericRequestEvent) bool
 
 	GetConfig(name string) (json.RawMessage, error)
 	ResolveConfigValue(event *GenericRequestEvent, value *ghval.GitHubValue) (string, error)
@@ -63,6 +63,15 @@ type client struct {
 	client *github.Client
 }
 
+// AuthorizationType represents the usergroup that is allowed to do the action
+type AuthorizationType string
+
+const (
+	AuthorizationAll  AuthorizationType = "all"
+	AuthorizationOrg  AuthorizationType = "org"
+	AuthorizationTeam AuthorizationType = "team"
+)
+
 // EventActionType represents the action type of a github event
 type EventActionType string
 
@@ -89,4 +98,20 @@ const (
 	StateFailure State = "failure"
 	StatePending State = "pending"
 	StateSuccess State = "success"
+)
+
+// MembershipRole represents the membership role of organizations and teams
+type MembershipRole string
+
+const (
+	MembershipRoleAdmin      MembershipRole = "admin"
+	MembershipRoleMember     MembershipRole = "member"
+	MembershipRoleMaintainer MembershipRole = "maintainer"
+)
+
+// MembershipStatus represents the current membership status of a user
+type MembershipStatus string
+
+const (
+	MembershipStatusActive MembershipStatus = "active"
 )

--- a/pkg/tm-bot/hook/handler.go
+++ b/pkg/tm-bot/hook/handler.go
@@ -115,12 +115,6 @@ func (h *Handler) handleGenericEvent(w http.ResponseWriter, event *ghutils.Gener
 		return
 	}
 
-	if !client.IsAuthorized(event) {
-		h.log.V(3).Info("user not authorized", "user", event.GetAuthorName())
-		http.Error(w, "unauthorized user", http.StatusUnauthorized)
-		return
-	}
-
 	if err := plugins.HandleRequest(client, event); err != nil {
 		h.log.Error(err, "")
 		http.Error(w, "unable to handle request", http.StatusInternalServerError)

--- a/pkg/tm-bot/hook/handler.go
+++ b/pkg/tm-bot/hook/handler.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/test-infra/pkg/tm-bot/plugins"
 	"github.com/gardener/test-infra/pkg/tm-bot/plugins/echo"
+	"github.com/gardener/test-infra/pkg/tm-bot/plugins/skip"
 	"github.com/gardener/test-infra/pkg/tm-bot/plugins/tests"
 	"github.com/gardener/test-infra/pkg/tm-bot/plugins/xkcd"
 	"github.com/pkg/errors"
@@ -52,6 +53,7 @@ func New(log logr.Logger, ghMgr ghutils.Manager, webhookSecretToken string, k8sC
 	plugins.Register(xkcdPlugin)
 
 	plugins.Register(tests.New(log, k8sClient))
+	plugins.Register(skip.New(log))
 
 	if err := plugins.ResumePlugins(ghMgr); err != nil {
 		return nil, errors.Wrap(err, "unable to resume running plugins")

--- a/pkg/tm-bot/plugins/echo/echo.go
+++ b/pkg/tm-bot/plugins/echo/echo.go
@@ -34,15 +34,19 @@ func (e *echo) New(runID string) plugins.Plugin {
 	return &echo{runID: runID}
 }
 
-func (e *echo) Command() string {
+func (_ *echo) Command() string {
 	return "echo"
 }
 
-func (e *echo) Description() string {
+func (_ *echo) Authorization() github.AuthorizationType {
+	return github.AuthorizationAll
+}
+
+func (_ *echo) Description() string {
 	return "Prints the provided value"
 }
 
-func (e *echo) Example() string {
+func (_ *echo) Example() string {
 	return "/echo --val \"text to echo\""
 }
 

--- a/pkg/tm-bot/plugins/plugins.go
+++ b/pkg/tm-bot/plugins/plugins.go
@@ -31,14 +31,9 @@ type Plugin interface {
 	// Command returns the unique matching command for the plugin
 	Command() string
 
-	// Flags return command line style flags for the command
-	Flags() *pflag.FlagSet
-
-	// Run runs the command with the parsed flags (flag.Parse()) and the event that triggered the command
-	Run(fs *pflag.FlagSet, client github.Client, event *github.GenericRequestEvent) error
-
-	// resume the plugin execution from a persisted state
-	ResumeFromState(client github.Client, event *github.GenericRequestEvent, state string) error
+	// Authorization returns the authorization type of the plugin.
+	// Defines who is allowed to call the plugin
+	Authorization() github.AuthorizationType
 
 	// Description returns a short description of the plugin
 	Description() string
@@ -46,8 +41,17 @@ type Plugin interface {
 	// Example returns an example for the command
 	Example() string
 
+	// Flags return command line style flags for the command
+	Flags() *pflag.FlagSet
+
 	// Create a deep copy of the plugin
 	New(runID string) Plugin
+
+	// Run runs the command with the parsed flags (flag.Parse()) and the event that triggered the command
+	Run(fs *pflag.FlagSet, client github.Client, event *github.GenericRequestEvent) error
+
+	// resume the plugin execution from a persisted state
+	ResumeFromState(client github.Client, event *github.GenericRequestEvent, state string) error
 }
 
 // Persistence describes the interface for persisting plugin states

--- a/pkg/tm-bot/plugins/plugins.go
+++ b/pkg/tm-bot/plugins/plugins.go
@@ -83,6 +83,7 @@ type State struct {
 // Register registers a plugin with its command to be executed on a event
 func Register(plugin Plugin) {
 	Plugins.registered[plugin.Command()] = plugin
+	Plugins.log.Info("registered plugin", "name", plugin.Command())
 }
 
 // Setup sets up the plugins with a logger and a persistent storage

--- a/pkg/tm-bot/plugins/request.go
+++ b/pkg/tm-bot/plugins/request.go
@@ -46,6 +46,11 @@ func (p *plugins) runPlugin(client github.Client, event *github.GenericRequestEv
 		return
 	}
 
+	if !client.IsAuthorized(plugin.Authorization(), event) {
+		p.log.V(3).Info("user not authorized", "user", event.GetAuthorName(), "plugin", plugin.Command())
+		return
+	}
+
 	p.initState(plugin, runID, event)
 
 	fs := plugin.Flags()

--- a/pkg/tm-bot/plugins/request.go
+++ b/pkg/tm-bot/plugins/request.go
@@ -98,6 +98,12 @@ func (p *plugins) resumePlugin(ghMgr github.Manager, name, runID string, state *
 // Error responds to the client if an error occurs
 func (p *plugins) Error(client github.Client, event *github.GenericRequestEvent, plugin Plugin, err error) error {
 	p.log.Error(err, err.Error())
+	switch err.(type) {
+	case *pluginerr.PluginError:
+		break
+	default:
+		return nil
+	}
 
 	if plugin != nil {
 		_, err := client.Comment(event, FormatErrorResponse(event.GetAuthorName(), pluginerr.ShortForError(err), FormatUsageError(plugin.Command(), plugin.Description(), plugin.Example(), plugin.Flags().FlagUsages())))

--- a/pkg/tm-bot/plugins/respond.go
+++ b/pkg/tm-bot/plugins/respond.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 )
 
-const AboutThisBotWithoutCommands = "Instructions for interacting with me using PR comments are available [here](https://github.com/gardener/test-infra)"
+const AboutThisBotWithoutCommands = "Instructions for interacting with me using PR comments are available <a href=\"https://github.com/gardener/test-infra/tree/master/cmd/tm-bot#plugins\">here</a>"
 
 // FormatSimpleResponse formats a response that does not warrant additional explanation in the
 // details section.

--- a/pkg/tm-bot/plugins/skip/skip.go
+++ b/pkg/tm-bot/plugins/skip/skip.go
@@ -1,0 +1,76 @@
+// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package skip
+
+import (
+	"github.com/gardener/test-infra/pkg/tm-bot/github"
+	"github.com/gardener/test-infra/pkg/tm-bot/plugins"
+	"github.com/gardener/test-infra/pkg/tm-bot/tests"
+	"github.com/go-logr/logr"
+	"github.com/spf13/pflag"
+)
+
+type skip struct {
+	log   logr.Logger
+	runID string
+}
+
+func New(log logr.Logger) plugins.Plugin {
+	return &skip{log: log}
+}
+
+func (e *skip) New(runID string) plugins.Plugin {
+	return &skip{
+		log:   e.log,
+		runID: runID,
+	}
+}
+
+func (_ *skip) Command() string {
+	return "skip"
+}
+
+func (_ *skip) Authorization() github.AuthorizationType {
+	return github.AuthorizationOrg
+}
+
+func (_ *skip) Description() string {
+	return "Clears the testmachinery github status to skip a failed or pending test"
+}
+
+func (_ *skip) Example() string {
+	return "/skip"
+}
+
+func (_ *skip) ResumeFromState(_ github.Client, _ *github.GenericRequestEvent, _ string) error {
+	return nil
+}
+
+func (e *skip) Flags() *pflag.FlagSet {
+	flagset := pflag.NewFlagSet(e.Command(), pflag.ContinueOnError)
+	return flagset
+}
+
+func (e *skip) Run(flagset *pflag.FlagSet, client github.Client, event *github.GenericRequestEvent) error {
+	updater := tests.NewStatusUpdater(e.log, client, event)
+	if err := updater.UpdateStatus(github.StateSuccess, "skipped"); err != nil {
+		e.log.Error(err, "unable to update github status to skipped")
+		_, err = client.Comment(event, plugins.FormatErrorResponse(event.GetAuthorName(), "I was unable to skip the tests. Please try again", ""))
+		return err
+	}
+
+	_, err := client.Comment(event, plugins.FormatSimpleResponse(event.GetAuthorName(), "I skipped all necessary testmachinery tests"))
+	return err
+}

--- a/pkg/tm-bot/plugins/tests/test.go
+++ b/pkg/tm-bot/plugins/tests/test.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	_default "github.com/gardener/test-infra/pkg/testrunner/renderer/default"
+	"github.com/gardener/test-infra/pkg/tm-bot/github"
 	"github.com/gardener/test-infra/pkg/tm-bot/plugins"
 	"github.com/go-logr/logr"
 	"time"
@@ -57,6 +58,10 @@ func (t *test) New(runID string) plugins.Plugin {
 
 func (t *test) Command() string {
 	return "test"
+}
+
+func (_ *test) Authorization() github.AuthorizationType {
+	return github.AuthorizationOrg
 }
 
 func (t *test) Description() string {

--- a/pkg/tm-bot/plugins/xkcd/xkcd.go
+++ b/pkg/tm-bot/plugins/xkcd/xkcd.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"github.com/gardener/test-infra/pkg/tm-bot/github"
 	"github.com/gardener/test-infra/pkg/tm-bot/plugins"
+	pluginerr "github.com/gardener/test-infra/pkg/tm-bot/plugins/errors"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 	"math/rand"
@@ -81,11 +82,11 @@ func (x *xkcd) Flags() *pflag.FlagSet {
 func (x *xkcd) Run(flagset *pflag.FlagSet, client github.Client, event *github.GenericRequestEvent) error {
 	max, err := x.getCurrentMax()
 	if err != nil {
-		return err
+		return pluginerr.New("unable to get maximum xkcd number", err.Error())
 	}
 	if flagset.Changed("num") {
 		if x.num > max {
-			return fmt.Errorf("xkcd %d does not exist. The maximum number is currently %d", x.num, max)
+			return pluginerr.New(fmt.Sprintf("xkcd %d does not exist. The maximum number is currently %d", x.num, max), "")
 		}
 	} else {
 		x.num = rand.Intn(max)

--- a/pkg/tm-bot/plugins/xkcd/xkcd.go
+++ b/pkg/tm-bot/plugins/xkcd/xkcd.go
@@ -56,6 +56,10 @@ func (_ *xkcd) Command() string {
 	return "xkcd"
 }
 
+func (_ *xkcd) Authorization() github.AuthorizationType {
+	return github.AuthorizationAll
+}
+
 func (_ *xkcd) Description() string {
 	return "Adds an random image of xkcd"
 }

--- a/pkg/tm-bot/router.go
+++ b/pkg/tm-bot/router.go
@@ -34,7 +34,7 @@ func setup(log logr.Logger) (*mux.Router, error) {
 		return nil, errors.Wrap(err, "unable to initialize kubernetes client")
 	}
 
-	ghClient, err := github.NewManager(log.WithName("github"), githubApiURL, githubAppID, githubKeyFile, repoConfigFile)
+	ghClient, err := github.NewManager(log.WithName("github"), githubApiURL, githubAppID, githubKeyFile, repoConfigFile, githubDefaultTeamName)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to initialize github client")
 	}

--- a/pkg/tm-bot/server.go
+++ b/pkg/tm-bot/server.go
@@ -31,11 +31,12 @@ var (
 	serverCertFile string
 	serverKeyFile  string
 
-	githubApiURL       string
-	githubAppID        int
-	githubKeyFile      string
-	webhookSecretToken string
-	repoConfigFile     string
+	githubApiURL          string
+	githubAppID           int
+	githubKeyFile         string
+	webhookSecretToken    string
+	repoConfigFile        string
+	githubDefaultTeamName string
 
 	kubeconfigPath string
 )
@@ -103,6 +104,7 @@ func InitFlags(flagset *flag.FlagSet) {
 	flagset.StringVar(&githubKeyFile, "github-key-file", "", "GitHub app private key file path")
 	flagset.StringVar(&webhookSecretToken, "webhook-secret-token", "testing", "GitHub webhook secret to verify payload")
 	flagset.StringVar(&repoConfigFile, "config-file-path", ".ci/tm-config.yaml", "Path the bot configuration in the repository")
+	flagset.StringVar(&githubDefaultTeamName, "github-default-team", "", "Slug name of the default team to grant access")
 
 	flagset.StringVar(&kubeconfigPath, "kubeconfig", os.Getenv("KUBECONFIG"), "Kubeconfig path to a testmachinery cluster")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Enhances the authorization mechanism of the github bot.
It is now possible for every plugin to define its own authorization level
- `all`: everyone is allowed to call the plugin
- `org`: only org members are allowed to call the plugin
- `team`: only the requested team is allowed to call the plugin. If no requested team can be found the configured default team will be used instead.

`skip` plugin is added to manually skip failed steps.
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Enhanced the authorization of the github bot
```
```improvement user
Added `skip` plugin to manually skip failed testmachinery test in a PR
```
