### PR TITLE
Add system component annotation

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -15,6 +15,11 @@
 package common
 
 const (
+	AnnotationSystemStep = "testmachinery.sapcloud.io/system-step"
+)
+
+// images
+const (
 	DockerImageGardenerApiServer = "eu.gcr.io/gardener-project/gardener/apiserver"
 )
 

--- a/pkg/testrunner/renderer/templates/steps.go
+++ b/pkg/testrunner/renderer/templates/steps.go
@@ -16,6 +16,7 @@ package templates
 
 import (
 	"fmt"
+	"github.com/gardener/test-infra/pkg/common"
 	"strconv"
 
 	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
@@ -26,6 +27,9 @@ import (
 func GetStepLockHost(provider hostscheduler.Provider, cloudprovider gardenv1beta1.CloudProvider) v1beta1.DAGStep {
 	return v1beta1.DAGStep{
 		Name: "prepare-host",
+		Annotations: map[string]string{
+			common.AnnotationSystemStep: "true",
+		},
 		Definition: v1beta1.StepDefinition{
 			Name:        fmt.Sprintf("tm-scheduler-lock-%s", provider),
 			LocationSet: &TestInfraLocationName,
@@ -43,6 +47,9 @@ func GetStepLockHost(provider hostscheduler.Provider, cloudprovider gardenv1beta
 func GetStepReleaseHost(provider hostscheduler.Provider, dependencies []string, clean bool) v1beta1.DAGStep {
 	step := v1beta1.DAGStep{
 		Name: "release-host",
+		Annotations: map[string]string{
+			common.AnnotationSystemStep: "true",
+		},
 		Definition: v1beta1.StepDefinition{
 			Name:        fmt.Sprintf("tm-scheduler-release-%s", provider),
 			LocationSet: &TestInfraLocationName,

--- a/pkg/tm-bot/tests/status.go
+++ b/pkg/tm-bot/tests/status.go
@@ -94,7 +94,7 @@ func (u *StatusUpdater) Update(tr *tmv1beta1.Testrun, argoUrl string) error {
 		return err
 	}
 
-	state := GitHubState[tr.Status.Phase]
+	state := GitHubState[util.TestrunStatusPhase(tr)]
 	if err := u.UpdateStatus(state, tr.Name); err != nil {
 		return err
 	}
@@ -159,5 +159,5 @@ Phase: %s
 %s
 </pre>
 `
-	return fmt.Sprintf(format, tr.Name, argo, tr.Status.Phase, statusTable.String())
+	return fmt.Sprintf(format, tr.Name, argo, util.TestrunStatusPhase(tr), statusTable.String())
 }

--- a/pkg/util/testrun.go
+++ b/pkg/util/testrun.go
@@ -1,0 +1,39 @@
+// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	argov1alpha1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
+	"github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
+	"github.com/gardener/test-infra/pkg/common"
+)
+
+// TestrunStatusPhase determines the real testrun phase of a testrun by ignoring exit handler failures and system component failures if all other tests passed.
+func TestrunStatusPhase(tr *v1beta1.Testrun) argov1alpha1.NodePhase {
+	if tr.Status.Phase == v1beta1.PhaseStatusSuccess {
+		return v1beta1.PhaseStatusSuccess
+	}
+
+	for _, step := range tr.Status.Steps {
+		if step.Phase == v1beta1.PhaseStatusInit {
+			continue
+		}
+		if step.Phase != v1beta1.PhaseStatusSuccess && step.Annotations[common.AnnotationSystemStep] != "true" {
+			return step.Phase
+		}
+	}
+
+	return v1beta1.PhaseStatusSuccess
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
System steps (like lock and release) currently influence the status of a testrun so taht possible succesfull tests are rejeted because some testmachinery infrastructure issue.
This failure rate should be minimized and testruns that successfully run all on system steps shiuld still succeed.

To ignore such steps, a annotation is added that is respected by the helper method `TestrunStatusPhase` to get the real outcome of the tests


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
