### PR TITLE
disabling metrics as they're broken since argo v2.4.0

### DIFF
--- a/charts/bootstrap_tm_prerequisites/templates/argo.yaml
+++ b/charts/bootstrap_tm_prerequisites/templates/argo.yaml
@@ -42,7 +42,7 @@ data:
               name: {{.Values.objectStorage.secret.name}}
               key: secretKey
         metricsConfig:
-          enabled: true
+          enabled: false # because metrics are broken since v2.4.0: https://github.com/argoproj/argo/issues/1634
           path: /metrics
           port: 80
 ---


### PR DESCRIPTION
**What this PR does / why we need it**:
Disables metrics server of argo as it is broken since argo `v2.4.0`, see https://github.com/argoproj/argo/issues/1634

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator

```
