### PR TITLE
Fix special testflow case that results in a invalid workflow

### DIFF
--- a/cmd/testmachinery-controller/main.go
+++ b/cmd/testmachinery-controller/main.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 
+	goflag "flag"
 	flag "github.com/spf13/pflag"
 
 	"github.com/gardener/test-infra/pkg/logger"
@@ -91,6 +92,7 @@ func init() {
 	logger.InitFlags(nil)
 	testmachinery.InitFlags(nil)
 	server.InitFlags(nil)
+	flag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 	flag.Parse()
 
 	log, err := logger.New(nil)

--- a/pkg/testmachinery/testflow/flow_operations.go
+++ b/pkg/testmachinery/testflow/flow_operations.go
@@ -212,7 +212,7 @@ func getNextSerialParent(n *node.Node, filters ...nodeFilterFunc) *node.Node {
 		branches[i] = node.NewSet()
 	}
 
-	for len(lastParents) != 0 {
+	for !emptyNodeList(lastParents) {
 		parent, lastParents = getJointNodes(lastParents, branches, getNextSerialParent)
 		if parent != nil && checkFilter(parent, filters...) {
 			return parent
@@ -240,7 +240,7 @@ func getNextSerialChild(n *node.Node, filters ...nodeFilterFunc) *node.Node {
 		branches[i] = node.NewSet()
 	}
 
-	for len(lastChildren) != 0 {
+	for !emptyNodeList(lastChildren) {
 		child, lastChildren = getJointNodes(lastChildren, branches, getNextSerialChild)
 		if child != nil && checkFilter(child, filters...) {
 			return child
@@ -251,10 +251,13 @@ func getNextSerialChild(n *node.Node, filters ...nodeFilterFunc) *node.Node {
 }
 
 func getJointNodes(nodes []*node.Node, branches []*node.Set, getNext func(*node.Node, ...nodeFilterFunc) *node.Node) (*node.Node, []*node.Node) {
-	lastNodes := make([]*node.Node, 0)
+	lastNodes := make([]*node.Node, len(nodes))
 	for i, n := range nodes {
+		if n == nil {
+			continue
+		}
 		if nextNode := getNext(n); nextNode != nil {
-			lastNodes = append(lastNodes, nextNode)
+			lastNodes[i] = nextNode
 			branches[i].Add(nextNode)
 		}
 	}
@@ -287,6 +290,16 @@ func findJointNode(nodeSets []*node.Set) *node.Node {
 		}
 	}
 	return nil
+}
+
+// emptyNodeList checks if all nodes of a node list are nil
+func emptyNodeList(nodes []*node.Node) bool {
+	for _, n := range nodes {
+		if n != nil {
+			return false
+		}
+	}
+	return true
 }
 
 func checkFilter(node *node.Node, filters ...nodeFilterFunc) bool {

--- a/pkg/testmachinery/testflow/flow_operations_test.go
+++ b/pkg/testmachinery/testflow/flow_operations_test.go
@@ -204,24 +204,7 @@ var _ = Describe("flow operations", func() {
 			B := testNode("B", node.NewSet(A), defaultTestDef, testDAGStep([]string{"A"}))
 			C := testNode("C", node.NewSet(A), defaultTestDef, testDAGStep([]string{"A"}))
 			D := testNode("D", node.NewSet(B, C), defaultTestDef, testDAGStep([]string{"B", "C"}))
-			steps := map[string]*testflow.Step{
-				"A": {
-					Info:  A.Step(),
-					Nodes: node.NewSet(A),
-				},
-				"B": {
-					Info:  B.Step(),
-					Nodes: node.NewSet(B),
-				},
-				"C": {
-					Info:  C.Step(),
-					Nodes: node.NewSet(C),
-				},
-				"D": {
-					Info:  D.Step(),
-					Nodes: node.NewSet(D),
-				},
-			}
+			steps := createStepsFromNodes(A, B, C, D)
 
 			Expect(testflow.ApplyOutputScope(steps)).ToNot(HaveOccurred())
 
@@ -245,24 +228,7 @@ var _ = Describe("flow operations", func() {
 			B := testNode("B", node.NewSet(A), defaultTestDef, testDAGStepB)
 			C := testNode("C", node.NewSet(B), defaultTestDef, testDAGStep([]string{"B"}))
 			D := testNode("D", node.NewSet(C), defaultTestDef, testDAGStep([]string{"C"}))
-			steps := map[string]*testflow.Step{
-				"A": {
-					Info:  A.Step(),
-					Nodes: node.NewSet(A),
-				},
-				"B": {
-					Info:  B.Step(),
-					Nodes: node.NewSet(B),
-				},
-				"C": {
-					Info:  C.Step(),
-					Nodes: node.NewSet(C),
-				},
-				"D": {
-					Info:  D.Step(),
-					Nodes: node.NewSet(D),
-				},
-			}
+			steps := createStepsFromNodes(A, B, C, D)
 
 			Expect(testflow.ApplyOutputScope(steps)).ToNot(HaveOccurred())
 
@@ -282,24 +248,7 @@ var _ = Describe("flow operations", func() {
 			B := testNode("B", node.NewSet(A), defaultTestDef, testDAGStepB)
 			C := testNode("C", node.NewSet(B), defaultTestDef, testDAGStep([]string{"B"}))
 			D := testNode("D", node.NewSet(C), defaultTestDef, testDAGStep([]string{"C"}))
-			steps := map[string]*testflow.Step{
-				"A": {
-					Info:  A.Step(),
-					Nodes: node.NewSet(A),
-				},
-				"B": {
-					Info:  B.Step(),
-					Nodes: node.NewSet(B),
-				},
-				"C": {
-					Info:  C.Step(),
-					Nodes: node.NewSet(C),
-				},
-				"D": {
-					Info:  D.Step(),
-					Nodes: node.NewSet(D),
-				},
-			}
+			steps := createStepsFromNodes(A, B, C, D)
 
 			Expect(testflow.ApplyOutputScope(steps)).ToNot(HaveOccurred())
 
@@ -320,20 +269,7 @@ var _ = Describe("flow operations", func() {
 			A := testNode("ZA", node.NewSet(rootNode), defaultTestDef, testDAGStepA)
 			C := testNode("ZC", node.NewSet(A), defaultTestDef, testDAGStepC)
 			B := testNode("ZB", node.NewSet(C), defaultTestDef, testDAGStep([]string{"ZC"}))
-			steps := map[string]*testflow.Step{
-				"A": {
-					Info:  A.Step(),
-					Nodes: node.NewSet(A),
-				},
-				"B": {
-					Info:  B.Step(),
-					Nodes: node.NewSet(B),
-				},
-				"C": {
-					Info:  C.Step(),
-					Nodes: node.NewSet(C),
-				},
-			}
+			steps := createStepsFromNodes(A, B, C)
 
 			Expect(testflow.ApplyOutputScope(steps)).ToNot(HaveOccurred())
 
@@ -363,36 +299,7 @@ var _ = Describe("flow operations", func() {
 			E := testNode("E", node.NewSet(C), defaultTestDef, testDAGStepE)
 			F := testNode("F", node.NewSet(C), defaultTestDef, testDAGStepF)
 			G := testNode("G", node.NewSet(D, E, F), defaultTestDef, testDAGStep([]string{"D", "E", "F"}))
-			steps := map[string]*testflow.Step{
-				"A": {
-					Info:  A.Step(),
-					Nodes: node.NewSet(A),
-				},
-				"B": {
-					Info:  B.Step(),
-					Nodes: node.NewSet(B),
-				},
-				"C": {
-					Info:  C.Step(),
-					Nodes: node.NewSet(C),
-				},
-				"D": {
-					Info:  D.Step(),
-					Nodes: node.NewSet(D),
-				},
-				"E": {
-					Info:  E.Step(),
-					Nodes: node.NewSet(E),
-				},
-				"F": {
-					Info:  F.Step(),
-					Nodes: node.NewSet(F),
-				},
-				"G": {
-					Info:  G.Step(),
-					Nodes: node.NewSet(G),
-				},
-			}
+			steps := createStepsFromNodes(A, B, C, D, E, F, G)
 
 			Expect(testflow.ApplyOutputScope(steps)).ToNot(HaveOccurred())
 
@@ -402,6 +309,22 @@ var _ = Describe("flow operations", func() {
 			Expect(D.GetInputSource()).To(Equal(A))
 			Expect(E.GetInputSource()).To(Equal(A))
 			Expect(F.GetInputSource()).To(Equal(A))
+			Expect(G.GetInputSource()).To(Equal(A))
+		})
+
+		It("should set the last serial parent as artifact source", func() {
+			rootNode := testNode("root", node.NewSet(), defaultTestDef, nil)
+			A := testNode("A", node.NewSet(rootNode), defaultTestDef, testDAGStep([]string{}))
+			B := testNode("B", node.NewSet(A), defaultTestDef, testDAGStep([]string{"A"}))
+			C := testNode("C", node.NewSet(A), defaultTestDef, testDAGStepWitContinueOnError([]string{"B"}))
+			D := testNode("D", node.NewSet(B), defaultTestDef, testDAGStepWitContinueOnError([]string{"B"}))
+			E := testNode("E", node.NewSet(D), defaultTestDef, testDAGStepWitContinueOnError([]string{"D"}))
+			F := testNode("F", node.NewSet(E), defaultTestDef, testDAGStepWitContinueOnError([]string{"E"}))
+			G := testNode("G", node.NewSet(C, F), defaultTestDef, testDAGStep([]string{"C", "F"}))
+			steps := createStepsFromNodes(A, B, C, D, E, F, G)
+
+			Expect(testflow.ApplyOutputScope(steps)).ToNot(HaveOccurred())
+			Expect(rootNode.HasOutput()).To(BeTrue())
 			Expect(G.GetInputSource()).To(Equal(A))
 		})
 
@@ -720,6 +643,13 @@ func testDAGStepWithConfig(dependencies []string, elements []v1beta1.ConfigEleme
 	return step
 }
 
+func testDAGStepWitContinueOnError(dependencies []string) *v1beta1.DAGStep {
+	step := testDAGStep(dependencies)
+	step.Definition.ContinueOnError = true
+
+	return step
+}
+
 var serialTestDef = func() testdefinition.TestDefinition {
 	return testdefinition.TestDefinition{
 		Info: &v1beta1.TestDefinition{
@@ -736,4 +666,15 @@ func testDefWithConfig(cfgs []v1beta1.ConfigElement) *testdefinition.TestDefinit
 	td := testdefinition.NewEmpty()
 	td.AddConfig(config.New(cfgs, config.LevelTestDefinition))
 	return td
+}
+
+func createStepsFromNodes(nodes ...*node.Node) map[string]*testflow.Step {
+	steps := make(map[string]*testflow.Step)
+	for _, n := range nodes {
+		steps[n.Name()] = &testflow.Step{
+			Info:  n.Step(),
+			Nodes: node.NewSet(n),
+		}
+	}
+	return steps
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This Pr fixes a invalid workflow generation for a special testflow structure.
All testflows where a branch has more elements than a parallel branch would have up to the root note are affected.
e.g.
```
   A
  /  \
 B    C
 |    |
 |    D
 |    |
 |    E
 \   /
   F
```

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Fixed a special testflow case that results in an invalid argo workflow
```
