### PR TITLE
add flag retryFailedTestcases which allows to retry failed e2e testcases in separate kubetest call to reduce flakiness

### DIFF
--- a/.test-defs/allE2eTestgrid.yaml
+++ b/.test-defs/allE2eTestgrid.yaml
@@ -51,5 +51,5 @@ spec:
   - >-
     export E2E_EXPORT_PATH=$TM_EXPORT_PATH &&
     export E2E_KUBECONFIG_PATH=$TM_KUBECONFIG_PATH/shoot.config &&
-    go run --mod=vendor ./integration-tests/e2e -cleanUpAfterwards=true -flakeAttempts=5
+    go run --mod=vendor ./integration-tests/e2e -cleanUpAfterwards=true -flakeAttempts=5 -retryFailedTestcases=true
   image: golang:1.13

--- a/.test-defs/e2eFast.yaml
+++ b/.test-defs/e2eFast.yaml
@@ -38,5 +38,5 @@ spec:
   - >-
     export E2E_EXPORT_PATH=$TM_EXPORT_PATH &&
     export E2E_KUBECONFIG_PATH=$TM_KUBECONFIG_PATH/shoot.config &&
-    go run -mod=vendor ./integration-tests/e2e -cleanUpAfterwards=true -flakeAttempts=5
+    go run -mod=vendor ./integration-tests/e2e -cleanUpAfterwards=true -flakeAttempts=5 -retryFailedTestcases=true
   image: golang:1.13

--- a/.test-defs/e2eSlow.yaml
+++ b/.test-defs/e2eSlow.yaml
@@ -39,5 +39,5 @@ spec:
   - >-
     export E2E_EXPORT_PATH=$TM_EXPORT_PATH &&
     export E2E_KUBECONFIG_PATH=$TM_KUBECONFIG_PATH/shoot.config &&
-    go run -mod=vendor ./integration-tests/e2e -cleanUpAfterwards=true -flakeAttempts=5
+    go run -mod=vendor ./integration-tests/e2e -cleanUpAfterwards=true -flakeAttempts=5 -retryFailedTestcases=true
   image: golang:1.13

--- a/integration-tests/e2e/config/config.go
+++ b/integration-tests/e2e/config/config.go
@@ -57,6 +57,7 @@ var (
 	ExplicitTestcases        arrayTestcase
 	DownloadsDir             string
 	RunCleanUpAfterTest      bool
+	RetryFailedTestcases     bool
 )
 
 const (
@@ -79,6 +80,7 @@ func init() {
 	flag.IntVar(&FlakeAttempts, "flakeAttempts", 2, "Testcase flake attempts. Will run testcase n times, until it is successful")
 	flag.StringVar(&TestcaseGroupString, "testcasegroup", "", "Testcase groups to run (conformance, fast, slow")
 	flag.Var(&ExplicitTestcases, "testcase", "List of testcases. If used description file and execution group are ingored.")
+	flag.BoolVar(&RetryFailedTestcases, "retryFailedTestcases", false, "List of testcases. If used description file and execution group are ingored.")
 	flag.Parse()
 	if Debug {
 		log.SetLevel(log.DebugLevel)

--- a/integration-tests/e2e/config/config.go
+++ b/integration-tests/e2e/config/config.go
@@ -80,7 +80,7 @@ func init() {
 	flag.IntVar(&FlakeAttempts, "flakeAttempts", 2, "Testcase flake attempts. Will run testcase n times, until it is successful")
 	flag.StringVar(&TestcaseGroupString, "testcasegroup", "", "Testcase groups to run (conformance, fast, slow")
 	flag.Var(&ExplicitTestcases, "testcase", "List of testcases. If used description file and execution group are ingored.")
-	flag.BoolVar(&RetryFailedTestcases, "retryFailedTestcases", false, "List of testcases. If used description file and execution group are ingored.")
+	flag.BoolVar(&RetryFailedTestcases, "retryFailedTestcases", false, "runs an additional kubetest run for failed tests only")
 	flag.Parse()
 	if Debug {
 		log.SetLevel(log.DebugLevel)

--- a/integration-tests/e2e/kubetest/results_evaluator.go
+++ b/integration-tests/e2e/kubetest/results_evaluator.go
@@ -122,7 +122,7 @@ func analyzeJunitXMLsEnrichSummary(junitXMLFilePaths []string, summary *Summary)
 
 func addFlakynessInfoToSummary(summary *Summary, failureOccurrences *map[string]int) {
 	for testcaseName, failureOccurrence := range *failureOccurrences {
-		if failureOccurrence != config.FlakeAttempts {
+		if failureOccurrence < config.FlakeAttempts {
 			// testcase had failures and successes
 			summary.FlakedTestcases++
 		} else {
@@ -130,6 +130,8 @@ func addFlakynessInfoToSummary(summary *Summary, failureOccurrences *map[string]
 			summary.FailedTestcaseNames = append(summary.FailedTestcaseNames, testcaseName)
 		}
 	}
+	summary.FailedTestcases = len(summary.FailedTestcaseNames)
+	summary.TestsuiteSuccessful = summary.FailedTestcases == 0
 	if summary.FlakedTestcases != 0 {
 		summary.Flaked = true
 	}
@@ -183,8 +185,6 @@ func analyzeE2eLogs(e2eLogFilePaths []string) (Summary, error) {
 					return summary, errors.Wrapf(err, "Empty or non integer values in map, for regexp '%s'", regexpPassedFailed.String())
 				}
 				summary.SuccessfulTestcases += groupToValueInt["Passed"]
-				summary.FailedTestcases += groupToValueInt["Failed"]
-				summary.TestsuiteSuccessful = summary.FailedTestcases == 0
 			}
 			if regexpGinkgoRanIn.MatchString(lineString) {
 				log.Info(lineString)

--- a/integration-tests/e2e/main.go
+++ b/integration-tests/e2e/main.go
@@ -24,7 +24,7 @@ func main() {
 			log.Fatalf("failed to clean dir '%s': %s", config.ExportPath, err)
 		}
 		if err := os.MkdirAll(config.ExportPath, os.FileMode(0777)); err != nil {
-			log.Fatalf("failed to clean dir '%s': %s", config.ExportPath, err)
+			log.Fatalf("failed to create dir '%s': %s", config.ExportPath, err)
 		}
 		desc = createDescFileOfFailedTestcases(resultSummary.FailedTestcaseNames)
 		kubetestResultsPath = kubetest.Run(desc)

--- a/integration-tests/e2e/main.go
+++ b/integration-tests/e2e/main.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"bufio"
 	"github.com/gardener/test-infra/integration-tests/e2e/config"
 	"github.com/gardener/test-infra/integration-tests/e2e/kubetest"
 	"github.com/gardener/test-infra/integration-tests/e2e/kubetest/setup"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+	"os"
+	"path/filepath"
 )
 
 func main() {
@@ -15,6 +18,18 @@ func main() {
 	desc := kubetest.Generate()
 	kubetestResultsPath := kubetest.Run(desc)
 	resultSummary := kubetest.Analyze(kubetestResultsPath)
+
+	if config.RetryFailedTestcases {
+		if err := os.RemoveAll(config.ExportPath); err != nil {
+			log.Fatalf("failed to clean dir '%s': %s", config.ExportPath, err)
+		}
+		if err := os.MkdirAll(config.ExportPath, os.FileMode(0777)); err != nil {
+			log.Fatalf("failed to clean dir '%s': %s", config.ExportPath, err)
+		}
+		desc = createDescFileOfFailedTestcases(resultSummary.FailedTestcaseNames)
+		kubetestResultsPath = kubetest.Run(desc)
+		resultSummary = kubetest.Analyze(kubetestResultsPath)
+	}
 	if config.PublishResultsToTestgrid == true && resultSummary.TestsuiteSuccessful == true {
 		kubetest.Publish(config.ExportPath, resultSummary)
 	}
@@ -26,4 +41,25 @@ func main() {
 	if !resultSummary.TestsuiteSuccessful {
 		log.Fatalf("e2e testsuite failed for %d testcases: %v", resultSummary.FailedTestcases, resultSummary.FailedTestcaseNames)
 	}
+}
+
+func createDescFileOfFailedTestcases(failedTestcases []string) string {
+	generatedRunDescPath := filepath.Join(config.TmpDir, "failedTestcasesDescription.txt")
+	file, err := os.OpenFile(generatedRunDescPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+
+	if err != nil {
+		log.Fatalf("failed creating file: %s", err)
+	}
+	datawriter := bufio.NewWriter(file)
+	for _, testcase := range failedTestcases {
+		_, _ = datawriter.WriteString(testcase + "\n")
+	}
+	if err := datawriter.Flush(); err != nil {
+		log.Fatalf("failed to flush data writer %s", err)
+	}
+	if err := file.Close(); err != nil {
+		log.Fatalf("failed to close file %s", err)
+	}
+
+	return file.Name()
 }

--- a/pkg/testrunner/result/status-uploader.go
+++ b/pkg/testrunner/result/status-uploader.go
@@ -122,7 +122,7 @@ func getRelease(githubClient *github.Client, repoOwner, repoName, componentVersi
 			return nil, errors.New(fmt.Sprintf("Github releases GET failed with status code %d", response.StatusCode))
 		}
 		for _, release := range releases {
-			if *release.Draft && *release.Name == releaseName.String() {
+			if *release.Draft && strings.Contains(*release.Name, releaseName.String()) {
 				return release, nil
 			}
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
add flag retryFailedTestcases which allows to retry failed e2e testcases in separate kubetest call to reduce flakiness

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```
add flag retryFailedTestcases which allows to retry failed e2e testcases in separate kubetest call to reduce flakiness

```
