### PR TITLE
Add support for argo 2.4.1

### DIFF
--- a/charts/bootstrap_tm_prerequisites/values.yaml
+++ b/charts/bootstrap_tm_prerequisites/values.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 argo:
-  tag: v2.3.0
+  tag: v2.4.1
   containerRuntimeExecutor: docker
 
 configmap:

--- a/charts/testmachinery/templates/deployment-tm-controller.yaml
+++ b/charts/testmachinery/templates/deployment-tm-controller.yaml
@@ -49,8 +49,6 @@ spec:
         - --key-file=/etc/testmachinery-controller/srv/tls.key
         - --namespace={{ .Release.Namespace }}
         - --enable-pod-gc={{ .Values.cleanup.enabled }}
-        - --base-image={{ .Values.controller.steps.baseImage }}
-        - --prepare-image={{ .Values.controller.steps.prepareImage }}
         - -v={{ .Values.controller.verbosity }}
         {{- if .Values.secrets.github.data }}
         - --github-secrets-path={{ .Values.secrets.github.path }}/github-secrets.yaml

--- a/charts/testmachinery/values.yaml
+++ b/charts/testmachinery/values.yaml
@@ -24,10 +24,6 @@ controller:
   testDefPath: ""
   verbosity: 2
 
-  steps:
-    baseImage: eu.gcr.io/gardener-project/gardener/testmachinery/base-step:0.69.0
-    prepareImage: eu.gcr.io/gardener-project/gardener/testmachinery/prepare-step:0.69.0
-
   serviceAccountName: testmachinery-controller
   webhook:
     http:

--- a/hack/images/prepare/prepare
+++ b/hack/images/prepare/prepare
@@ -15,7 +15,11 @@
 # limitations under the License.
 FILEPATH="$1"
 
-for repo in $(cat "$FILEPATH" | jq -c '.[]' ); do
+for d in $(cat "$FILEPATH" | jq -c '.directories[]' ); do
+    mkdir -p $d
+done
+
+for repo in $(cat "$FILEPATH" | jq -c '.repositories[]' ); do
     url=$( echo $repo | jq -r '.url')
     revision=$( echo $repo | jq -r '.revision')
     name=$( echo $repo | jq -r '.name')

--- a/pkg/testmachinery/prepare/types.go
+++ b/pkg/testmachinery/prepare/types.go
@@ -2,11 +2,22 @@ package prepare
 
 import "github.com/gardener/test-infra/pkg/testmachinery/testdefinition"
 
-// PrepareDefinition is the TestDefinition of the prepare step to initiliaze the setup.
+const (
+	PrepareConfigPath = "/tm/config.json"
+)
+
+// PrepareDefinition is the TestDefinition of the prepare step to initialiaze the setup.
 type Definition struct {
 	TestDefinition *testdefinition.TestDefinition
 	GlobalInput    bool
-	repositories   map[string]*Repository
+	config         Config
+}
+
+// Config represents the configuration for the prepare step.
+// It defined which repos should be cloned and which folder have to be created
+type Config struct {
+	Directories  []string               `json:"directories"`
+	Repositories map[string]*Repository `json:"repositories"`
 }
 
 // PrepareRepository is passed as a json array to the prepare step.

--- a/pkg/testmachinery/testmachinery.go
+++ b/pkg/testmachinery/testmachinery.go
@@ -16,6 +16,7 @@ package testmachinery
 
 import (
 	"fmt"
+	"github.com/gardener/test-infra/pkg/version"
 	"io/ioutil"
 	"os"
 
@@ -69,9 +70,9 @@ func InitFlags(flagset *flag.FlagSet) {
 
 	flagset.StringVar(&TESTDEF_PATH, "testdef-path", util.Getenv("TESTDEF_PATH", ".test-defs"),
 		"Set repository path where the Test Machinery should search for testdefinition")
-	flagset.StringVar(&PREPARE_IMAGE, "prepare-image", util.Getenv("PREPARE_IMAGE", "eu.gcr.io/gardener-project/gardener/testmachinery/prepare-step:latest"),
+	flagset.StringVar(&PREPARE_IMAGE, "prepare-image", util.Getenv("PREPARE_IMAGE", fmt.Sprintf("eu.gcr.io/gardener-project/gardener/testmachinery/prepare-step:%s", version.Get().GitVersion)),
 		"Set the prepare image that is used in the prepare and postprepare step")
-	flagset.StringVar(&BASE_IMAGE, "base-image", util.Getenv("BASE_IMAGE", "eu.gcr.io/gardener-project/gardener/testmachinery/base-step:latest"),
+	flagset.StringVar(&BASE_IMAGE, "base-image", util.Getenv("BASE_IMAGE", fmt.Sprintf("eu.gcr.io/gardener-project/gardener/testmachinery/base-step:%s", version.Get().GitVersion)),
 		"Set the base image that is used as the default image if a TestDefinition does not define a image")
 
 	flag.BoolVar(&tmConfig.Local, "local", false, "The controller runs outside of a cluster.")


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Adding support for Argo 2.4.1 by creating all testmachinery directories at startup in the prepare step.

Also base and prepare images are now build with every new release and are also used by default

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Add support for Argo 2.4.1
```
