### PR TITLE
Update argo to 2.4.2

### DIFF
--- a/charts/bootstrap_tm_prerequisites/templates/argo.yaml
+++ b/charts/bootstrap_tm_prerequisites/templates/argo.yaml
@@ -42,7 +42,7 @@ data:
               name: {{.Values.objectStorage.secret.name}}
               key: secretKey
         metricsConfig:
-          enabled: false # because metrics are broken since v2.4.0: https://github.com/argoproj/argo/issues/1634
+          enabled: true # fixed in 2.4.2
           path: /metrics
           port: 80
 ---

--- a/charts/bootstrap_tm_prerequisites/values.yaml
+++ b/charts/bootstrap_tm_prerequisites/values.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 argo:
-  tag: v2.4.1
+  tag: v2.4.2
   containerRuntimeExecutor: docker
 
 configmap:

--- a/cmd/prepare/main.go
+++ b/cmd/prepare/main.go
@@ -22,7 +22,6 @@ import (
 	"os"
 )
 
-
 func init() {
 	logger.InitFlags(nil)
 }

--- a/cmd/prepare/prepare.go
+++ b/cmd/prepare/prepare.go
@@ -36,7 +36,7 @@ for repo in $(cat "$FILEPATH" | jq -c '.repositories[]' ); do
     rm -rf .git
     popd
 done
- */
+*/
 
 import (
 	"encoding/json"
@@ -70,7 +70,7 @@ func runPrepare(log logr.Logger, cfg *prepare.Config, repoBasePath string) error
 		repoPath := path.Join(repoBasePath, repo.Name)
 		log.Info("Clone repo", "repo", repo.URL, "revision", repo.Revision, "path", repoPath)
 
-		if err := runGit(cwd, "clone", "-v",  repo.URL, repoPath); err != nil {
+		if err := runGit(cwd, "clone", "-v", repo.URL, repoPath); err != nil {
 			return err
 		}
 
@@ -111,7 +111,7 @@ func runGit(pwd string, args ...string) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	if err :=  cmd.Run(); err != nil {
+	if err := cmd.Run(); err != nil {
 		return errors.Wrap(err, fmt.Sprintf("Command: %s", strings.Join(args, " ")))
 	}
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
reenable metrics for argo as it is fixed in 2.4.2
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Updated argo to 2.4.2
```
