### PR TITLE
avoid ingesting all failed retries of e2e testcases

### DIFF
--- a/integration-tests/e2e/kubetest/xml_junit_result.go
+++ b/integration-tests/e2e/kubetest/xml_junit_result.go
@@ -58,4 +58,5 @@ type TestcaseResult struct {
 	TestDesc       string    `xml:"-" json:"test_desc_file"`  // calculated
 	ExecutionGroup string    `xml:"-" json:"execution_group"` // calculated
 	Successful     bool      `xml:"-" json:"successful"`      // calculated
+	Flaked         int       `xml:"-" json:"flaked"`          // calculated
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
avoid ingesting all failed retries of e2e testcases

**Which issue(s) this PR fixes**:
multiple redundant failed e2e testcase documents in elasticsearch, which falsifies the evaluation in Kibana.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```
avoid ingesting all failed retries of e2e testcases
```
