### PR TITLE
Specify specific kubernetes versions per cloudprovider

### DIFF
--- a/cmd/testrunner/cmd/run_gardener/run.go
+++ b/cmd/testrunner/cmd/run_gardener/run.go
@@ -50,6 +50,8 @@ var (
 
 	testrunNamePrefix       string
 	componentDescriptorPath string
+	kubernetesVersions      []string
+	cloudproviders          []v1beta1.CloudProvider
 	testLabel               string
 	hibernation             bool
 )
@@ -76,6 +78,15 @@ var runCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
+		shootFlavors := make([]templates.ShootFlavor, len(cloudproviders))
+		for i, cp := range cloudproviders {
+			shootFlavors[i] = templates.ShootFlavor{
+				CloudProvider:      cp,
+				KubernetesVersions: util.ConvertStringArrayToVersions(kubernetesVersions),
+			}
+		}
+
+		defaultConfig.Shoots.Flavors = shootFlavors
 		defaultConfig.Components = components
 		defaultConfig.Namespace = testrunnerConfig.Namespace
 		defaultConfig.Shoots.DefaultTest = templates.TestWithLabels(testLabel)
@@ -171,8 +182,8 @@ func init() {
 	runCmd.Flags().StringVar(&defaultConfig.Gardener.Commit, "gardener-commit", "", "Specify the gardener commit that is deployed by garden setup")
 
 	runCmd.Flags().StringVar(&defaultConfig.Shoots.Namespace, "project-namespace", "garden-core", "Specify the shoot namespace where the shoots should be created")
-	runCmd.Flags().StringArrayVar(&defaultConfig.Shoots.KubernetesVersions, "kubernetes-version", []string{}, "Specify the kubernetes version to test")
-	runCmd.Flags().VarP(cmdvalues.NewCloudProviderArrayValue(&defaultConfig.Shoots.CloudProviders, v1beta1.CloudProviderGCP, v1beta1.CloudProviderGCP, v1beta1.CloudProviderAWS, v1beta1.CloudProviderAzure), "cloudprovider", "p", "Specify the cloudproviders to test.")
+	runCmd.Flags().StringArrayVar(&kubernetesVersions, "kubernetes-version", []string{}, "Specify the kubernetes version to test")
+	runCmd.Flags().VarP(cmdvalues.NewCloudProviderArrayValue(&cloudproviders, v1beta1.CloudProviderGCP, v1beta1.CloudProviderGCP, v1beta1.CloudProviderAWS, v1beta1.CloudProviderAzure), "cloudprovider", "p", "Specify the cloudproviders to test.")
 
 	runCmd.Flags().StringVarP(&testLabel, "label", "l", string(testmachinery.TestLabelDefault), "Specify test label that should be fetched by the testmachinery")
 	runCmd.Flags().BoolVar(&hibernation, "hibernation", false, "test hibernation")

--- a/cmd/tm-bot/README.md
+++ b/cmd/tm-bot/README.md
@@ -79,7 +79,17 @@ Usage:
       --kubernetes-version stringArray     Specify the kubernetes version to test
   -l, --label string                       Specify test label that should be fetched by the testmachinery (default "default")
       --namespace string                   Testrun namespace (default "default")
+      --pause                              Pauses the testrun before gardener is deleted
       --project-namespace string           Specify the shoot namespace where the shoots should be created (default "garden-core")
+```
+
+#### Resume
+Resumes a paused testrun.
+```
+Command resume
+Resumes the last paused testrun
+
+Example: /resume
 ```
 
 
@@ -97,10 +107,9 @@ test:
     version: # StringOrGitHubConfig
     commit: # StringOrGitHubConfig
 
-  kubernetes:
-    versions: # []string
-
-  cloudproviders: # []CloudProvider
+  shootFlavors:
+  - cloudprovider: # cloudprovider e.g. aws
+    kubernetesVersions: # []string
 ```
 
 ```yaml

--- a/pkg/testrunner/renderer/default/testrun.go
+++ b/pkg/testrunner/renderer/default/testrun.go
@@ -34,7 +34,7 @@ type shoot struct {
 func testrun(cfg *Config, shoots []*shoot) (*v1beta1.Testrun, error) {
 	gsLocationName := "gs"
 	prepareHostCluster := templates.GetStepLockHost(cfg.HostProvider, cfg.BaseClusterCloudprovider)
-	createGardener, err := templates.GetStepCreateGardener(gsLocationName, []string{prepareHostCluster.Name}, cfg.BaseClusterCloudprovider, cfg.Shoots.KubernetesVersions, cfg.Gardener)
+	createGardener, err := templates.GetStepCreateGardener(gsLocationName, []string{prepareHostCluster.Name}, cfg.BaseClusterCloudprovider, cfg.Shoots.Flavors, cfg.Gardener)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tm-bot/plugins/tests/test.go
+++ b/pkg/tm-bot/plugins/tests/test.go
@@ -15,6 +15,7 @@
 package tests
 
 import (
+	"github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	_default "github.com/gardener/test-infra/pkg/testrunner/renderer/default"
 	"github.com/gardener/test-infra/pkg/tm-bot/github"
@@ -31,10 +32,12 @@ type test struct {
 	timeout   time.Duration
 	interval  time.Duration
 
-	config      _default.Config
-	testLabel   string
-	hibernation bool
-	dryRun      bool
+	config             _default.Config
+	kubernetesVersions []string
+	cloudproviders     []v1beta1.CloudProvider
+	testLabel          string
+	hibernation        bool
+	dryRun             bool
 }
 
 func New(log logr.Logger, k8sClient kubernetes.Interface) plugins.Plugin {

--- a/pkg/tm-bot/plugins/tests/types.go
+++ b/pkg/tm-bot/plugins/tests/types.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/test-infra/pkg/hostscheduler"
+	"github.com/gardener/test-infra/pkg/testrunner/renderer/templates"
 	"github.com/gardener/test-infra/pkg/tm-bot/github/ghval"
 )
 
@@ -33,11 +34,7 @@ type DefaultsConfig struct {
 		Commit  *ghval.StringOrGitHubValue `json:"commit"`
 	} `json:"gardener"`
 
-	Kubernetes *struct {
-		Versions *[]string `json:"versions"`
-	} `json:"kubernetes"`
-
-	CloudProviders *[]v1beta1.CloudProvider `json:"cloudproviders"`
+	ShootFlavors *[]templates.ShootFlavor `json:"shootFlavors"`
 }
 
 type State struct {

--- a/pkg/util/gardener.go
+++ b/pkg/util/gardener.go
@@ -1,0 +1,47 @@
+// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	"github.com/gardener/gardener/pkg/apis/garden/v1beta1"
+)
+
+// ConvertStringToVersion converts a string to gardener experable versions
+func ConvertStringToVersion(v string) v1alpha1.ExpirableVersion {
+	return v1alpha1.ExpirableVersion{
+		Version:        v,
+		ExpirationDate: nil,
+	}
+}
+
+// ConvertStringArrayToVersions converts a string array of versions to gardener experable versions
+func ConvertStringArrayToVersions(versions []string) []v1alpha1.ExpirableVersion {
+	expVersions := make([]v1alpha1.ExpirableVersion, len(versions))
+	for i, v := range versions {
+		expVersions[i] = ConvertStringToVersion(v)
+	}
+	return expVersions
+}
+
+// ContainsCloudprovider checks whether a cloudprovier is part of an array of cloudproviders
+func ContainsCloudprovider(cloudproviders []v1beta1.CloudProvider, cloudprovider v1beta1.CloudProvider) bool {
+	for _, cp := range cloudproviders {
+		if cp == cloudprovider {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Enable the configuration of specific kubernetes versions per cloudprovider.
A shoot flavor is introduced which can be extended in the future by more flavors (operating system, etc). 
The default configuration for test has changed and is incompatible with the old version but shouldn't be a problem as we are not fully rolled out the bot.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Enable the configuration of specific kubernetes versions per cloudprovider
```
