### PR TITLE
Add recreate command and use v1alpha1 shoots

### DIFF
--- a/pkg/hostscheduler/gardenerscheduler/cleanup.go
+++ b/pkg/hostscheduler/gardenerscheduler/cleanup.go
@@ -16,13 +16,13 @@ package gardenerscheduler
 import (
 	"context"
 	"fmt"
+	"github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	"github.com/gardener/gardener/pkg/operation/botanist"
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 
-	"github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/test-infra/pkg/hostscheduler"
 	"github.com/gardener/test-infra/pkg/hostscheduler/cleanup"
@@ -57,7 +57,7 @@ func (s *gardenerscheduler) Cleanup(flagset *flag.FlagSet) (hostscheduler.Schedu
 			}
 		}
 
-		shoot := &v1beta1.Shoot{}
+		shoot := &v1alpha1.Shoot{}
 		err = s.client.Client().Get(ctx, client.ObjectKey{Namespace: hostConfig.Namespace, Name: hostConfig.Name}, shoot)
 		if err != nil {
 			return fmt.Errorf("cannot get shoot %s: %s", hostConfig.Name, err.Error())

--- a/pkg/hostscheduler/gardenerscheduler/list.go
+++ b/pkg/hostscheduler/gardenerscheduler/list.go
@@ -16,10 +16,9 @@ package gardenerscheduler
 import (
 	"context"
 	"fmt"
-	"github.com/gardener/gardener/pkg/apis/garden/v1beta1/helper"
+	"github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	"os"
 
-	"github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/test-infra/pkg/hostscheduler"
 	"github.com/gardener/test-infra/pkg/util/cmdutil"
 	flag "github.com/spf13/pflag"
@@ -30,7 +29,7 @@ import (
 func (s *gardenerscheduler) List(flagset *flag.FlagSet) (hostscheduler.SchedulerFunc, error) {
 	return func(ctx context.Context) error {
 
-		shoots := &v1beta1.ShootList{}
+		shoots := &v1alpha1.ShootList{}
 		selector := labels.SelectorFromSet(labels.Set(map[string]string{
 			ShootLabel: "true",
 		}))
@@ -50,7 +49,7 @@ func (s *gardenerscheduler) List(flagset *flag.FlagSet) (hostscheduler.Scheduler
 				message string
 			)
 			if s.cloudprovider != CloudProviderAll {
-				if cp, err := helper.DetermineCloudProviderInShoot(shoot.Spec.Cloud); err != nil || cp != s.cloudprovider {
+				if shoot.Spec.Provider.Type != string(s.cloudprovider) {
 					continue
 				}
 			}

--- a/pkg/hostscheduler/gardenerscheduler/recreate.go
+++ b/pkg/hostscheduler/gardenerscheduler/recreate.go
@@ -1,0 +1,92 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gardenerscheduler
+
+import (
+	"context"
+	"fmt"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	"github.com/gardener/gardener/pkg/operation/common"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/gardener/test-infra/pkg/hostscheduler"
+	"github.com/pkg/errors"
+	flag "github.com/spf13/pflag"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func (s *gardenerscheduler) Recreate(flagset *flag.FlagSet) (hostscheduler.SchedulerFunc, error) {
+	name := flagset.String("name", "", "shoot name to recreate")
+	force := flagset.BoolP("force", "f", false, "Ignore that a shoot is currently locked. !! Use with care.")
+	return func(ctx context.Context) error {
+		if name == nil || *name == "" {
+			return errors.New("no shoot cluster is defined. Use --name or create a config file")
+		}
+		shoot := &v1alpha1.Shoot{}
+		if err := s.client.Client().Get(ctx, client.ObjectKey{Name: *name, Namespace: s.namespace}, shoot); err != nil {
+			return errors.Wrapf(err, "cannot get shoot %s", *name)
+		}
+
+		if *force == false {
+			if isLocked(shoot) {
+				return fmt.Errorf("shoot %s is still in use", *name)
+			}
+		}
+
+		newShoot := shoot.DeepCopy()
+		newShoot.ObjectMeta = metav1.ObjectMeta{
+			Name:        shoot.GetName(),
+			Namespace:   shoot.GetNamespace(),
+			Labels:      shoot.GetLabels(),
+			Annotations: shoot.GetAnnotations(),
+		}
+		newShoot.Status = v1alpha1.ShootStatus{}
+
+		if err := patchAnnotation(ctx, s.client.Client(), shoot, common.ConfirmationDeletion, "true"); err != nil {
+			return errors.Wrap(err, "unable to patch deletion confirmation")
+		}
+		s.log.Info("delete shoot")
+		if err := s.client.Client().Delete(ctx, shoot); err != nil {
+			return errors.Wrap(err, "unable to delete shoot")
+		}
+		if err := WaitUntilShootIsDeleted(ctx, s.log, s.client, shoot); err != nil {
+			return errors.Wrap(err, "error waiting for shoot to be deleted")
+		}
+		s.log.Info("shoot successfully deleted")
+
+		// recreate the shoot
+		s.log.Info("recreate shoot")
+		if err := s.client.Client().Create(ctx, newShoot); err != nil {
+			return errors.Wrap(err, "unable to create shoot")
+		}
+		if _, err := WaitUntilShootIsReconciled(ctx, s.log, s.client, shoot); err != nil {
+			return errors.Wrap(err, "error waiting for shoot to be deleted")
+		}
+		s.log.Info("successfully recreated shoot")
+
+		return nil
+	}, nil
+}
+
+func patchAnnotation(ctx context.Context, k8sClient client.Client, oldShoot *v1alpha1.Shoot, key, value string) error {
+	newShoot := oldShoot.DeepCopy()
+	metav1.SetMetaDataAnnotation(&newShoot.ObjectMeta, key, value)
+	patchBytes, err := kutil.CreateTwoWayMergePatch(oldShoot, newShoot)
+	if err != nil {
+		return fmt.Errorf("failed to patch bytes")
+	}
+	return k8sClient.Patch(ctx, oldShoot, client.ConstantPatch(types.MergePatchType, patchBytes))
+}

--- a/pkg/hostscheduler/gardenerscheduler/release.go
+++ b/pkg/hostscheduler/gardenerscheduler/release.go
@@ -16,9 +16,9 @@ package gardenerscheduler
 import (
 	"context"
 	"fmt"
+	"github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	"github.com/pkg/errors"
 
-	"github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/test-infra/pkg/hostscheduler"
 	flag "github.com/spf13/pflag"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -38,9 +38,8 @@ func (s *gardenerscheduler) Release(flagset *flag.FlagSet) (hostscheduler.Schedu
 			}
 		}
 
-		shoot := &v1beta1.Shoot{}
-		err = s.client.Client().Get(ctx, client.ObjectKey{Namespace: hostConfig.Namespace, Name: hostConfig.Name}, shoot)
-		if err != nil {
+		shoot := &v1alpha1.Shoot{}
+		if err := s.client.Client().Get(ctx, client.ObjectKey{Namespace: hostConfig.Namespace, Name: hostConfig.Name}, shoot); err != nil {
 			return fmt.Errorf("cannot get shoot %s: %s", hostConfig.Name, err.Error())
 		}
 
@@ -70,7 +69,7 @@ func (s *gardenerscheduler) Release(flagset *flag.FlagSet) (hostscheduler.Schedu
 			return fmt.Errorf("cannot hibernate shoot %s: %s", shoot.Name, err.Error())
 		}
 
-		shoot.Spec.Hibernation = &v1beta1.Hibernation{Enabled: &hibernationTrue}
+		shoot.Spec.Hibernation = &v1alpha1.Hibernation{Enabled: &hibernationTrue}
 		shoot.Labels[ShootLabelStatus] = ShootStatusFree
 		delete(shoot.Annotations, ShootAnnotationLockedAt)
 		delete(shoot.Annotations, ShootAnnotationID)

--- a/pkg/hostscheduler/gardenerscheduler/types.go
+++ b/pkg/hostscheduler/gardenerscheduler/types.go
@@ -15,6 +15,7 @@ package gardenerscheduler
 
 import (
 	"fmt"
+	"github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	"github.com/go-logr/logr"
 
 	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
@@ -56,7 +57,7 @@ type gardenerscheduler struct {
 	cloudprovider gardenv1beta1.CloudProvider
 }
 
-func isFree(shoot *gardenv1beta1.Shoot) bool {
+func isFree(shoot *v1alpha1.Shoot) bool {
 	val, ok := shoot.Labels[ShootLabelStatus]
 	if !ok {
 		return false
@@ -65,7 +66,7 @@ func isFree(shoot *gardenv1beta1.Shoot) bool {
 	return val == ShootStatusFree
 }
 
-func isLocked(shoot *gardenv1beta1.Shoot) bool {
+func isLocked(shoot *v1alpha1.Shoot) bool {
 	val, ok := shoot.Labels[ShootLabelStatus]
 	if !ok {
 		return false

--- a/pkg/hostscheduler/gkescheduler/recreate.go
+++ b/pkg/hostscheduler/gkescheduler/recreate.go
@@ -1,0 +1,28 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gkescheduler
+
+import (
+	"context"
+	"fmt"
+	"github.com/gardener/test-infra/pkg/hostscheduler"
+	flag "github.com/spf13/pflag"
+)
+
+func (s *gkescheduler) Recreate(flagset *flag.FlagSet) (hostscheduler.SchedulerFunc, error) {
+	return func(ctx context.Context) error {
+		fmt.Println("recreate for gke clusters currently not implemented")
+		return nil
+	}, nil
+}

--- a/pkg/hostscheduler/types.go
+++ b/pkg/hostscheduler/types.go
@@ -30,6 +30,7 @@ type Interface interface {
 	Cleanup(*flag.FlagSet) (SchedulerFunc, error)
 
 	List(*flag.FlagSet) (SchedulerFunc, error)
+	Recreate(*flag.FlagSet) (SchedulerFunc, error)
 }
 
 // SchedulerFunc is the default hostscheduler functions which is called by the framework


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Add recreate command to hostscheduler. The recreate command recreates existing host clusters to have a full cleanup after some time.
```
```improvement operator
Update hostscheduler to use new gardener v1alpha1 api
```