### PR TITLE
Add temp support for gardener extensions and fix chart behavior

### DIFF
--- a/cmd/local-validator/main.go
+++ b/cmd/local-validator/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/gardener/test-infra/pkg/testmachinery"
 	"os"
 
 	"github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
@@ -30,8 +31,14 @@ import (
 // Connection to remote is needed to validate remote testdefinitions
 func main() {
 	logger.InitFlags(nil)
+	testmachinery.InitFlags(nil)
 	trFilePath := flag.String("testrun", "examples/int-testrun.yaml", "Filepath to the testrun")
 	flag.Parse()
+
+	if err := testmachinery.Setup(); err != nil {
+		fmt.Print(err.Error())
+		os.Exit(1)
+	}
 
 	log, err := logger.New(nil)
 	if err != nil {

--- a/cmd/testrunner/cmd/run_gardener/run.go
+++ b/cmd/testrunner/cmd/run_gardener/run.go
@@ -196,7 +196,7 @@ func init() {
 	runCmd.Flags().StringVar(&defaultConfig.Gardener.Version, "gardener-version", "", "Specify the gardener version to be deployed by garden setup")
 	runCmd.Flags().StringVar(&defaultConfig.Gardener.ImageTag, "gardener-image", "", "Specify the gardener image tag to be deployed by garden setup")
 	runCmd.Flags().StringVar(&defaultConfig.Gardener.Commit, "gardener-commit", "", "Specify the gardener commit that is deployed by garden setup")
-	runCmd.Flags().StringVar(&gardenerExtensions, "gardener-extensions", "provider-gcp=github.com/gardener/gardener-extensions.git:master", "Specify the gardener extensions versions to be deployed by garden setup")
+	runCmd.Flags().StringVar(&gardenerExtensions, "gardener-extensions", "provider-gcp=github.com/gardener/gardener-extensions.git::master", "Specify the gardener extensions versions to be deployed by garden setup")
 
 	runCmd.Flags().StringVar(&defaultConfig.Shoots.Namespace, "project-namespace", "garden-core", "Specify the shoot namespace where the shoots should be created")
 	runCmd.Flags().StringArrayVar(&kubernetesVersions, "kubernetes-version", []string{}, "Specify the kubernetes version to test")

--- a/cmd/testrunner/cmd/run_template/run_template.go
+++ b/cmd/testrunner/cmd/run_template/run_template.go
@@ -38,7 +38,6 @@ var collectConfig = result.Config{}
 var shootParameters = testrunnerTemplate.Parameters{}
 
 var (
-	flavorConfigPath    string
 	testrunNamePrefix   string
 	shootPrefix         string
 	tmKubeconfigPath    string
@@ -86,7 +85,7 @@ var runCmd = &cobra.Command{
 		testrunnerConfig.Interval = time.Duration(interval) * time.Second
 		collectConfig.ComponentDescriptorPath = shootParameters.ComponentDescriptorPath
 
-		shootFlavors, err := GetShootFlavors(flavorConfigPath, gardenK8sClient, shootPrefix, filterPatchVersions)
+		shootFlavors, err := GetShootFlavors(shootParameters.FlavorConfigPath, gardenK8sClient, shootPrefix, filterPatchVersions)
 		if err != nil {
 			logger.Log.Error(err, "unable to parse shoot flavors from test configuration")
 			os.Exit(1)
@@ -188,7 +187,7 @@ func init() {
 		logger.Log.Error(err, "mark flag required", "flag", "gardener-kubeconfig-path")
 	}
 
-	runCmd.Flags().StringVar(&flavorConfigPath, "flavor-config", "", "Path to shoot test configuration.")
+	runCmd.Flags().StringVar(&shootParameters.FlavorConfigPath, "flavor-config", "", "Path to shoot test configuration.")
 	if err := runCmd.MarkFlagFilename("flavor-config"); err != nil {
 		logger.Log.Error(err, "mark flag filename", "flag", "flavor-config")
 	}

--- a/cmd/testrunner/cmd/run_template/setup.go
+++ b/cmd/testrunner/cmd/run_template/setup.go
@@ -13,7 +13,7 @@ func GetShootFlavors(cfgPath string, k8sClient kubernetes.Interface, shootPrefix
 	// read and parse test shoot configuration
 	dat, err := ioutil.ReadFile(cfgPath)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to read test shoot configuration file from %s", flavorConfigPath)
+		return nil, errors.Wrapf(err, "unable to read test shoot configuration file from %s", cfgPath)
 	}
 
 	flavors := common.ExtendedShootFlavors{}

--- a/docs/testrunner/testrunner_run-gardener.md
+++ b/docs/testrunner/testrunner_run-gardener.md
@@ -20,8 +20,9 @@ testrunner run-gardener [flags]
       --fail-on-error                      Testrunners exits with 1 if one testruns failed. (default true)
       --garden-setup-version string        Specify the garden setup version to setup gardener (default "master")
       --gardener-commit string             Specify the gardener commit that is deployed by garden setup
+      --gardener-extensions string         Specify the gardener extensions versions to be deployed by garden setup (default "provider-gcp=github.com/gardener/gardener-extensions.git:master")
       --gardener-image string              Specify the gardener image tag to be deployed by garden setup
-      --gardener-version string            Specify the gardener to be deployed by garden setup
+      --gardener-version string            Specify the gardener version to be deployed by garden setup
   -h, --help                               help for run-gardener
       --hibernation                        test hibernation
       --host-cloudprovider CloudProvider   Specify the cloudprovider of the host cluster. Optional and only affect gardener base cluster (default gcp)

--- a/docs/testrunner/testrunner_run-template.md
+++ b/docs/testrunner/testrunner_run-template.md
@@ -13,34 +13,34 @@ testrunner run-template [flags]
 ### Options
 
 ```
-      --asset-component stringArray        The github components to which the testrun status shall be attached as an asset.
-      --asset-prefix string                Prefix of the asset name.
-      --component-descriptor-path string   Path to the component descriptor (BOM) of the current landscape.
-      --concourse-onError-dir string       On error dir which is used by Concourse.
-      --enable-telemetry                   Enables the measurements of metrics during execution
-      --es-config-name string              The elasticsearch secret-server config name. (default "sap_internal")
-      --fail-on-error                      Testrunners exits with 1 if one testruns failed. (default true)
-      --filter-patch-versions              Filters patch versions so that only the latest patch versions per minor versions is used.
-      --gardener-kubeconfig-path string    Path to the gardener kubeconfig.
-      --github-password string             Github password.
-      --github-user string                 On error dir which is used by Concourse.
-  -h, --help                               help for run-template
-      --interval int                       Poll interval in seconds of the testrunner to poll for the testrun status. (default 20)
-      --landscape string                   Current gardener landscape.
-  -n, --namespace string                   Namesapce where the testrun should be deployed. (default "default")
-      --output-dir-path string             The filepath where the summary should be written to. (default "./testout")
-      --s3-endpoint string                 S3 endpoint of the testmachinery cluster.
-      --s3-ssl                             S3 has SSL enabled.
-      --set string                         setValues additional helm values
-      --shoot-name string                  Shoot name which is used to run tests.
-      --shoot-test-config string           Path to shoot test configuration.
-      --shoot-testruns-chart-path string   Path to the testruns chart to test shoots.
-      --testrun-prefix string              Testrun name prefix which is used to generate a unique testrun name. (default "default-")
-      --testruns-chart-path string         Path to the default testruns chart.
-      --timeout int                        Timout in seconds of the testrunner to wait for the complete testrun to finish. (default 3600)
-      --tm-kubeconfig-path string          Path to the testmachinery cluster kubeconfig
-      --upload-status-asset                Upload testrun status as a github release asset.
-  -f, --values stringArray                 yaml value files to override template values
+      --asset-component stringArray           The github components to which the testrun status shall be attached as an asset.
+      --asset-prefix string                   Prefix of the asset name.
+      --component-descriptor-path string      Path to the component descriptor (BOM) of the current landscape.
+      --concourse-onError-dir string          On error dir which is used by Concourse.
+      --enable-telemetry                      Enables the measurements of metrics during execution
+      --es-config-name string                 The elasticsearch secret-server config name. (default "sap_internal")
+      --fail-on-error                         Testrunners exits with 1 if one testruns failed. (default true)
+      --filter-patch-versions                 Filters patch versions so that only the latest patch versions per minor versions is used.
+      --flavor-config string                  Path to shoot test configuration.
+      --flavored-testruns-chart-path string   Path to the testruns chart to test shoots.
+      --gardener-kubeconfig-path string       Path to the gardener kubeconfig.
+      --github-password string                Github password.
+      --github-user string                    On error dir which is used by Concourse.
+  -h, --help                                  help for run-template
+      --interval int                          Poll interval in seconds of the testrunner to poll for the testrun status. (default 20)
+      --landscape string                      Current gardener landscape.
+  -n, --namespace string                      Namesapce where the testrun should be deployed. (default "default")
+      --output-dir-path string                The filepath where the summary should be written to. (default "./testout")
+      --s3-endpoint string                    S3 endpoint of the testmachinery cluster.
+      --s3-ssl                                S3 has SSL enabled.
+      --set string                            setValues additional helm values
+      --shoot-name string                     Shoot name which is used to run tests.
+      --testrun-prefix string                 Testrun name prefix which is used to generate a unique testrun name. (default "default-")
+      --testruns-chart-path string            Path to the default testruns chart.
+      --timeout int                           Timout in seconds of the testrunner to wait for the complete testrun to finish. (default 3600)
+      --tm-kubeconfig-path string             Path to the testmachinery cluster kubeconfig
+      --upload-status-asset                   Upload testrun status as a github release asset.
+  -f, --values stringArray                    yaml value files to override template values
 ```
 
 ### Options inherited from parent commands

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -25,9 +25,10 @@ const (
 	DockerImageGardenerApiServer = "eu.gcr.io/gardener-project/gardener/apiserver"
 
 	// Repositories
-	TestInfraRepo   = "https://github.com/gardener/test-infra.git"
-	GardenSetupRepo = "https://github.com/gardener/garden-setup.git"
-	GardenerRepo    = "https://github.com/gardener/gardener.git"
+	TestInfraRepo          = "https://github.com/gardener/test-infra.git"
+	GardenSetupRepo        = "https://github.com/gardener/garden-setup.git"
+	GardenerRepo           = "https://github.com/gardener/gardener.git"
+	GardenerExtensionsRepo = "https://github.com/gardener/gardener-extensions.git"
 
 	PatternLatest = "latest"
 )

--- a/pkg/common/types_gardensetup.go
+++ b/pkg/common/types_gardensetup.go
@@ -22,10 +22,10 @@ type GSExtensionConfig struct {
 	Tag             string `json:"tag,omitempty"`
 	Commit          string `json:"commit,omitempty"`
 	Branch          string `json:"branch,omitempty"`
-	Repository      string `json:"repo,omitemtpy"`
-	ImageTag        string `json:"image_tag,omitemtpy"`
-	ImageRepository string `json:"image_repo,omitemtpy"`
-	ChartPath       string `json:"chart_path,omitemtpy"`
+	Repository      string `json:"repo,omitempty"`
+	ImageTag        string `json:"image_tag,omitempty"`
+	ImageRepository string `json:"image_repo,omitempty"`
+	ChartPath       string `json:"chart_path,omitempty"`
 }
 
 // GSDependencies represents the dependency vector of all elements in garden setup

--- a/pkg/common/types_gardensetup.go
+++ b/pkg/common/types_gardensetup.go
@@ -1,0 +1,51 @@
+// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+// GSExtensions defines extensions and their configuration that is consumed by the acre.yaml
+type GSExtensions = map[string]GSExtensionConfig
+
+// GSExtensionsConfig defines an extension used in the acre.yaml to specify an Extension
+type GSExtensionConfig struct {
+	Tag             string `json:"tag,omitempty"`
+	Commit          string `json:"commit,omitempty"`
+	Branch          string `json:"branch,omitempty"`
+	Repository      string `json:"repo,omitemtpy"`
+	ImageTag        string `json:"image_tag,omitemtpy"`
+	ImageRepository string `json:"image_repo,omitemtpy"`
+	ChartPath       string `json:"chart_path,omitemtpy"`
+}
+
+// GSDependencies represents the dependency vector of all elements in garden setup
+type GSDependencies struct {
+	Versions GSVersions `json:"versions"`
+}
+
+// GSVersions specifies all elements and their versions
+type GSVersions struct {
+	Gardener GSGardenerDependency `json:"gardener"`
+}
+
+// GSGardenerDependency represents the gardener version and its dependencies in the dependency vector
+type GSGardenerDependency struct {
+	Core       GSVersion            `json:"core"`
+	Extensions map[string]GSVersion `json:"extensions"`
+}
+
+// GSVersion is one specific version in the garden setup dependency vector
+type GSVersion struct {
+	Repository string `json:"repo"`
+	Version    string `json:"version"`
+}

--- a/pkg/testrun_renderer/default/default.go
+++ b/pkg/testrun_renderer/default/default.go
@@ -43,7 +43,7 @@ type Config struct {
 	// CloudProvider of the base cluster (has to be specified to install the correct credentials and cloudprofiles for the soil/seeds)
 	BaseClusterCloudprovider common.CloudProvider
 
-	// Revision for the gardensetup repo that i sused to install gardener
+	// Revision for the gardensetup repo that is used to install gardener
 	GardenSetupRevision string
 
 	// List of components (by default read from a component_descriptor) that are added as locations
@@ -51,6 +51,9 @@ type Config struct {
 
 	// Gardener specific configuration
 	Gardener templates.GardenerConfig
+
+	// GardenerExtensions specify the extensions and their versions to deploy
+	GardenerExtensions common.GSExtensions
 
 	// Gardener tests that do not depend on shoots and run after the shoot tests
 	Tests testrun_renderer.TestsFunc
@@ -150,6 +153,14 @@ func Validate(cfg *Config) error {
 
 	if cfg.Shoots.Namespace == "" {
 		result = multierror.Append(result, errors.New("the shoot project namespace has to be defined"))
+	}
+
+	if cfg.Gardener.Version == "" && cfg.Gardener.Commit == "" {
+		result = multierror.Append(result, errors.New("a gardener version or commit has to be defined"))
+	}
+
+	if len(cfg.GardenerExtensions) == 0 {
+		result = multierror.Append(result, errors.New("the gardener extensions version has to be defined"))
 	}
 
 	return util.ReturnMultiError(result)

--- a/pkg/testrun_renderer/default/default.go
+++ b/pkg/testrun_renderer/default/default.go
@@ -160,7 +160,7 @@ func Validate(cfg *Config) error {
 	}
 
 	if len(cfg.GardenerExtensions) == 0 {
-		result = multierror.Append(result, errors.New("the gardener extensions version has to be defined"))
+		result = multierror.Append(result, errors.New("the gardener extensions have to be defined"))
 	}
 
 	return util.ReturnMultiError(result)

--- a/pkg/testrun_renderer/default/testrun.go
+++ b/pkg/testrun_renderer/default/testrun.go
@@ -34,7 +34,7 @@ type shoot struct {
 func testrun(cfg *Config, shoots []*shoot) (*v1beta1.Testrun, error) {
 	gsLocationName := "gs"
 	prepareHostCluster := templates.GetStepLockHost(cfg.HostProvider, cfg.BaseClusterCloudprovider)
-	createGardener, err := templates.GetStepCreateGardener(gsLocationName, []string{prepareHostCluster.Name}, cfg.BaseClusterCloudprovider, cfg.Shoots.Flavors.GetUsedKubernetesVersions(), cfg.Shoots.Flavors.GetUsedMachineImages(), cfg.Gardener)
+	createGardener, err := templates.GetStepCreateGardener(gsLocationName, []string{prepareHostCluster.Name}, cfg.BaseClusterCloudprovider, cfg.Shoots.Flavors.GetUsedKubernetesVersions(), cfg.Shoots.Flavors.GetUsedMachineImages(), cfg.Gardener, cfg.GardenerExtensions)
 	if err != nil {
 		return nil, err
 	}
@@ -47,7 +47,7 @@ func testrun(cfg *Config, shoots []*shoot) (*v1beta1.Testrun, error) {
 
 		Spec: v1beta1.TestrunSpec{
 			LocationSets: []v1beta1.LocationSet{
-				templates.GetDefaultLocationsSet(cfg.Gardener),
+				templates.GetDefaultLocationsSet(cfg.Gardener, cfg.GardenerExtensions),
 				templates.TestInfraLocation,
 				templates.GetGardenSetupLocation(gsLocationName, cfg.GardenSetupRevision),
 			},

--- a/pkg/testrun_renderer/templates/helper.go
+++ b/pkg/testrun_renderer/templates/helper.go
@@ -1,0 +1,48 @@
+// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package templates
+
+import (
+	"fmt"
+	"github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
+	"github.com/gardener/test-infra/pkg/common"
+)
+
+func GetLocationsFromExtensions(extensions common.GSExtensions) []v1beta1.TestLocation {
+	extSet := make(map[string]interface{}, 0)
+	ext := make([]v1beta1.TestLocation, 0)
+	for _, e := range extensions {
+		var revision string
+		if e.Tag != "" {
+			revision = e.Tag
+		} else if e.Commit != "" {
+			revision = e.Commit
+		} else if e.Branch != "" {
+			revision = e.Branch
+		}
+		name := fmt.Sprintf("%s/%s", e.Repository, revision)
+		if _, ok := extSet[name]; ok {
+			continue
+		}
+
+		extSet[name] = new(interface{})
+		ext = append(ext, v1beta1.TestLocation{
+			Type:     v1beta1.LocationTypeGit,
+			Repo:     e.Repository,
+			Revision: revision,
+		})
+	}
+	return ext
+}

--- a/pkg/testrun_renderer/templates/templates.go
+++ b/pkg/testrun_renderer/templates/templates.go
@@ -35,28 +35,28 @@ var TestInfraLocation = v1beta1.LocationSet{
 	},
 }
 
-func GetDefaultLocationsSet(cfg GardenerConfig) v1beta1.LocationSet {
+func GetDefaultLocationsSet(gardenerCfg GardenerConfig, gardenerExtensions common.GSExtensions) v1beta1.LocationSet {
 	set := v1beta1.LocationSet{
 		Name:      DefaultLocationSetName,
 		Default:   true,
-		Locations: []v1beta1.TestLocation{},
+		Locations: GetLocationsFromExtensions(gardenerExtensions),
 	}
 
-	if cfg.Version != "" {
+	if gardenerCfg.Version != "" {
 		set.Locations = []v1beta1.TestLocation{
 			{
 				Type:     v1beta1.LocationTypeGit,
 				Repo:     common.GardenerRepo,
-				Revision: cfg.Version,
+				Revision: gardenerCfg.Version,
 			},
 		}
 	}
-	if cfg.Commit != "" {
+	if gardenerCfg.Commit != "" {
 		set.Locations = []v1beta1.TestLocation{
 			{
 				Type:     v1beta1.LocationTypeGit,
 				Repo:     common.GardenerRepo,
-				Revision: cfg.Commit,
+				Revision: gardenerCfg.Commit,
 			},
 		}
 	}

--- a/pkg/testrun_renderer/templates/templates.go
+++ b/pkg/testrun_renderer/templates/templates.go
@@ -43,22 +43,18 @@ func GetDefaultLocationsSet(gardenerCfg GardenerConfig, gardenerExtensions commo
 	}
 
 	if gardenerCfg.Version != "" {
-		set.Locations = []v1beta1.TestLocation{
-			{
-				Type:     v1beta1.LocationTypeGit,
-				Repo:     common.GardenerRepo,
-				Revision: gardenerCfg.Version,
-			},
-		}
+		set.Locations = append(set.Locations, v1beta1.TestLocation{
+			Type:     v1beta1.LocationTypeGit,
+			Repo:     common.GardenerRepo,
+			Revision: gardenerCfg.Version,
+		})
 	}
 	if gardenerCfg.Commit != "" {
-		set.Locations = []v1beta1.TestLocation{
-			{
-				Type:     v1beta1.LocationTypeGit,
-				Repo:     common.GardenerRepo,
-				Revision: gardenerCfg.Commit,
-			},
-		}
+		set.Locations = append(set.Locations, v1beta1.TestLocation{
+			Type:     v1beta1.LocationTypeGit,
+			Repo:     common.GardenerRepo,
+			Revision: gardenerCfg.Commit,
+		})
 	}
 
 	return set

--- a/pkg/testrunner/template/helper.go
+++ b/pkg/testrunner/template/helper.go
@@ -22,7 +22,6 @@ import (
 	"github.com/gardener/test-infra/pkg/testrunner/componentdescriptor"
 	"github.com/pkg/errors"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"reflect"
 	"sigs.k8s.io/yaml"
@@ -64,15 +63,15 @@ func readFileValues(files []string) (map[string]interface{}, error) {
 }
 
 // determineAbsoluteShootChartPath returns the chart to render for the specific shoot flavor
-func determineAbsoluteShootChartPath(defaultChart string, chart *string) (string, error) {
+func determineAbsoluteShootChartPath(parameters *internalParameters, chart *string) (string, error) {
 	if chart == nil {
-		return defaultChart, nil
+		return parameters.ChartPath, nil
 	}
 	if filepath.IsAbs(*chart) {
 		return *chart, nil
 	}
 
-	cDir, err := filepath.Abs(filepath.Dir(os.Args[0]))
+	cDir, err := filepath.Abs(filepath.Dir(parameters.FlavorConfigPath))
 	if err != nil {
 		return "", err
 	}

--- a/pkg/testrunner/template/template.go
+++ b/pkg/testrunner/template/template.go
@@ -72,6 +72,7 @@ func getInternalParametersFunc(parameters *Parameters) (func(string) *internalPa
 
 	return func(chartPath string) *internalParameters {
 		return &internalParameters{
+			FlavorConfigPath:    parameters.FlavorConfigPath,
 			ComponentDescriptor: componentDescriptor,
 			ChartPath:           chartPath,
 			GardenerKubeconfig:  gardenerKubeconfig,
@@ -109,7 +110,7 @@ func renderChartWithShoot(log logr.Logger, renderer *templateRenderer, parameter
 	}
 
 	for _, shoot := range shootFlavors {
-		chartPath, err := determineAbsoluteShootChartPath(parameters.ChartPath, shoot.ChartPath)
+		chartPath, err := determineAbsoluteShootChartPath(parameters, shoot.ChartPath)
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to determine chart to render")
 		}

--- a/pkg/tm-bot/github/client.go
+++ b/pkg/tm-bot/github/client.go
@@ -20,10 +20,12 @@ import (
 	"fmt"
 	"github.com/gardener/test-infra/pkg/tm-bot/github/ghval"
 	pluginerr "github.com/gardener/test-infra/pkg/tm-bot/plugins/errors"
+	"github.com/gardener/test-infra/pkg/util"
 	"github.com/go-logr/logr"
 	"github.com/google/go-github/v27/github"
 	"github.com/pkg/errors"
 	"net/http"
+	"sigs.k8s.io/yaml"
 )
 
 func NewClient(log logr.Logger, ghClient *github.Client, owner, defaultTeamName string, config map[string]json.RawMessage) (Client, error) {
@@ -93,6 +95,26 @@ func (c *client) ResolveConfigValue(event *GenericRequestEvent, value *ghval.Git
 		if err != nil {
 			return "", pluginerr.New(fmt.Sprintf("unable to get config in path %s", *value.Path), err.Error())
 		}
+
+		if value.StructuredJSONPath != nil {
+			var val interface{}
+			_, err := util.JSONPath([]byte(content), *value.StructuredJSONPath, val)
+			if err != nil {
+				return "", err
+			}
+
+			switch v := val.(type) {
+			case string:
+				return v, nil
+			default:
+				yamlData, err := yaml.Marshal(v)
+				if err != nil {
+					return "", err
+				}
+				return string(yamlData), nil
+			}
+		}
+
 		return content, nil
 	}
 	return "", pluginerr.New("no value is defined", "no value is defined")

--- a/pkg/tm-bot/github/client.go
+++ b/pkg/tm-bot/github/client.go
@@ -98,7 +98,7 @@ func (c *client) ResolveConfigValue(event *GenericRequestEvent, value *ghval.Git
 
 		if value.StructuredJSONPath != nil {
 			var val interface{}
-			_, err := util.JSONPath([]byte(content), *value.StructuredJSONPath, val)
+			_, err := util.JSONPath([]byte(content), *value.StructuredJSONPath, &val)
 			if err != nil {
 				return "", err
 			}

--- a/pkg/tm-bot/github/ghval/ghval.go
+++ b/pkg/tm-bot/github/ghval/ghval.go
@@ -44,6 +44,10 @@ type GitHubValue struct {
 	// Path will read the value from the default branch
 	Path *string `json:"path"`
 
+	// StructuredJSONPath reads the specified path from the parsed path file.
+	// Path has to be defined and has to be in yaml format in order to get the path.
+	StructuredJSONPath *string `json:"structureJSONPath"`
+
 	// Use the commit of the current Pull Request
 	PRHead *bool `json:"prHead"`
 }

--- a/pkg/tm-bot/github/ghval/ghval.go
+++ b/pkg/tm-bot/github/ghval/ghval.go
@@ -46,7 +46,7 @@ type GitHubValue struct {
 
 	// StructuredJSONPath reads the specified path from the parsed path file.
 	// Path has to be defined and has to be in yaml format in order to get the path.
-	StructuredJSONPath *string `json:"structureJSONPath"`
+	StructuredJSONPath *string `json:"structuredJSONPath"`
 
 	// Use the commit of the current Pull Request
 	PRHead *bool `json:"prHead"`

--- a/pkg/tm-bot/plugins/tests/flags.go
+++ b/pkg/tm-bot/plugins/tests/flags.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gardener/test-infra/pkg/tm-bot/plugins/errors"
 	"github.com/gardener/test-infra/pkg/util"
 	"github.com/gardener/test-infra/pkg/util/cmdvalues"
+	"github.com/gardener/test-infra/pkg/util/gardensetup"
 	"github.com/ghodss/yaml"
 	"github.com/spf13/pflag"
 )
@@ -34,6 +35,7 @@ const (
 	gardensetupRevision = "garden-setup-version"
 	gardenerVersion     = "gardener-version"
 	gardenerCommit      = "gardener-commit"
+	gardenerExtensions  = "gardener-extensions"
 	kubernetesVersion   = "kubernetes-version"
 	cloudprovider       = "cloudprovider"
 )
@@ -59,6 +61,7 @@ func (t *test) Flags() *pflag.FlagSet {
 	flagset.StringVar(&t.config.Gardener.Version, gardenerVersion, "", "Specify the gardener to be deployed by garden setup")
 	flagset.StringVar(&t.config.Gardener.ImageTag, "gardener-image", "", "Specify the gardener image tag to be deployed by garden setup")
 	flagset.StringVar(&t.config.Gardener.Commit, gardenerCommit, "", "Specify the gardener commit that is deployed by garden setup")
+	flagset.StringVar(&t.gardenerExtensions, gardenerExtensions, "", "Specify the gardener extensions in the format <extension-name>=<repo>:<revision>")
 
 	flagset.StringVar(&t.config.Shoots.Namespace, "project-namespace", "garden-core", "Specify the shoot namespace where the shoots should be created")
 	flagset.StringArrayVar(&t.kubernetesVersions, kubernetesVersion, []string{}, "Specify the kubernetes version to test")
@@ -94,25 +97,26 @@ func (t *test) ApplyDefaultConfig(client github.Client, event *github.GenericReq
 		val, err := client.ResolveConfigValue(event, defaultConfig.GardenSetup.Revision.Value())
 		if err != nil {
 			return errors.New("unable to resolve default config value for garden setup revision", err.Error())
-		} else {
-			t.config.GardenSetupRevision = val
 		}
+		t.config.GardenSetupRevision = val
 	}
 	if !flagset.Changed(gardenerVersion) && defaultConfig.Gardener != nil && defaultConfig.Gardener.Version != nil {
 		val, err := client.ResolveConfigValue(event, defaultConfig.Gardener.Version.Value())
 		if err != nil {
 			return errors.New("unable to resolve default config value for gardener version", err.Error())
-		} else {
-			t.config.Gardener.Version = val
 		}
+		t.config.Gardener.Version = val
 	}
 	if !flagset.Changed(gardenerCommit) && defaultConfig.Gardener != nil && defaultConfig.Gardener.Commit != nil {
 		val, err := client.ResolveConfigValue(event, defaultConfig.Gardener.Commit.Value())
 		if err != nil {
 			return errors.New("unable to resolve default config value for gardener commit", err.Error())
-		} else {
-			t.config.Gardener.Commit = val
 		}
+		t.config.Gardener.Commit = val
+	}
+
+	if err := t.applyDefaultExtensions(client, event, defaultConfig, flagset); err != nil {
+		return err
 	}
 
 	if err := t.applyDefaultShootFlavors(defaultConfig, flagset); err != nil {
@@ -167,4 +171,47 @@ func (t *test) applyDefaultShootFlavors(defaultConfig DefaultsConfig, flagset *p
 		return nil
 	}
 	return errors.New("At least one cloudprovider and one kubernetes version has to be defined", "neither a default configuration nor cloudprovider and kubernetes flags are defined.")
+}
+
+func (t *test) applyDefaultExtensions(client github.Client, event *github.GenericRequestEvent, defaultConfig DefaultsConfig, flagset *pflag.FlagSet) error {
+	var (
+		err        error
+		defaultExt common.GSExtensions
+		flagExt    common.GSExtensions
+	)
+	if flagset.Changed(gardenerExtensions) {
+		flagExt, err = gardensetup.ParseFlag(t.gardenerExtensions)
+		if err != nil {
+			return err
+		}
+	}
+	if t.config.GardenerExtensions != nil {
+		val, err := client.ResolveConfigValue(event, defaultConfig.GardenerExtensions)
+		if err != nil {
+			return errors.New("unable to resolve default config value for gardener extensions", err.Error())
+		}
+
+		var rawDep map[string]common.GSVersion
+		if err := yaml.Unmarshal([]byte(val), &rawDep); err != nil {
+			return errors.Wrap(err, "unable to parse default config value for gardener extensions")
+		}
+		defaultExt = gardensetup.ConvertRawDependenciesToInternalExtensionConfig(rawDep)
+	}
+	if defaultConfig.GardenerExtensions == nil {
+		return errors.New("gardener extensions have to be defined", "no gardener extensions are either defined by flag nor by the default config")
+	}
+
+	if flagset.Changed(gardenerExtensions) && defaultConfig.GardenerExtensions == nil {
+		t.config.GardenerExtensions = flagExt
+		return nil
+	}
+	if !flagset.Changed(gardenerExtensions) && defaultConfig.GardenerExtensions != nil {
+		t.config.GardenerExtensions = defaultExt
+		return nil
+	}
+	if flagset.Changed(gardenerExtensions) && defaultConfig.GardenerExtensions != nil {
+		t.config.GardenerExtensions = gardensetup.MergeExtensions(defaultExt, flagExt)
+	}
+
+	return errors.New("gardener extensions have to be defined", "no gardener extensions are either defined by flag nor by the default config")
 }

--- a/pkg/tm-bot/plugins/tests/test.go
+++ b/pkg/tm-bot/plugins/tests/test.go
@@ -35,6 +35,7 @@ type test struct {
 	config             _default.Config
 	kubernetesVersions []string
 	cloudproviders     []common.CloudProvider
+	gardenerExtensions string
 	testLabel          string
 	hibernation        bool
 	dryRun             bool
@@ -88,6 +89,11 @@ test:
     version: # StringOrGitHubConfig
     commit: # StringOrGitHubConfig
 
+  gardener-extensions: #StringOrGitHubConfig but the string has to be a yaml map of 
+#    extension_name:
+#      version: 0.0.0
+#      repo: github.com/x/x
+
   shootFlavors:
   - cloudprovider: # cloudprovider e.g. aws
     kubernetesVersions: 
@@ -102,6 +108,7 @@ parameter: "string"
 parameter:
   value: "string" # raw string value. Same as defining only a string
   path: test/path # read the file in the default branch of the repo (repo root will used to define the path) and return its content as a string
+  structureJSONPath: # parses the file read from path and returns the string at the specified structureJSONPath
   prHead: true # use the commit sha of the current PR's head
 `
 }

--- a/pkg/tm-bot/plugins/tests/types.go
+++ b/pkg/tm-bot/plugins/tests/types.go
@@ -35,7 +35,7 @@ type DefaultsConfig struct {
 
 	// github.com/gardener/gardener-extension version
 	// has to be a yaml of a map[extension-name]{version: "0.0.0",repo:"github.com/x/x"}
-	GardenerExtensions *ghval.GitHubValue `json:"gardenerExtensions"`
+	GardenerExtensions *ghval.GitHubValue `json:"gardener-extensions"`
 
 	ShootFlavors *[]*common.ShootFlavor `json:"shootFlavors"`
 }

--- a/pkg/tm-bot/plugins/tests/types.go
+++ b/pkg/tm-bot/plugins/tests/types.go
@@ -33,6 +33,10 @@ type DefaultsConfig struct {
 		Commit  *ghval.StringOrGitHubValue `json:"commit"`
 	} `json:"gardener"`
 
+	// github.com/gardener/gardener-extension version
+	// has to be a yaml of a map[extension-name]{version: "0.0.0",repo:"github.com/x/x"}
+	GardenerExtensions *ghval.GitHubValue `json:"gardenerExtensions"`
+
 	ShootFlavors *[]*common.ShootFlavor `json:"shootFlavors"`
 }
 

--- a/pkg/util/gardensetup/gardensetup_suite_test.go
+++ b/pkg/util/gardensetup/gardensetup_suite_test.go
@@ -12,35 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package template
+package gardensetup_test
 
 import (
-	"github.com/gardener/test-infra/pkg/testrunner/componentdescriptor"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
 )
 
-// Parameters are the parameters which describe the test that is executed by the testrunner.
-type Parameters struct {
-	FlavorConfigPath string
-	// Path to the kubeconfig where the gardener is running.
-	GardenKubeconfigPath     string
-	Namespace                string
-	FlavoredTestrunChartPath string
-	DefaultTestrunChartPath  string
-
-	// metadata
-	Landscape               string
-	ComponentDescriptorPath string
-
-	SetValues  string
-	FileValues []string
-}
-
-type internalParameters struct {
-	FlavorConfigPath    string
-	ComponentDescriptor componentdescriptor.ComponentList
-	ChartPath           string
-
-	GardenerKubeconfig []byte
-	GardenerVersion    string
-	Landscape          string
+func TestUtil(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "GardenSetup Utils Test Suite")
 }

--- a/pkg/util/gardensetup/gs_extensions.go
+++ b/pkg/util/gardensetup/gs_extensions.go
@@ -1,0 +1,96 @@
+// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gardensetup
+
+import (
+	"fmt"
+	"github.com/Masterminds/semver"
+	"github.com/gardener/test-infra/pkg/common"
+	"k8s.io/helm/pkg/strvals"
+	"reflect"
+	"strings"
+)
+
+func ParseFlag(value string) (common.GSExtensions, error) {
+	pVals, err := strvals.Parse(value)
+	if err != nil {
+		return nil, err
+	}
+
+	extensions := make(common.GSExtensions, len(pVals))
+	for name, val := range pVals {
+		var pair []string
+		switch v := val.(type) {
+		case string:
+			pair = strings.Split(v, ":")
+		default:
+			return nil, fmt.Errorf("unsupported type %s at %s expected string with repo:version pair", reflect.TypeOf(v), name)
+		}
+
+		if len(pair) != 2 {
+			return nil, fmt.Errorf("value %s of %s has to be of type repo:version", val, name)
+		}
+
+		config, err := parseExtensionFromPair(pair)
+		if err != nil {
+			return nil, err
+		}
+
+		extensions[name] = config
+	}
+
+	return extensions, nil
+}
+
+func parseExtensionFromPair(pair []string) (common.GSExtensionConfig, error) {
+	var (
+		repository = pair[0]
+		revision   = pair[1]
+	)
+	config := common.GSExtensionConfig{
+		Repository: repository,
+	}
+
+	if len(revision) == 40 {
+		config.Commit = revision
+		config.ImageTag = revision
+	} else if _, err := semver.NewVersion(revision); err == nil {
+		config.Tag = revision
+	} else {
+		config.Branch = revision
+	}
+
+	return config, nil
+}
+
+// MergeExtensions merges gardener extensions whereas new will overwrite all keys that are defined by base
+func MergeExtensions(base, newVal common.GSExtensions) common.GSExtensions {
+	for key, val := range newVal {
+		base[key] = val
+	}
+	return base
+}
+
+// ConvertRawDependenciesToInternalExtensionConfig converts gardener dependencies to gardensetup extension configuration that can be used in the acre.yaml
+func ConvertRawDependenciesToInternalExtensionConfig(deps map[string]common.GSVersion) common.GSExtensions {
+	extensions := make(common.GSExtensions, len(deps))
+	for name, cfg := range deps {
+		extensions[name] = common.GSExtensionConfig{
+			Tag:        cfg.Version,
+			Repository: cfg.Repository,
+		}
+	}
+	return extensions
+}

--- a/pkg/util/gardensetup/gs_extensions.go
+++ b/pkg/util/gardensetup/gs_extensions.go
@@ -34,13 +34,13 @@ func ParseFlag(value string) (common.GSExtensions, error) {
 		var pair []string
 		switch v := val.(type) {
 		case string:
-			pair = strings.Split(v, ":")
+			pair = strings.Split(v, "::")
 		default:
-			return nil, fmt.Errorf("unsupported type %s at %s expected string with repo:version pair", reflect.TypeOf(v), name)
+			return nil, fmt.Errorf("unsupported type %s at %s expected string with repo::version pair", reflect.TypeOf(v), name)
 		}
 
 		if len(pair) != 2 {
-			return nil, fmt.Errorf("value %s of %s has to be of type repo:version", val, name)
+			return nil, fmt.Errorf("value %s of %s has to be of type repo::version", val, name)
 		}
 
 		config, err := parseExtensionFromPair(pair)
@@ -63,6 +63,7 @@ func parseExtensionFromPair(pair []string) (common.GSExtensionConfig, error) {
 		Repository: repository,
 	}
 
+	// check if revision is a commit sha by checking for length of exactly 40
 	if len(revision) == 40 {
 		config.Commit = revision
 		config.ImageTag = revision

--- a/pkg/util/gardensetup/gs_extensions_test.go
+++ b/pkg/util/gardensetup/gs_extensions_test.go
@@ -80,7 +80,7 @@ var _ = Describe("gardensetup extensions util", func() {
 
 	Context("parse flag", func() {
 		It("should parse one extensions definition with a valid version", func() {
-			f := "ext1=repo1:0.0.1"
+			f := "ext1=repo1::0.0.1"
 			res, err := gardensetup.ParseFlag(f)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res).To(Equal(common.GSExtensions{
@@ -89,7 +89,7 @@ var _ = Describe("gardensetup extensions util", func() {
 		})
 
 		It("should parse one extensions definition with a commit", func() {
-			f := "ext1=repo1:000000000a000000b0000000000000c000000000"
+			f := "ext1=repo1::000000000a000000b0000000000000c000000000"
 			res, err := gardensetup.ParseFlag(f)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res).To(Equal(common.GSExtensions{
@@ -98,7 +98,7 @@ var _ = Describe("gardensetup extensions util", func() {
 		})
 
 		It("should parse one extensions definition with a branch", func() {
-			f := "ext1=repo1:patch-1"
+			f := "ext1=repo1::patch-1"
 			res, err := gardensetup.ParseFlag(f)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res).To(Equal(common.GSExtensions{
@@ -107,7 +107,7 @@ var _ = Describe("gardensetup extensions util", func() {
 		})
 
 		It("should parse multiple extension definitions", func() {
-			f := "ext1=repo1:0.0.1,ext2=repo2:0.0.0"
+			f := "ext1=repo1::0.0.1,ext2=repo2::0.0.0"
 			res, err := gardensetup.ParseFlag(f)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res).To(Equal(common.GSExtensions{

--- a/pkg/util/gardensetup/gs_extensions_test.go
+++ b/pkg/util/gardensetup/gs_extensions_test.go
@@ -1,0 +1,119 @@
+// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gardensetup_test
+
+import (
+	"github.com/gardener/test-infra/pkg/common"
+	"github.com/gardener/test-infra/pkg/util/gardensetup"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("gardensetup extensions util", func() {
+
+	Context("Merge", func() {
+		It("should merge two extensions with the same keys", func() {
+			base := common.GSExtensions{
+				"key1": common.GSExtensionConfig{Repository: "a1"},
+				"key2": common.GSExtensionConfig{Repository: "a2"},
+			}
+			newVal := common.GSExtensions{
+				"key1": common.GSExtensionConfig{Repository: "b1"},
+				"key2": common.GSExtensionConfig{Repository: "b2"},
+			}
+			expected := common.GSExtensions{
+				"key1": common.GSExtensionConfig{Repository: "b1"},
+				"key2": common.GSExtensionConfig{Repository: "b2"},
+			}
+
+			res := gardensetup.MergeExtensions(base, newVal)
+			Expect(res).To(Equal(expected))
+		})
+
+		It("should keep base key if their are not defined by the new value", func() {
+			base := common.GSExtensions{
+				"key1": common.GSExtensionConfig{Repository: "a1"},
+				"key2": common.GSExtensionConfig{Repository: "a2"},
+			}
+			newVal := common.GSExtensions{
+				"key1": common.GSExtensionConfig{Repository: "b1"},
+			}
+			expected := common.GSExtensions{
+				"key1": common.GSExtensionConfig{Repository: "b1"},
+				"key2": common.GSExtensionConfig{Repository: "a2"},
+			}
+
+			res := gardensetup.MergeExtensions(base, newVal)
+			Expect(res).To(Equal(expected))
+		})
+		It("should add additional values defined by the new key to existing base keys", func() {
+			base := common.GSExtensions{
+				"key1": common.GSExtensionConfig{Repository: "a1"},
+				"key2": common.GSExtensionConfig{Repository: "a2"},
+			}
+			newVal := common.GSExtensions{
+				"key1": common.GSExtensionConfig{Repository: "b1"},
+				"key3": common.GSExtensionConfig{Repository: "b1"},
+			}
+			expected := common.GSExtensions{
+				"key1": common.GSExtensionConfig{Repository: "b1"},
+				"key2": common.GSExtensionConfig{Repository: "a2"},
+				"key3": common.GSExtensionConfig{Repository: "b1"},
+			}
+
+			res := gardensetup.MergeExtensions(base, newVal)
+			Expect(res).To(Equal(expected))
+		})
+	})
+
+	Context("parse flag", func() {
+		It("should parse one extensions definition with a valid version", func() {
+			f := "ext1=repo1:0.0.1"
+			res, err := gardensetup.ParseFlag(f)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res).To(Equal(common.GSExtensions{
+				"ext1": common.GSExtensionConfig{Repository: "repo1", Tag: "0.0.1"},
+			}))
+		})
+
+		It("should parse one extensions definition with a commit", func() {
+			f := "ext1=repo1:000000000a000000b0000000000000c000000000"
+			res, err := gardensetup.ParseFlag(f)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res).To(Equal(common.GSExtensions{
+				"ext1": common.GSExtensionConfig{Repository: "repo1", Commit: "000000000a000000b0000000000000c000000000", ImageTag: "000000000a000000b0000000000000c000000000"},
+			}))
+		})
+
+		It("should parse one extensions definition with a branch", func() {
+			f := "ext1=repo1:patch-1"
+			res, err := gardensetup.ParseFlag(f)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res).To(Equal(common.GSExtensions{
+				"ext1": common.GSExtensionConfig{Repository: "repo1", Branch: "patch-1"},
+			}))
+		})
+
+		It("should parse multiple extension definitions", func() {
+			f := "ext1=repo1:0.0.1,ext2=repo2:0.0.0"
+			res, err := gardensetup.ParseFlag(f)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res).To(Equal(common.GSExtensions{
+				"ext1": common.GSExtensionConfig{Repository: "repo1", Tag: "0.0.1"},
+				"ext2": common.GSExtensionConfig{Repository: "repo2", Tag: "0.0.0"},
+			}))
+		})
+	})
+})

--- a/pkg/util/jsonpath.go
+++ b/pkg/util/jsonpath.go
@@ -1,0 +1,55 @@
+// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"encoding/json"
+	"fmt"
+	"sigs.k8s.io/yaml"
+	"strings"
+)
+
+func JSONPath(content []byte, path string, dest interface{}) ([]byte, error) {
+	subPaths := strings.Split(path, ".")
+	if len(subPaths) == 0 {
+		return content, nil
+	}
+	data, err := getJSONPath("", content, subPaths)
+	if err != nil {
+		return nil, err
+	}
+	if err := yaml.Unmarshal(data, dest); err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func getJSONPath(identifier string, content []byte, path []string) ([]byte, error) {
+	var obj map[string]json.RawMessage
+	if err := yaml.Unmarshal(content, &obj); err != nil {
+		return nil, err
+	}
+
+	subContent, ok := obj[path[0]]
+	if !ok {
+		return nil, fmt.Errorf("no object at %s.%s", identifier, path[0])
+	}
+
+	if len(path) == 1 {
+		return subContent, nil
+	}
+
+	return getJSONPath(fmt.Sprintf("%s.%s", identifier, path[0]), subContent, path[1:])
+}

--- a/pkg/util/jsonpath_test.go
+++ b/pkg/util/jsonpath_test.go
@@ -1,0 +1,51 @@
+// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util_test
+
+import (
+	"github.com/gardener/test-infra/pkg/util"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("jsonpath util", func() {
+	It("should get json path with dep of 2", func() {
+		content := `
+test:
+  dep1:
+    dep2: val
+`
+		var parsedRes string
+		res, err := util.JSONPath([]byte(content), "test.dep1.dep2", &parsedRes)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(string(res)).To(Equal("\"val\""))
+		Expect(parsedRes).To(Equal("val"))
+	})
+
+	It("should get json path and return struct", func() {
+		content := `
+test:
+  dep1:
+    dep2: val
+`
+		expected := map[string]interface{}{
+			"dep2": "val",
+		}
+		var result map[string]interface{}
+		_, err := util.JSONPath([]byte(content), "test.dep1", &result)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(Equal(expected))
+	})
+})


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds simple support for gardener extensions to the gardener extensions repo is added to the necessary test locations.

**Special notes for your reviewer**:
cc @Diaphteiros 
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Add temp support for gardener extensions in full gardener test with the tm-bot
```
```improvement operator
Fix chart behavior to use the flavors config path as working directory for relativ chart paths in the flavors
```
