### PR TITLE
refactor status-uploader

### DIFF
--- a/integration-tests/e2e/kubetest/description/1.16/working.json
+++ b/integration-tests/e2e/kubetest/description/1.16/working.json
@@ -459,6 +459,5 @@
   { "testcase": "[sig-network] Services should handle load balancer cleanup finalizer for service [Slow]", "groups": ["slow"], "exclude": ["alicloud"] },
   { "testcase": "[sig-instrumentation] Logging soak [Performance] [Slow] [Disruptive] should survive logging 1KB every 1s seconds, for a duration of 2m0s", "groups": ["slow"]},
   { "testcase": "[k8s.io] Downward API [Serial] [Disruptive] [NodeFeature:EphemeralStorage] Downward API tests for local ephemeral storage should provide default limits.ephemeral-storage from node allocatable", "groups": ["slow"]},
-  { "testcase": "[k8s.io] Downward API [Serial] [Disruptive] [NodeFeature:EphemeralStorage] Downward API tests for local ephemeral storage should provide container's limits.ephemeral-storage and requests.ephemeral-storage as env vars", "groups": ["slow"]},
-  { "testcase": "[sig-cli] Kubectl client Kubectl apply should reuse port when apply to an existing SVC", "groups": ["fast"]}
+  { "testcase": "[k8s.io] Downward API [Serial] [Disruptive] [NodeFeature:EphemeralStorage] Downward API tests for local ephemeral storage should provide container's limits.ephemeral-storage and requests.ephemeral-storage as env vars", "groups": ["slow"]}
 ]

--- a/integration-tests/e2e/kubetest/description/1.16/working.json
+++ b/integration-tests/e2e/kubetest/description/1.16/working.json
@@ -459,5 +459,6 @@
   { "testcase": "[sig-network] Services should handle load balancer cleanup finalizer for service [Slow]", "groups": ["slow"], "exclude": ["alicloud"] },
   { "testcase": "[sig-instrumentation] Logging soak [Performance] [Slow] [Disruptive] should survive logging 1KB every 1s seconds, for a duration of 2m0s", "groups": ["slow"]},
   { "testcase": "[k8s.io] Downward API [Serial] [Disruptive] [NodeFeature:EphemeralStorage] Downward API tests for local ephemeral storage should provide default limits.ephemeral-storage from node allocatable", "groups": ["slow"]},
-  { "testcase": "[k8s.io] Downward API [Serial] [Disruptive] [NodeFeature:EphemeralStorage] Downward API tests for local ephemeral storage should provide container's limits.ephemeral-storage and requests.ephemeral-storage as env vars", "groups": ["slow"]}
+  { "testcase": "[k8s.io] Downward API [Serial] [Disruptive] [NodeFeature:EphemeralStorage] Downward API tests for local ephemeral storage should provide container's limits.ephemeral-storage and requests.ephemeral-storage as env vars", "groups": ["slow"]},
+  { "testcase": "[sig-cli] Kubectl client Kubectl apply should reuse port when apply to an existing SVC", "groups": ["fast"]}
 ]

--- a/pkg/testrunner/result/collect.go
+++ b/pkg/testrunner/result/collect.go
@@ -69,7 +69,7 @@ func (c *Collector) Collect(log logr.Logger, tmClient kubernetes.Interface, name
 		fmt.Println(":---------------------------------------------------------------------------------------------:")
 	}
 
-	c.uploadStatusAssets(c.config, log, &runs, tmClient, log)
+	c.uploadStatusAssets(c.config, log, runs, tmClient, log)
 	output.RenderStatusTableForTestruns(os.Stdout, runs)
 
 	c.fetchTelemetryResults()
@@ -104,7 +104,7 @@ func getComponentsForUpload(cfg Config, runLogger logr.Logger) []*componentdescr
 	return componentsForUpload
 }
 
-func (c *Collector) uploadStatusAssets(cfg Config, runLogger logr.Logger, runs *testrunner.RunList, tmClient kubernetes.Interface, log logr.Logger) {
+func (c *Collector) uploadStatusAssets(cfg Config, runLogger logr.Logger, runs testrunner.RunList, tmClient kubernetes.Interface, log logr.Logger) {
 	if !cfg.UploadStatusAsset {
 		return
 	}

--- a/pkg/testrunner/result/collect.go
+++ b/pkg/testrunner/result/collect.go
@@ -111,7 +111,7 @@ func (c *Collector) uploadStatusAssets(cfg Config, runLogger logr.Logger, runs *
 
 	if len(cfg.AssetComponents) == 0 || cfg.GithubPassword == "" || cfg.GithubUser == "" || cfg.ComponentDescriptorPath == "" {
 		err := errors.New("missing github password / github user / component descriptor path argument", "")
-		log.Error(err, fmt.Sprintf("components: %s, ghUser: %s, ghPasswordLength: %s", cfg.AssetComponents, cfg.GithubUser, len(cfg.GithubPassword)))
+		log.Error(err, fmt.Sprintf("components: %s, ghUser: %s, ghPasswordLength: %d", cfg.AssetComponents, cfg.GithubUser, len(cfg.GithubPassword)))
 	}
 
 	componentsForUpload := getComponentsForUpload(cfg, runLogger)

--- a/pkg/testrunner/result/collect.go
+++ b/pkg/testrunner/result/collect.go
@@ -115,9 +115,7 @@ func (c *Collector) uploadStatusAssets(cfg Config, runLogger logr.Logger, runs *
 	}
 
 	componentsForUpload := getComponentsForUpload(cfg, runLogger)
-	if err := UploadStatusToGithub(log, runs, componentsForUpload, cfg.GithubUser, cfg.GithubPassword, cfg.AssetPrefix); err != nil {
-		runLogger.Error(err, "upload of testrun status to github release(s) failed")
-	} else {
+	if err := UploadStatusToGithub(log, runs, componentsForUpload, cfg.GithubUser, cfg.GithubPassword, cfg.AssetPrefix); err == nil {
 		if err := MarkTestrunsAsUploadedToGithub(runLogger, tmClient, runs); err != nil {
 			runLogger.Error(err, "unable to mark testrun status as uploaded to github")
 		}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -15,17 +15,20 @@
 package util
 
 import (
+	"archive/zip"
 	"bytes"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"github.com/google/go-github/v27/github"
 	"github.com/pkg/errors"
+	"io"
 	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"reflect"
 	"regexp"
 	"strconv"
@@ -247,4 +250,103 @@ func GetHTTPClient(username, password string, skipTLS bool) *http.Client {
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		},
 	}
+}
+func Unzip(archive, target string) error {
+	reader, err := zip.OpenReader(archive)
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(target, 0755); err != nil {
+		return err
+	}
+
+	for _, file := range reader.File {
+		path := filepath.Join(target, file.Name)
+		if file.FileInfo().IsDir() {
+			os.MkdirAll(path, file.Mode())
+			continue
+		}
+
+		fileReader, err := file.Open()
+		if err != nil {
+			return err
+		}
+		defer fileReader.Close()
+
+		targetFile, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, file.Mode())
+		if err != nil {
+			return err
+		}
+		defer targetFile.Close()
+
+		if _, err := io.Copy(targetFile, fileReader); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func Zipit(source, target string) error {
+	zipfile, err := os.Create(target)
+	if err != nil {
+		return err
+	}
+	defer zipfile.Close()
+
+	archive := zip.NewWriter(zipfile)
+	defer archive.Close()
+
+	info, err := os.Stat(source)
+	if err != nil {
+		return nil
+	}
+
+	var baseDir string
+	if info.IsDir() {
+		baseDir = filepath.Base(source)
+	}
+
+	if err = filepath.Walk(source, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		header, err := zip.FileInfoHeader(info)
+		if err != nil {
+			return err
+		}
+
+		if baseDir != "" {
+			header.Name = filepath.Join(baseDir, strings.TrimPrefix(path, source))
+		}
+
+		if info.IsDir() {
+			header.Name += "/"
+		} else {
+			header.Method = zip.Deflate
+		}
+
+		writer, err := archive.CreateHeader(header)
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		file, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+		_, err = io.Copy(writer, file)
+		return err
+	}); err != nil {
+		return err
+	}
+
+	return err
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
refactor status-uploader, so that github assets of multiple testruns can be uploaded at once. Also archive assets and provide an overview file. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```
refactor status-uploader, so that github assets of multiple testruns can be uploaded at once. Also archive assets and provide an overview file. 

```
