### PR TITLE
Refactor status asset upload

### DIFF
--- a/pkg/testrunner/result/status-uploader.go
+++ b/pkg/testrunner/result/status-uploader.go
@@ -74,7 +74,7 @@ func UploadStatusToGithub(loggerInstance logr.Logger, runs testrunner.RunList, c
 			return err
 		}
 		l.Info(fmt.Sprintf("unzipping %s into %s", archiveFilename, archiveContentDir))
-		if err := util.Unzip(archiveFilepath, archiveContentDir); err != nil {
+		if err := util.Unzip(archiveFilepath, filepath.Dir(archiveContentDir)); err != nil {
 			l.Error(err, fmt.Sprintf("failed to unzip %s", archiveFilepath))
 			return err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Multiple fixes of asset upload functionality

**Which issue(s) this PR fixes**:
- failed testrun asset leftovers, which have been created by previous patch version testruns
- some components are missing assets, because a single other component consists the results

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```
- asset uploader uploads for each component individually.
- asset uploader always deletes previously failed testrun assets before checking for upload necessity

```
