### PR TITLE
Add more authentication with better error message for the tm bot

### DIFF
--- a/pkg/tm-bot/github/types.go
+++ b/pkg/tm-bot/github/types.go
@@ -78,9 +78,10 @@ type client struct {
 type AuthorizationType string
 
 const (
-	AuthorizationAll  AuthorizationType = "all"
-	AuthorizationOrg  AuthorizationType = "org"
-	AuthorizationTeam AuthorizationType = "team"
+	AuthorizationAll        AuthorizationType = "all"
+	AuthorizationOrg        AuthorizationType = "org"
+	AuthorizationTeam       AuthorizationType = "team"
+	AuthorizationCodeOwners AuthorizationType = "codeowners"
 )
 
 // EventActionType represents the action type of a github event

--- a/pkg/tm-bot/plugins/echo/echo.go
+++ b/pkg/tm-bot/plugins/echo/echo.go
@@ -39,7 +39,7 @@ func (_ *echo) Command() string {
 }
 
 func (_ *echo) Authorization() github.AuthorizationType {
-	return github.AuthorizationAll
+	return github.AuthorizationTeam
 }
 
 func (_ *echo) Description() string {

--- a/pkg/tm-bot/plugins/request.go
+++ b/pkg/tm-bot/plugins/request.go
@@ -47,12 +47,13 @@ func (p *Plugins) HandleRequest(client github.Client, event *github.GenericReque
 func (p *Plugins) runPlugin(client github.Client, event *github.GenericRequestEvent, args []string) {
 	runID, plugin, err := p.Get(args[0])
 	if err != nil {
-		_ = p.Error(client, event, nil, err)
+		p.log.Error(err, "unable to get plugin for command", "command", args[0])
 		return
 	}
 
 	if !client.IsAuthorized(plugin.Authorization(), event) {
 		p.log.V(3).Info("user not authorized", "user", event.GetAuthorName(), "plugin", plugin.Command())
+		_, _ = client.Comment(event, FormatUnauthorizedResponse(event.GetAuthorName(), args[0]))
 		return
 	}
 

--- a/pkg/tm-bot/plugins/respond.go
+++ b/pkg/tm-bot/plugins/respond.go
@@ -86,3 +86,9 @@ Usage:
 `
 	return fmt.Sprintf(format, name, description, example, usage)
 }
+
+// FormatUnauthorizedResponse returns the user not authorized response
+func FormatUnauthorizedResponse(to, name string) string {
+	format := ":construction: @%s you are not allowed to use the command `%s`"
+	return fmt.Sprintf(format, to, name)
+}

--- a/pkg/tm-bot/plugins/resume/resume.go
+++ b/pkg/tm-bot/plugins/resume/resume.go
@@ -50,7 +50,7 @@ func (r *resume) Command() string {
 }
 
 func (r *resume) Authorization() github.AuthorizationType {
-	return github.AuthorizationOrg
+	return github.AuthorizationTeam
 }
 
 func (r *resume) Description() string {

--- a/pkg/tm-bot/plugins/skip/skip.go
+++ b/pkg/tm-bot/plugins/skip/skip.go
@@ -43,7 +43,7 @@ func (_ *skip) Command() string {
 }
 
 func (_ *skip) Authorization() github.AuthorizationType {
-	return github.AuthorizationOrg
+	return github.AuthorizationCodeOwners
 }
 
 func (_ *skip) Description() string {

--- a/pkg/tm-bot/plugins/tests/test.go
+++ b/pkg/tm-bot/plugins/tests/test.go
@@ -65,7 +65,7 @@ func (t *test) Command() string {
 }
 
 func (_ *test) Authorization() github.AuthorizationType {
-	return github.AuthorizationOrg
+	return github.AuthorizationTeam
 }
 
 func (t *test) Description() string {

--- a/pkg/tm-bot/plugins/xkcd/xkcd.go
+++ b/pkg/tm-bot/plugins/xkcd/xkcd.go
@@ -58,7 +58,7 @@ func (_ *xkcd) Command() string {
 }
 
 func (_ *xkcd) Authorization() github.AuthorizationType {
-	return github.AuthorizationAll
+	return github.AuthorizationOrg
 }
 
 func (_ *xkcd) Description() string {

--- a/pkg/tm-bot/ui/pages/CommandHelp.go
+++ b/pkg/tm-bot/ui/pages/CommandHelp.go
@@ -23,9 +23,10 @@ import (
 )
 
 var AuthorizationTooltip = map[github.AuthorizationType]string{
-	github.AuthorizationAll:  "Everyone is allowed to use the command",
-	github.AuthorizationOrg:  "Everyone that is member of the org is allowed to use the command",
-	github.AuthorizationTeam: "Everyone that is in the default team or in the requested reviewers is allowed to use the command",
+	github.AuthorizationAll:        "Everyone is allowed to use the command",
+	github.AuthorizationOrg:        "Everyone that is member of the org is allowed to use the command",
+	github.AuthorizationTeam:       "Everyone that is in the default team is allowed to use the command",
+	github.AuthorizationCodeOwners: "Only codeowners are allowed to use command. If no code owner exists the default team is used.",
 }
 
 type CommandHelpItem struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
Ignore command that are not known by the bot.
Add more authentication to the bot commands and notify the user if he is not allowed to execute a command.

Also added another authentication mechanism `codeowners` to distinguish between default team authorization and codeowners authorization.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
Ignore commands that are not known to the bot
```
```improvement user
Notify users if they are not allowed to execute a command.
```
