### PR TITLE
Add a few pre computed fields to teststeps (for better grafana int)

### DIFF
--- a/docs/testrunner/README.md
+++ b/docs/testrunner/README.md
@@ -18,7 +18,7 @@ Testrunner is an additional component of the Test Machinery that abstracts templ
 
 The testrunner is a basic go commandline tool that can be run by either calling it directly via
 ```
-go run cmd/testmachinery-run/main.go [flags]
+go run -mod=vendor cmd/testrunner/main.go [flags]
 ```
 or via the prebuild binary which is updated and kept in sync with each new Test Machinery version (also available in the image `eu.gcr.io/gardener-project/gardener/testmachinery/testmachinery-run`)
 ```

--- a/pkg/testrunner/result/output.go
+++ b/pkg/testrunner/result/output.go
@@ -18,6 +18,7 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"fmt"
+	"github.com/Masterminds/semver"
 	argov1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/utils"
@@ -39,7 +40,7 @@ func Output(log logr.Logger, config *Config, tmClient kubernetes.Interface, name
 	metadata.Testrun.StartTime = tr.Status.StartTime
 	metadata.Annotations = tr.Annotations
 
-	trSummary, summaries, err := DetermineTestrunSummary(tr, metadata, config)
+	trSummary, summaries, err := DetermineTestrunSummary(tr, metadata, config, tmClient, log)
 	if err != nil {
 		return err
 	}
@@ -91,7 +92,7 @@ func Output(log logr.Logger, config *Config, tmClient kubernetes.Interface, name
 }
 
 // DetermineTestrunSummary parses a testruns status and returns
-func DetermineTestrunSummary(tr *tmv1beta1.Testrun, metadata *testrunner.Metadata, config *Config) (testrunner.TestrunSummary, []testrunner.StepSummary, error) {
+func DetermineTestrunSummary(tr *tmv1beta1.Testrun, metadata *testrunner.Metadata, config *Config, tmClient kubernetes.Interface, log logr.Logger) (testrunner.TestrunSummary, []testrunner.StepSummary, error) {
 	status := tr.Status
 	testsRun := 0
 	summaries := make([]testrunner.StepSummary, 0)
@@ -106,15 +107,17 @@ func DetermineTestrunSummary(tr *tmv1beta1.Testrun, metadata *testrunner.Metadat
 				stepMetadata.Configuration[elem.Name] = elem.Value
 			}
 		}
+		pre := preComputeTeststepFields(step, stepMetadata, tmClient, log)
 
 		summary := testrunner.StepSummary{
-			Metadata:  &stepMetadata,
-			Type:      testrunner.SummaryTypeTeststep,
-			Name:      step.TestDefinition.Name,
-			StepName:  step.Position.Step,
-			Phase:     step.Phase,
-			StartTime: step.StartTime,
-			Duration:  step.Duration,
+			Metadata:    &stepMetadata,
+			Type:        testrunner.SummaryTypeTeststep,
+			Name:        step.TestDefinition.Name,
+			StepName:    step.Position.Step,
+			Phase:       step.Phase,
+			StartTime:   step.StartTime,
+			Duration:    step.Duration,
+			PreComputed: pre,
 		}
 
 		summaries = append(summaries, summary)
@@ -230,4 +233,35 @@ func getFilesFromTar(r io.Reader) ([][]byte, error) {
 	}
 
 	return files, nil
+}
+
+// preComputeTeststepFields precomputes fields for elasticsearch that are otherwise hard to add at runtime (i.e. as grafana does not support scripted fields)
+func preComputeTeststepFields(stepStatus *tmv1beta1.StepStatus, metadata testrunner.Metadata, tmClient kubernetes.Interface, log logr.Logger) *testrunner.StepPreComputed {
+	var stepEnriched testrunner.StepPreComputed
+
+	switch stepStatus.Phase {
+	case tmv1beta1.PhaseStatusFailed, tmv1beta1.PhaseStatusTimeout:
+		stepEnriched.PhaseNum = 0
+	case tmv1beta1.PhaseStatusSuccess:
+		stepEnriched.PhaseNum = 100
+	}
+
+	k8sVersion := metadata.KubernetesVersion
+	if k8sVersion != "" {
+		semVer, err := semver.NewVersion(k8sVersion)
+		if err != nil {
+			log.Error(err, "cannot parse k8s Version, will not precompute derived data")
+		} else {
+			stepEnriched.K8SMajorMinorVersion = fmt.Sprintf("%d.%d", semVer.Major(), semVer.Minor())
+		}
+	}
+
+	clusterDomain, err := testrunner.GeClusterDomainURL(tmClient)
+	if err == nil {
+		stepEnriched.ArgoDisplayName = "argo"
+		stepEnriched.LogsDisplayName = "logs"
+		stepEnriched.ClusterDomain = clusterDomain
+	}
+
+	return &stepEnriched
 }

--- a/pkg/testrunner/result/output.go
+++ b/pkg/testrunner/result/output.go
@@ -241,9 +241,11 @@ func preComputeTeststepFields(stepStatus *tmv1beta1.StepStatus, metadata testrun
 
 	switch stepStatus.Phase {
 	case tmv1beta1.PhaseStatusFailed, tmv1beta1.PhaseStatusTimeout:
-		stepEnriched.PhaseNum = 0
+		zero := 0
+		stepEnriched.PhaseNum = &zero
 	case tmv1beta1.PhaseStatusSuccess:
-		stepEnriched.PhaseNum = 100
+		hundred := 100
+		stepEnriched.PhaseNum = &hundred
 	}
 
 	k8sVersion := metadata.KubernetesVersion
@@ -256,7 +258,7 @@ func preComputeTeststepFields(stepStatus *tmv1beta1.StepStatus, metadata testrun
 		}
 	}
 
-	clusterDomain, err := testrunner.GeClusterDomainURL(tmClient)
+	clusterDomain, err := testrunner.GetClusterDomainURL(tmClient)
 	if err == nil {
 		stepEnriched.ArgoDisplayName = "argo"
 		stepEnriched.LogsDisplayName = "logs"

--- a/pkg/testrunner/result/output_test.go
+++ b/pkg/testrunner/result/output_test.go
@@ -2,12 +2,12 @@ package result_test
 
 import (
 	"github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
+	"github.com/gardener/test-infra/pkg/logger"
 	"github.com/gardener/test-infra/pkg/testrunner"
 	"github.com/gardener/test-infra/pkg/testrunner/result"
 	"github.com/gardener/test-infra/test/resources"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	"testing"
 )
 
@@ -17,7 +17,7 @@ func TestValidationWebhook(t *testing.T) {
 }
 
 var _ = Describe("output generation tests", func() {
-
+	log := logger.Log.WithName("output_test")
 	Context("configuration", func() {
 		It("should include environment variable configuration to in the metadata", func() {
 			configElement := v1beta1.ConfigElement{
@@ -39,7 +39,7 @@ var _ = Describe("output generation tests", func() {
 				},
 			}
 
-			_, summaries, err := result.DetermineTestrunSummary(tr, &testrunner.Metadata{}, &result.Config{})
+			_, summaries, err := result.DetermineTestrunSummary(tr, &testrunner.Metadata{}, &result.Config{}, nil, log)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(summaries).To(HaveLen(1))
@@ -68,8 +68,7 @@ var _ = Describe("output generation tests", func() {
 				},
 			},
 		}
-
-		_, summaries, err := result.DetermineTestrunSummary(tr, &testrunner.Metadata{}, &result.Config{})
+		_, summaries, err := result.DetermineTestrunSummary(tr, &testrunner.Metadata{}, &result.Config{}, nil, log)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(summaries).To(HaveLen(1))

--- a/pkg/testrunner/result/output_test.go
+++ b/pkg/testrunner/result/output_test.go
@@ -2,12 +2,12 @@ package result_test
 
 import (
 	"github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
-	"github.com/gardener/test-infra/pkg/logger"
 	"github.com/gardener/test-infra/pkg/testrunner"
 	"github.com/gardener/test-infra/pkg/testrunner/result"
 	"github.com/gardener/test-infra/test/resources"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"testing"
 )
 
@@ -17,7 +17,7 @@ func TestValidationWebhook(t *testing.T) {
 }
 
 var _ = Describe("output generation tests", func() {
-	log := logger.Log.WithName("output_test")
+	log := log.NullLogger{}
 	Context("configuration", func() {
 		It("should include environment variable configuration to in the metadata", func() {
 			configElement := v1beta1.ConfigElement{

--- a/pkg/testrunner/run.go
+++ b/pkg/testrunner/run.go
@@ -23,7 +23,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/hashicorp/go-multierror"
 	"k8s.io/api/extensions/v1beta1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"net/url"
 	"path"
 	"regexp"
@@ -141,10 +141,13 @@ func GetArgoURL(tmClient kubernetes.Interface, tr *tmv1beta1.Testrun) (string, e
 }
 
 // GetClusterDomainURL tries to derive the cluster domain url from an grafana ingress if possible. Returns an error if the ingress cannot be found or is in unexpected form.
-func GeClusterDomainURL(tmClient kubernetes.Interface) (string, error) {
+func GetClusterDomainURL(tmClient kubernetes.Interface) (string, error) {
 	// try to derive the cluster domain url from grafana ingress if possible
 	// return err if the ingress cannot be found
-	ingress, err := tmClient.Kubernetes().ExtensionsV1beta1().Ingresses("monitoring").Get("grafana", v1.GetOptions{})
+	if tmClient == nil {
+		return "", nil
+	}
+	ingress, err := tmClient.Kubernetes().ExtensionsV1beta1().Ingresses("monitoring").Get("grafana", metav1.GetOptions{})
 	if err != nil {
 		return "", fmt.Errorf("cannot get grafana ingress: %v", err)
 	}

--- a/pkg/testrunner/run.go
+++ b/pkg/testrunner/run.go
@@ -23,8 +23,10 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/hashicorp/go-multierror"
 	"k8s.io/api/extensions/v1beta1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"net/url"
 	"path"
+	"regexp"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener/pkg/client/kubernetes"
@@ -136,4 +138,24 @@ func GetArgoURL(tmClient kubernetes.Interface, tr *tmv1beta1.Testrun) (string, e
 	argoUrl.Path = path.Join(argoUrl.Path, "workflows", tr.Namespace, testmachinery.GetWorkflowName(tr))
 
 	return argoUrl.String(), nil
+}
+
+// GetClusterDomainURL tries to derive the cluster domain url from an grafana ingress if possible. Returns an error if the ingress cannot be found or is in unexpected form.
+func GeClusterDomainURL(tmClient kubernetes.Interface) (string, error) {
+	// try to derive the cluster domain url from grafana ingress if possible
+	// return err if the ingress cannot be found
+	ingress, err := tmClient.Kubernetes().ExtensionsV1beta1().Ingresses("monitoring").Get("grafana", v1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("cannot get grafana ingress: %v", err)
+	}
+	if len(ingress.Spec.Rules) == 0 {
+		return "", fmt.Errorf("cannot get ingress rule from ingress %v", ingress)
+	}
+	host := ingress.Spec.Rules[0].Host
+	r, _ := regexp.Compile("[a-z]+\\.ingress\\.(.+)$")
+	matches := r.FindStringSubmatch(host)
+	if len(matches) < 2 {
+		return "", fmt.Errorf("cannot regex cluster domain from ingress %v", ingress)
+	}
+	return matches[1], nil
 }

--- a/pkg/testrunner/types.go
+++ b/pkg/testrunner/types.go
@@ -135,7 +135,7 @@ type StepSummary struct {
 // StepPreComputed contains fields that could be created at runtime via scripted fields, but are created statically for better performance and better support of grafana
 type StepPreComputed struct {
 	// same as StepSummary.Phase but mapping states to ints (Failed&Timeout -> 0, Succeeded -> 100); allows to do averages on success rate in dashboards
-	PhaseNum int `json:"phaseNum,omitempty"`
+	PhaseNum *int `json:"phaseNum,omitempty"`
 	// A K8S Version without the patch suffix, e.g. "1.16"
 	K8SMajorMinorVersion string `json:"k8sMajMinVer,omitempty"`
 	// Dummy field for grafana/log links

--- a/pkg/testrunner/types.go
+++ b/pkg/testrunner/types.go
@@ -122,11 +122,26 @@ type TestrunSummary struct {
 
 // StepSummary is the result of a specific step.
 type StepSummary struct {
-	Metadata  *Metadata        `json:"tm,omitempty"`
-	Type      SummaryType      `json:"type,omitempty"`
-	Name      string           `json:"name,omitempty"`
-	StepName  string           `json:"stepName,omitempty"`
-	Phase     argov1.NodePhase `json:"phase,omitempty"`
-	StartTime *metav1.Time     `json:"startTime,omitempty"`
-	Duration  int64            `json:"duration,omitempty"`
+	Metadata    *Metadata        `json:"tm,omitempty"`
+	Type        SummaryType      `json:"type,omitempty"`
+	Name        string           `json:"name,omitempty"`
+	StepName    string           `json:"stepName,omitempty"`
+	Phase       argov1.NodePhase `json:"phase,omitempty"`
+	StartTime   *metav1.Time     `json:"startTime,omitempty"`
+	Duration    int64            `json:"duration,omitempty"`
+	PreComputed *StepPreComputed `json:"pre,omitempty"`
+}
+
+// StepPreComputed contains fields that could be created at runtime via scripted fields, but are created statically for better performance and better support of grafana
+type StepPreComputed struct {
+	// same as StepSummary.Phase but mapping states to ints (Failed&Timeout -> 0, Succeeded -> 100); allows to do averages on success rate in dashboards
+	PhaseNum int `json:"phaseNum,omitempty"`
+	// A K8S Version without the patch suffix, e.g. "1.16"
+	K8SMajorMinorVersion string `json:"k8sMajMinVer,omitempty"`
+	// Dummy field for grafana/log links
+	LogsDisplayName string `json:"logsText,omitempty"`
+	// Dummy field for argoui/workflow links
+	ArgoDisplayName string `json:"argoText,omitempty"`
+	// the cluster domain of the testmachinery (useful to build other URLs in dashboards)
+	ClusterDomain string `json:"clusterDomain,omitempty"`
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a few pre computed fields to teststeps for better grafana ingegration.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator

```
