### PR TITLE
Add a unique run id to every testrun that is running within one testrunner execution

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20191027212112-611e8accdfc9 // indirect
 	github.com/golang/mock v1.3.1
 	github.com/google/go-github/v27 v27.0.4
+	github.com/google/uuid v1.1.1
 	github.com/googleapis/gnostic v0.3.1 // indirect
 	github.com/gorilla/mux v1.6.2
 	github.com/gorilla/sessions v1.1.3

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -16,11 +16,36 @@ package common
 
 // Annotations
 const (
-	PurposeTestrunAnnotation = "testmachinery.sapcloud.io/purpose"
-	ResumeTestrunAnnotation  = "testmachinery.sapcloud.io/resume"
+	// AnnotationResumeTestrun is the annotation name to trigger resume on the testrun
+	AnnotationResumeTestrun = "testmachinery.sapcloud.io/resume"
 
-	TemplateIDTestrunAnnotation = "testrunner.testmachinery.sapcloud.io/templateID"
+	// AnnotationTestrunPurpose is the annotation name to specify a purpose of the testrun
+	AnnotationTestrunPurpose = "testmachinery.sapcloud.io/purpose"
 
+	// LabelTestrunRunID is the annotation to specify the unique name of the run (multiple testuns) this test belongs to.
+	// A run represents all tests that are running from one testrunner.
+	LabelTestrunRunID = "testrunner.testmachinery.sapcloud.io/runID"
+
+	// AnnotationTemplateIDTestrun is the annotation to specify the name of the template the testun is rendered from
+	AnnotationTemplateIDTestrun = "testrunner.testmachinery.sapcloud.io/templateID"
+
+	// AnnotationLandscape is the annotation to specify the landscape this testrun is testing
+	AnnotationLandscape = "testrunner.testmachinery.sapcloud.io/landscape"
+
+	// AnnotationK8sVersion is the annotation to specify the k8s version the testrun is testing
+	AnnotationK8sVersion = "testrunner.testmachinery.sapcloud.io/k8sVersion"
+
+	// AnnotationCloudProvider is the annotation to specify the cloudprovider the testrun is testing
+	AnnotationCloudProvider = "testrunner.testmachinery.sapcloud.io/cloudprovider"
+
+	// AnnotationOperatingSystem is the annotation to specify the operating system of teh shoot nodes the testrun is testing
+	AnnotationOperatingSystem = "testrunner.testmachinery.sapcloud.io/operating-system"
+
+	// AnnotationDimension is the annotation to specify the dimension the testrun is testing
+	AnnotationDimension = "testrunner.testmachinery.sapcloud.io/dimension"
+
+	// AnnotationSystemStep is the testflow step annotation to specify that the step is a testmachinery system step.
+	// It indicates that it should not be considered as a test and therefore should not count for a test to be failed.
 	AnnotationSystemStep = "testmachinery.sapcloud.io/system-step"
 
 	// images

--- a/pkg/testmachinery/controller/reconciler/testrun_control_resume.go
+++ b/pkg/testmachinery/controller/reconciler/testrun_control_resume.go
@@ -30,14 +30,14 @@ import (
 
 // Resume a workflow if a specific annotation is set
 func (r *TestmachineryReconciler) resumeAction(ctx context.Context, rCtx *reconcileContext) error {
-	if b, ok := rCtx.tr.Annotations[common.ResumeTestrunAnnotation]; ok && b == "true" {
+	if b, ok := rCtx.tr.Annotations[common.AnnotationResumeTestrun]; ok && b == "true" {
 		// resume workflow
 		argo.ResumeWorkflow(rCtx.wf)
 		if err := r.Client.Update(ctx, rCtx.wf); err != nil {
 			return err
 		}
 
-		delete(rCtx.tr.Annotations, common.ResumeTestrunAnnotation)
+		delete(rCtx.tr.Annotations, common.AnnotationResumeTestrun)
 		rCtx.updated = true
 	}
 	return nil

--- a/pkg/testrunner/metadata.go
+++ b/pkg/testrunner/metadata.go
@@ -17,24 +17,17 @@ package testrunner
 import (
 	"fmt"
 	tmv1beta1 "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
-)
-
-const (
-	AnnotationLandscape       = "testrunner.testmachinery.sapcloud.io/landscape"
-	AnnotationK8sVersion      = "testrunner.testmachinery.sapcloud.io/k8sVersion"
-	AnnotationCloudProvider   = "testrunner.testmachinery.sapcloud.io/cloudprovider"
-	AnnotationOperatingSystem = "testrunner.testmachinery.sapcloud.io/operating-system"
-	AnnotationDimension       = "testrunner.testmachinery.sapcloud.io/dimension"
+	"github.com/gardener/test-infra/pkg/common"
 )
 
 // CreateAnnotations creates annotations of the metadata to be set on the respective workflow
 func (m *Metadata) CreateAnnotations() map[string]string {
 	return map[string]string{
-		AnnotationLandscape:       m.Landscape,
-		AnnotationK8sVersion:      m.KubernetesVersion,
-		AnnotationCloudProvider:   m.CloudProvider,
-		AnnotationOperatingSystem: m.OperatingSystem,
-		AnnotationDimension:       m.GetDimensionFromMetadata(),
+		common.AnnotationLandscape:       m.Landscape,
+		common.AnnotationK8sVersion:      m.KubernetesVersion,
+		common.AnnotationCloudProvider:   m.CloudProvider,
+		common.AnnotationOperatingSystem: m.OperatingSystem,
+		common.AnnotationDimension:       m.GetDimensionFromMetadata(),
 	}
 }
 
@@ -57,12 +50,13 @@ func (m *Metadata) DeepCopy() *Metadata {
 // MetadataFromTestrun reads metadata from a testrun
 func MetadataFromTestrun(tr *tmv1beta1.Testrun) *Metadata {
 	return &Metadata{
-		Landscape:         tr.Annotations[AnnotationLandscape],
-		KubernetesVersion: tr.Annotations[AnnotationK8sVersion],
-		CloudProvider:     tr.Annotations[AnnotationCloudProvider],
-		OperatingSystem:   tr.Annotations[AnnotationOperatingSystem],
+		Landscape:         tr.Annotations[common.AnnotationLandscape],
+		KubernetesVersion: tr.Annotations[common.AnnotationK8sVersion],
+		CloudProvider:     tr.Annotations[common.AnnotationCloudProvider],
+		OperatingSystem:   tr.Annotations[common.AnnotationOperatingSystem],
 		Testrun: TestrunMetadata{
-			ID: tr.Name,
+			ID:    tr.Name,
+			RunId: tr.Annotations[common.LabelTestrunRunID],
 		},
 	}
 }

--- a/pkg/testrunner/run.go
+++ b/pkg/testrunner/run.go
@@ -18,42 +18,19 @@ import (
 	"context"
 	"fmt"
 	tmv1beta1 "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
+	"github.com/gardener/test-infra/pkg/common"
 	trerrors "github.com/gardener/test-infra/pkg/testrunner/error"
 	"github.com/gardener/test-infra/pkg/util"
 	"github.com/go-logr/logr"
-	"github.com/hashicorp/go-multierror"
 )
 
-// GetTestruns returns all testruns of a RunList as testrun array
-func (rl RunList) GetTestruns() []*tmv1beta1.Testrun {
-	testruns := make([]*tmv1beta1.Testrun, len(rl))
-	for i, run := range rl {
-		if run != nil {
-			testruns[i] = run.Testrun
-		}
+// SetRunID sets the provided run id as annotation and adds it to the metadata
+func (r *Run) SetRunID(id string) {
+	if r.Testrun.Labels == nil {
+		r.Testrun.Labels = make(map[string]string, 1)
 	}
-	return testruns
-}
-
-// HasErrors checks whether one run in list is erroneous.
-func (rl RunList) HasErrors() bool {
-	for _, run := range rl {
-		if run.Error != nil {
-			return true
-		}
-	}
-	return false
-}
-
-// Errors returns all errors of all testruns in this testrun
-func (rl RunList) Errors() error {
-	var res *multierror.Error
-	for _, run := range rl {
-		if run.Error != nil {
-			res = multierror.Append(res, run.Error)
-		}
-	}
-	return util.ReturnMultiError(res)
+	r.Testrun.Labels[common.LabelTestrunRunID] = id
+	r.Metadata.Testrun.RunId = id
 }
 
 func (r *Run) Exec(log logr.Logger, config *Config, prefix string) {

--- a/pkg/testrunner/template/renderer.go
+++ b/pkg/testrunner/template/renderer.go
@@ -100,12 +100,12 @@ func (s *renderState) Rerender(tr *v1beta1.Testrun) (*testrunner.Run, error) {
 		return nil, err
 	}
 
-	templateID, ok := tr.GetAnnotations()[common.TemplateIDTestrunAnnotation]
+	templateID, ok := tr.GetAnnotations()[common.AnnotationTemplateIDTestrun]
 	if !ok {
 		return nil, errors.Errorf("testrun %s does not have a template id", tr.GetName())
 	}
 	for _, run := range runs {
-		if id := run.Testrun.GetAnnotations()[common.TemplateIDTestrunAnnotation]; id == templateID {
+		if id := run.Testrun.GetAnnotations()[common.AnnotationTemplateIDTestrun]; id == templateID {
 			return run, nil
 		}
 	}
@@ -135,7 +135,7 @@ func ParseTestrunsFromChart(log logr.Logger, chart *chartrenderer.RenderedChart)
 			log.Info(fmt.Sprintf("cannot parse rendered file: %s", err.Error()))
 			continue
 		}
-		metav1.SetMetaDataAnnotation(&tr.ObjectMeta, common.TemplateIDTestrunAnnotation, filename)
+		metav1.SetMetaDataAnnotation(&tr.ObjectMeta, common.AnnotationTemplateIDTestrun, filename)
 		testruns = append(testruns, &tr)
 	}
 	return testruns

--- a/pkg/testrunner/types.go
+++ b/pkg/testrunner/types.go
@@ -35,6 +35,7 @@ type Config struct {
 	Timeout time.Duration
 
 	// Poll interval to check the testrun status
+	// DEPRECATED
 	Interval time.Duration
 
 	// Number of testrun retries after a failed run
@@ -108,6 +109,9 @@ type Metadata struct {
 type TestrunMetadata struct {
 	// Name of the testrun crd object.
 	ID string `json:"id"`
+
+	// Name of the run this test belongs to
+	RunId string `json:"runID,omitempty"`
 
 	// StartTime of the testrun.
 	StartTime *metav1.Time `json:"startTime"`

--- a/pkg/tm-bot/ui/static/style.css
+++ b/pkg/tm-bot/ui/static/style.css
@@ -120,6 +120,14 @@ ul.noBullets li {
     margin-right: 10px;
 }
 
+.runs_container .mdl-cell {
+    width: auto;
+}
+
+tr.disabled {
+    opacity: 50%;
+}
+
 .home {
     width: 90%;
     margin: 0 auto;

--- a/pkg/tm-bot/ui/templates/testrun.html
+++ b/pkg/tm-bot/ui/templates/testrun.html
@@ -7,8 +7,19 @@
         <div class="mdl-card__actions mdl-card--border">
             <div class="mdl-grid">
                 <div class="mdl-cell  mdl-list__item-primary-content">
-                    {{ .page.Dimension }}
+                    <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+                        <input class="mdl-textfield__input" id="run-id" value="{{ .page.RunID }}" readonly>
+                        <label class="mdl-textfield__label" for="run-id">Run Id</label>
+                    </div>
                 </div>
+                <div class="mdl-cell  mdl-list__item-primary-content">
+                    <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+                        <input class="mdl-textfield__input" id="dimension" value="{{ .page.Dimension }}" readonly>
+                        <label class="mdl-textfield__label" for="dimension">Dimension</label>
+                    </div>
+                </div>
+            </div>
+            <div class="mdl-grid">
                 <div class="mdl-cell mdl-list__item-primary-content">
                     <button class="mdl-button mdl-button--icon mdl-button--disabled"><i class="material-icons mdl-list__item-icon">schedule</i></button>
                     {{ .page.StartTime }}
@@ -35,7 +46,7 @@
                 </thead>
                 <tbody>
                 {{ range $_, $step := .page.Steps }}
-                    <tr>
+                    <tr {{if $step.IsSystem }} class="disabled" {{ end }}>
                         <td class="icon-cell">
                             <i id="phase-{{ $step.Name }}" class="material-icons mdl-list__item-icon" style="color:{{ $step.Phase.Color }}">{{ $step.Phase.Icon }}</i>
                             <div class="mdl-tooltip" for="phase-{{ $step.Name }}">{{ $step.Phase.Tooltip }}</div>

--- a/pkg/tm-bot/ui/templates/testruns.html
+++ b/pkg/tm-bot/ui/templates/testruns.html
@@ -1,5 +1,39 @@
-{{define "title"}}Testruns{{end}}
+{{define "title"}}
+    {{ if .page.rungroup }}
+        <a href="/testruns">Testruns</a> > {{ .page.rungroup }}
+    {{ else }}
+        Testruns
+    {{ end }}
+{{end}}
 {{define "content"}}
+    <div class="runs_container">
+        <div class="mdl-grid">
+            {{ range $_, $rg := .page.rungroups }}
+                <div class="mdl-cell">
+                    <div class="demo-card-wide mdl-card mdl-shadow--2dp">
+                        <div class="mdl-card__title">
+                            <h4 class="mdl-card__title-text">{{ $rg.DisplayName }}</h4>
+                        </div>
+                        <div class="mdl-card__supporting-text">
+                            {{ $rg.Name }} <br><br>
+                            {{ $rg.State }} <br>
+                            {{ $rg.StartTime }}
+                        </div>
+                        <div class="mdl-card__actions mdl-card--border">
+                            <a class="mdl-button mdl-button--colored mdl-js-button mdl-js-ripple-effect" href="/testruns?runID={{ $rg.Name }}">
+                                Details
+                            </a>
+                        </div>
+                        <div class="mdl-card__menu">
+                            <button id="phase-{{ $rg.Name }}" class="mdl-button mdl-button--icon mdl-js-button mdl-js-ripple-effect">
+                                <i class="material-icons mdl-list__item-icon" style="color:{{ $rg.Phase.Color }}">{{ $rg.Phase.Icon }}</i>
+                            </button>
+                            <div class="mdl-tooltip" for="phase-{{ $rg.Name }}">{{ $rg.Phase.Tooltip }}</div>
+                        </div>
+                    </div>
+                </div>
+            {{end}}
+        </div>
     <div class="table-container">
         <table id="command-table" class="mdl-data-table mdl-js-data-table mdl-shadow--2dp">
             <thead>

--- a/pkg/util/testrun.go
+++ b/pkg/util/testrun.go
@@ -41,6 +41,16 @@ func TestrunStatusPhase(tr *v1beta1.Testrun) argov1alpha1.NodePhase {
 	return v1beta1.PhaseStatusInit
 }
 
+func IsSystemStep(step *v1beta1.StepStatus) bool {
+	if len(step.Annotations) == 0 {
+		return false
+	}
+	if _, ok := step.Annotations[common.AnnotationSystemStep]; ok {
+		return true
+	}
+	return false
+}
+
 // Resume testruns resumes a testrun by adding the appropriate annotation to it
 func ResumeTestrun(ctx context.Context, k8sClient client.Client, tr *v1beta1.Testrun) error {
 	obj, err := client.ObjectKeyFromObject(tr)
@@ -53,7 +63,7 @@ func ResumeTestrun(ctx context.Context, k8sClient client.Client, tr *v1beta1.Tes
 	if tr.Annotations == nil {
 		tr.Annotations = make(map[string]string, 0)
 	}
-	tr.Annotations[common.ResumeTestrunAnnotation] = "true"
+	tr.Annotations[common.AnnotationResumeTestrun] = "true"
 	if err := k8sClient.Update(ctx, tr); err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Added an aditional run id to testruns that are triggered by the testrunner.
All testruns that are invoked by the same testrunner instnace will get the same id which means that these testruns can be grouped together.

These testgroups can also be viewed as separate lists in the UI.
<img width="1631" alt="Screen Shot 2019-12-02 at 13 56 25" src="https://user-images.githubusercontent.com/7979201/69962331-1be5ec80-150e-11ea-88ac-68eed32c4b92.png">


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Add run id that are set by the testrunner to group testruns
```
