### PR TITLE
notify on slack after release

### DIFF
--- a/cmd/testrunner/cmd/cmd.go
+++ b/cmd/testrunner/cmd/cmd.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"fmt"
+	notifycmd "github.com/gardener/test-infra/cmd/testrunner/cmd/notify"
 	"os"
 
 	"github.com/gardener/test-infra/cmd/testrunner/cmd/collect"
@@ -60,6 +61,7 @@ func init() {
 	run_testrun.AddCommand(rootCmd)
 	run_gardener.AddCommand(rootCmd)
 	collectcmd.AddCommand(rootCmd)
+	notifycmd.AddCommand(rootCmd)
 	gardener_telemetry.AddCommand(rootCmd)
 	docs.AddCommand(rootCmd)
 	versioncmd.AddCommand(rootCmd)

--- a/cmd/testrunner/cmd/notify/notify.go
+++ b/cmd/testrunner/cmd/notify/notify.go
@@ -1,0 +1,156 @@
+// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package notifycmd
+
+import (
+	"context"
+	"fmt"
+	"github.com/gardener/test-infra/pkg/logger"
+	"github.com/gardener/test-infra/pkg/testrunner"
+	"github.com/gardener/test-infra/pkg/testrunner/componentdescriptor"
+	"github.com/gardener/test-infra/pkg/testrunner/result"
+	"github.com/gardener/test-infra/pkg/util/slack"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+	"os"
+	"reflect"
+	"strings"
+)
+
+var SucessSymbols = map[bool]string{
+	true:  "✅",
+	false: "❌",
+}
+
+var (
+	overviewFileName        string
+	githubUser              string
+	githubPassword          string
+	githubRepositoryName    string
+	githubRepositoryVersion string
+
+	slackChannel string
+	slackToken   string
+)
+
+// AddCommand adds run-testrun to a command.
+func AddCommand(cmd *cobra.Command) {
+	cmd.AddCommand(notifyCmd)
+}
+
+var notifyCmd = &cobra.Command{
+	Use:   "notify",
+	Short: "Posts a result table of a previous run as table to slack.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := context.Background()
+		defer ctx.Done()
+
+		component, err := result.EnhanceComponent(&componentdescriptor.Component{
+			Name:    githubRepositoryName,
+			Version: githubRepositoryVersion,
+		}, githubUser, githubPassword)
+		if err != nil {
+			logger.Log.Error(err, "unable to get repository")
+			os.Exit(1)
+		}
+
+		overview, err := result.DownloadAssetOverview(logger.Log, component, overviewFileName)
+		if err != nil {
+			logger.Log.Error(err, "unable to download asset from repository")
+			os.Exit(1)
+		}
+
+		table, err := renderTableFromAsset(overview)
+		if err != nil {
+			return err
+		}
+		if table == "" {
+			logger.Log.Info("no table to render")
+			return nil
+		}
+
+		slackClient, err := slack.New(logger.Log, slackToken)
+		if err != nil {
+			return err
+		}
+
+		return slackClient.PostMessage(slackChannel, fmt.Sprintf("```\n%s\n```", table))
+	},
+}
+
+func init() {
+	notifyCmd.Flags().StringVar(&githubRepositoryName, "github-repo", "", "Specify the Github repository that should be used to get the test results")
+	notifyCmd.Flags().StringVar(&githubRepositoryVersion, "github-repo-version", "", "Specify the version fot the Github repository that should be used to get the test results")
+	notifyCmd.Flags().StringVar(&githubUser, "github-user", os.Getenv("GITHUB_USER"), "On error dir which is used by Concourse.")
+	notifyCmd.Flags().StringVar(&githubPassword, "github-password", os.Getenv("GITHUB_PASSWORD"), "Github password.")
+	notifyCmd.Flags().StringVar(&overviewFileName, "overview", "", "Name of the overview asset file in the release.")
+	notifyCmd.Flags().StringVar(&slackToken, "slack-token", "", "Client token to authenticate")
+	notifyCmd.Flags().StringVar(&slackChannel, "slack-channel", "", "Client channel id to send the message to.")
+}
+
+func renderTableFromAsset(overview result.AssetOverview) (string, error) {
+	writer := &strings.Builder{}
+	table := tablewriter.NewWriter(writer)
+	headerKeys := make(map[string]int, 0) // maps the header values to their index
+	header := []string{""}
+	dimensionRow := make(map[string]int, 0) // maps the dimension to their row
+	content := make([][]string, 0)
+
+	for _, asset := range overview.AssetOverviewItems {
+		d := asset.Dimension
+		if reflect.DeepEqual(d, testrunner.Dimension{}) {
+			continue
+		}
+		_, ok := headerKeys[d.Cloudprovider]
+		if !ok {
+			header = append(header, d.Cloudprovider)
+			headerKeys[d.Cloudprovider] = len(header) - 1
+		}
+	}
+
+	for _, asset := range overview.AssetOverviewItems {
+		d := asset.Dimension
+		if reflect.DeepEqual(d, testrunner.Dimension{}) {
+			continue
+		}
+		index, ok := headerKeys[d.Cloudprovider]
+		if !ok {
+			continue
+		}
+
+		dimensionKey := fmt.Sprintf("%s %s", d.KubernetesVersion, d.OperatingSystem)
+		if d.Description != "" {
+			dimensionKey = fmt.Sprintf("%s (%s)", dimensionKey, d.Description)
+		}
+
+		dRow, ok := dimensionRow[dimensionKey]
+		if !ok {
+			row := make([]string, len(header))
+			row[0] = dimensionKey
+			content = append(content, row)
+			dimensionRow[dimensionKey] = len(content) - 1
+			dRow = len(content) - 1
+		}
+		content[dRow][index] = SucessSymbols[asset.Successful]
+	}
+	if len(content) == 0 {
+		return "", nil
+	}
+
+	table.SetHeader(header)
+	table.AppendBulk(content)
+	table.Render()
+	return writer.String(), nil
+}

--- a/docs/testrunner/testrunner.md
+++ b/docs/testrunner/testrunner.md
@@ -24,6 +24,7 @@ Testrunner for Test Machinery
 * [testrunner collect](testrunner_collect.md)	 - Collects results from a completed testrun.
 * [testrunner docs](testrunner_docs.md)	 - Generate docs for the testrunner
 * [testrunner gardener-telemetry](testrunner_gardener-telemetry.md)	 - Collects metrics during gardener updates until gardener is updated and all shoots are successfully reconciled
+* [testrunner notify](testrunner_notify.md)	 - Posts a result table of a previous run as table to slack.
 * [testrunner run-gardener](testrunner_run-gardener.md)	 - Run the testrunner with the default gardener test
 * [testrunner run-template](testrunner_run-template.md)	 - Run the testrunner with a helm template containing testruns
 * [testrunner run-testrun](testrunner_run-testrun.md)	 - Run the testrunner with a testrun

--- a/docs/testrunner/testrunner_notify.md
+++ b/docs/testrunner/testrunner_notify.md
@@ -1,0 +1,41 @@
+## testrunner notify
+
+Posts a result table of a previous run as table to slack.
+
+### Synopsis
+
+Posts a result table of a previous run as table to slack.
+
+```
+testrunner notify [flags]
+```
+
+### Options
+
+```
+      --github-password string       Github password.
+      --github-repo string           Specify the Github repository that should be used to get the test results
+      --github-repo-version string   Specify the version fot the Github repository that should be used to get the test results
+      --github-user string           On error dir which is used by Concourse.
+  -h, --help                         help for notify
+      --overview string              Name of the overview asset file in the release.
+      --slack-channel string         Client channel id to send the message to.
+      --slack-token string           Client token to authenticate
+```
+
+### Options inherited from parent commands
+
+```
+      --cli                  logger runs as cli logger. enables cli logging
+      --dev                  enable development logging which result in console encoding, enabled stacktrace and enabled caller
+      --disable-caller       disable the caller of logs (default true)
+      --disable-stacktrace   disable the stacktrace of error logs (default true)
+      --disable-timestamp    disable timestamp output (default true)
+      --dry-run              Dry run will print the rendered template
+  -v, --verbosity int        number for the log level verbosity (default 1)
+```
+
+### SEE ALSO
+
+* [testrunner](testrunner.md)	 - Testrunner for Test Machinery
+

--- a/docs/testrunner/testrunner_run-gardener.md
+++ b/docs/testrunner/testrunner_run-gardener.md
@@ -20,7 +20,7 @@ testrunner run-gardener [flags]
       --fail-on-error                      Testrunners exits with 1 if one testruns failed. (default true)
       --garden-setup-version string        Specify the garden setup version to setup gardener (default "master")
       --gardener-commit string             Specify the gardener commit that is deployed by garden setup
-      --gardener-extensions string         Specify the gardener extensions versions to be deployed by garden setup (default "provider-gcp=github.com/gardener/gardener-extensions.git:master")
+      --gardener-extensions string         Specify the gardener extensions versions to be deployed by garden setup (default "provider-gcp=github.com/gardener/gardener-extensions.git::master")
       --gardener-image string              Specify the gardener image tag to be deployed by garden setup
       --gardener-version string            Specify the gardener version to be deployed by garden setup
   -h, --help                               help for run-gardener

--- a/docs/testrunner/testrunner_run-template.md
+++ b/docs/testrunner/testrunner_run-template.md
@@ -35,6 +35,7 @@ testrunner run-template [flags]
       --s3-ssl                                S3 has SSL enabled.
       --set string                            setValues additional helm values
       --shoot-name string                     Shoot name which is used to run tests.
+      --testrun-flake-attempts int            Max number of testruns until testrun is successful
       --testrun-prefix string                 Testrun name prefix which is used to generate a unique testrun name. (default "default-")
       --testruns-chart-path string            Path to the default testruns chart.
       --timeout int                           Timout in seconds of the testrunner to wait for the complete testrun to finish. (default 3600)

--- a/docs/testrunner/testrunner_run-testrun.md
+++ b/docs/testrunner/testrunner_run-testrun.md
@@ -13,13 +13,14 @@ testrunner run-testrun [flags]
 ### Options
 
 ```
-  -f, --file string                 Path to the testrun yaml
-  -h, --help                        help for run-testrun
-      --interval int                Poll interval in seconds of the testrunner to poll for the testrun status. (default 20)
-      --name-prefix string          Name prefix of the testrun (default "testrunner-")
-  -n, --namespace string            Namespace where the testrun should be deployed. (default "default")
-      --timeout int                 Timout in seconds of the testrunner to wait for the complete testrun to finish. (default 3600)
-      --tm-kubeconfig-path string   Path to the testmachinery cluster kubeconfig
+  -f, --file string                  Path to the testrun yaml
+  -h, --help                         help for run-testrun
+      --interval int                 Poll interval in seconds of the testrunner to poll for the testrun status. (default 20)
+      --name-prefix string           Name prefix of the testrun (default "testrunner-")
+  -n, --namespace string             Namespace where the testrun should be deployed. (default "default")
+      --testrun-flake-attempts int   Max number of testruns until testrun is successful
+      --timeout int                  Timout in seconds of the testrunner to wait for the complete testrun to finish. (default 3600)
+      --tm-kubeconfig-path string    Path to the testmachinery cluster kubeconfig
 ```
 
 ### Options inherited from parent commands

--- a/pkg/testrunner/result/collect.go
+++ b/pkg/testrunner/result/collect.go
@@ -115,7 +115,7 @@ func (c *Collector) uploadStatusAssets(cfg Config, runLogger logr.Logger, runs t
 	}
 
 	componentsForUpload := getComponentsForUpload(cfg, runLogger)
-	if err := UploadStatusToGithub(log, runs, componentsForUpload, cfg.GithubUser, cfg.GithubPassword, cfg.AssetPrefix); err == nil {
+	if err := UploadStatusToGithub(log.WithName("github-upload"), runs, componentsForUpload, cfg.GithubUser, cfg.GithubPassword, cfg.AssetPrefix); err == nil {
 		if err := MarkTestrunsAsUploadedToGithub(runLogger, tmClient, runs); err != nil {
 			runLogger.Error(err, "unable to mark testrun status as uploaded to github")
 		}

--- a/pkg/testrunner/types.go
+++ b/pkg/testrunner/types.go
@@ -162,3 +162,11 @@ type StepPreComputed struct {
 	// the cluster domain of the testmachinery (useful to build other URLs in dashboards)
 	ClusterDomain string `json:"clusterDomain,omitempty"`
 }
+
+// Dimension describes the basic dimension of a test
+type Dimension struct {
+	Description       string `json:"description,omitempty"`
+	Cloudprovider     string `json:"cloudprovider,omitempty"`
+	KubernetesVersion string `json:"k8sVersion,omitempty"`
+	OperatingSystem   string `json:"operating_system,omitempty"`
+}

--- a/pkg/util/slack/slack.go
+++ b/pkg/util/slack/slack.go
@@ -1,0 +1,107 @@
+// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package slack
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	"io/ioutil"
+	"net/http"
+)
+
+// Client defines the interface to interact with the slack API
+type Client interface {
+	// PostMessage will send a message to as the token user to the specified channel
+	PostMessage(channel string, message string) error
+}
+
+type slack struct {
+	log   logr.Logger
+	token string
+}
+
+// New creates a new slack client to interact with the slack API
+func New(log logr.Logger, token string) (Client, error) {
+	if len(token) == 0 {
+		return nil, errors.New("token has to be defined")
+	}
+	return &slack{
+		log:   log,
+		token: token,
+	}, nil
+}
+
+func (s *slack) PostMessage(channel string, message string) error {
+	slackReq, err := json.Marshal(MessageRequest{
+		Channel: channel,
+		AsUser:  true,
+		Text:    message,
+	})
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, "https://slack.com/api/chat.postMessage", bytes.NewBuffer(slackReq))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", s.token))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			s.log.Error(err, "unable to close request body")
+		}
+	}()
+
+	if resp.StatusCode >= 300 {
+		return errors.New("unable to send slack message")
+	}
+
+	rawBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	slackResp := &Response{}
+	if err := json.Unmarshal(rawBody, &slackResp); err != nil {
+		return err
+	}
+
+	if !slackResp.Ok {
+		return errors.Wrap(errors.New(*slackResp.Error), "unable to send response")
+	}
+
+	return nil
+}
+
+// MessageRequest defines a default slack request for a message
+type MessageRequest struct {
+	Channel string `json:"channel"`
+	Text    string `json:"text,omitempty"`
+	AsUser  bool   `json:"as_user,omitempty"`
+}
+
+// Response defines a slack response
+type Response struct {
+	Ok      bool         `json:"ok"`
+	Message *interface{} `json:"message"`
+	Error   *string      `json:"error"`
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a command to the testrunner that posts a slack message with a test result table to slack.
The table is generated from the overview that is pinned to a release of a repository.
<img width="341" alt="Screen Shot 2019-12-03 at 18 44 00" src="https://user-images.githubusercontent.com/7979201/70123131-4c469b80-1672-11ea-9fd9-a7769af220ac.png">


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Add notification option to post a test result table to slack after releases
```
