### PR TITLE
Integrate telemetry controller into the testrunner run

### DIFF
--- a/cmd/testrunner/cmd/gardener_telemetry/gardenertelemetry.go
+++ b/cmd/testrunner/cmd/gardener_telemetry/gardenertelemetry.go
@@ -109,7 +109,7 @@ var gardenerTelemtryCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		if err := analyse.Analyse(telemetry.RawResultsPath, "", common.ReportOutputFormatText); err != nil {
+		if _, err := analyse.Analyse(telemetry.RawResultsPath, "", common.ReportOutputFormatText); err != nil {
 			logger.Log.Error(err, "unable to analyze measurement")
 			os.Exit(1)
 		}

--- a/cmd/testrunner/cmd/run_template/run_template.go
+++ b/cmd/testrunner/cmd/run_template/run_template.go
@@ -84,7 +84,6 @@ var runCmd = &cobra.Command{
 		}
 
 		testrunnerConfig.Timeout = time.Duration(timeout) * time.Second
-		testrunnerConfig.Interval = time.Duration(interval) * time.Second
 		testrunnerConfig.FlakeAttempts = testrunFlakeAttempts
 		collectConfig.ComponentDescriptorPath = shootParameters.ComponentDescriptorPath
 

--- a/pkg/shoot-telemetry/analyse/figures.go
+++ b/pkg/shoot-telemetry/analyse/figures.go
@@ -19,21 +19,21 @@ import (
 	"sort"
 )
 
-type figures struct {
+type Figures struct {
 	Name                  string                       `json:"name"`
 	Provider              string                       `json:"provider"`
 	Seed                  string                       `json:"seed"`
 	CountUnhealthyPeriods int                          `json:"countUnhealthyPeriods"`
 	CountRequests         int                          `json:"countRequest"`
 	CountTimeouts         int                          `json:"countRequestTimeouts"`
-	DownPeriods           *figuresDowntimePeriods      `json:"downTimesSec"`
-	ResponseTimeDuration  *figuresResponseTimeDuration `json:"responseTimesMs"`
+	DownPeriods           *FiguresDowntimePeriods      `json:"downTimesSec"`
+	ResponseTimeDuration  *FiguresResponseTimeDuration `json:"responseTimesMs"`
 
 	downPeriodsStore     durationList
 	requestDurationStore responseTimeList
 }
 
-type figuresResponseTimeDuration struct {
+type FiguresResponseTimeDuration struct {
 	Min    int     `json:"min"`
 	Max    int     `json:"max"`
 	Avg    float64 `json:"avg"`
@@ -41,7 +41,7 @@ type figuresResponseTimeDuration struct {
 	Std    float64 `json:"std"`
 }
 
-type figuresDowntimePeriods struct {
+type FiguresDowntimePeriods struct {
 	Min    float64 `json:"min"`
 	Max    float64 `json:"max"`
 	Avg    float64 `json:"avg"`
@@ -49,11 +49,11 @@ type figuresDowntimePeriods struct {
 	Std    float64 `json:"std"`
 }
 
-func (f *figures) calculateDownPeriodStatistics() {
+func (f *Figures) calculateDownPeriodStatistics() {
 	if f.CountUnhealthyPeriods < 1 {
 		return
 	}
-	f.DownPeriods = &figuresDowntimePeriods{}
+	f.DownPeriods = &FiguresDowntimePeriods{}
 	sort.Sort(f.downPeriodsStore)
 
 	var sum, sumSqrt, avg, variance float64
@@ -82,11 +82,11 @@ func (f *figures) calculateDownPeriodStatistics() {
 	f.DownPeriods.Std = math.Sqrt(variance)
 }
 
-func (f *figures) calculateResponseTimeStatistics() {
+func (f *Figures) calculateResponseTimeStatistics() {
 	if f.CountRequests-f.CountTimeouts < 1 {
 		return
 	}
-	f.ResponseTimeDuration = &figuresResponseTimeDuration{}
+	f.ResponseTimeDuration = &FiguresResponseTimeDuration{}
 	sort.Sort(f.requestDurationStore)
 
 	var (

--- a/pkg/shoot-telemetry/analyse/report.go
+++ b/pkg/shoot-telemetry/analyse/report.go
@@ -26,7 +26,7 @@ import (
 )
 
 type report struct {
-	Figures []*figures `json:"results"`
+	Figures []*Figures `json:"results"`
 }
 
 func (a *report) exportReport(format, path string) error {

--- a/pkg/shoot-telemetry/cmd/analyse.go
+++ b/pkg/shoot-telemetry/cmd/analyse.go
@@ -48,7 +48,7 @@ func GetAnalyseCommand() *cobra.Command {
 						log.Error(err, "invalid flag input")
 						os.Exit(1)
 					}
-					if err := analyse.Analyse(inputPath, outputPath, outputFormat); err != nil {
+					if _, err := analyse.Analyse(inputPath, outputPath, outputFormat); err != nil {
 						log.Error(err, "Error while analysing data")
 						os.Exit(1)
 					}

--- a/pkg/shoot-telemetry/controller/output.go
+++ b/pkg/shoot-telemetry/controller/output.go
@@ -37,7 +37,7 @@ func (c *controller) generateOutput() error {
 		doc    = csv.NewWriter(outputFile)
 		record = []string{common.MeasurementsHeadCluster, common.MeasurementsHeadProvider, common.MeasurementsHeadSeed, common.MeasurementsHeadTimestamp, common.MeasurementsHeadStatusCode, common.MeasurementsHeadResponseTime}
 	)
-	logger.Log.V(3).Info("Write measurements to file")
+	logger.Log.V(5).Info("Write measurements to file")
 
 	outputFileStat, err := outputFile.Stat()
 	if err != nil {

--- a/pkg/shoot-telemetry/controller/target.go
+++ b/pkg/shoot-telemetry/controller/target.go
@@ -124,7 +124,7 @@ func (c *controller) observeTarget(t *target, stopCh <-chan struct{}) {
 	}, c.config.CheckInterval, false, stopCh)
 }
 
-// initTargets initiliazes the targets with all available shoots
+// initTargets initializes the targets with all available shoots
 func (c *controller) initTargets(k8sClient kubernetes.Interface) error {
 	shoots := &gardenv1alpha1.ShootList{}
 	if err := k8sClient.Client().List(context.TODO(), shoots); err != nil {

--- a/pkg/testrunner/result/output.go
+++ b/pkg/testrunner/result/output.go
@@ -127,12 +127,13 @@ func DetermineTestrunSummary(tr *tmv1beta1.Testrun, metadata *testrunner.Metadat
 	}
 
 	trSummary := testrunner.TestrunSummary{
-		Metadata:  metadata,
-		Type:      testrunner.SummaryTypeTestrun,
-		Phase:     status.Phase,
-		StartTime: status.StartTime,
-		Duration:  status.Duration,
-		TestsRun:  testsRun,
+		Metadata:      metadata,
+		Type:          testrunner.SummaryTypeTestrun,
+		Phase:         status.Phase,
+		StartTime:     status.StartTime,
+		Duration:      status.Duration,
+		TestsRun:      testsRun,
+		TelemetryData: metadata.TelemetryData,
 	}
 
 	return trSummary, summaries, nil

--- a/pkg/testrunner/result/types.go
+++ b/pkg/testrunner/result/types.go
@@ -15,6 +15,7 @@
 package result
 
 import (
+	"github.com/gardener/test-infra/pkg/shoot-telemetry/analyse"
 	telemetryCtrl "github.com/gardener/test-infra/pkg/testrunner/telemetry"
 	"github.com/go-logr/logr"
 )
@@ -36,7 +37,7 @@ type Config struct {
 	// Path to the error directory of concourse to put the notify.cfg in.
 	ConcourseOnErrorDir string
 
-	// EnableTelemetry enbales the measurement of shoot downtimes during execution
+	// EnableTelemetry enables the measurement of shoot downtimes during execution
 	EnableTelemetry bool
 
 	// ComponentDescriptorPath path to the component descriptor file
@@ -58,9 +59,11 @@ type Config struct {
 }
 
 type Collector struct {
-	log       logr.Logger
-	config    Config
-	telemetry *telemetryCtrl.Telemetry
+	log    logr.Logger
+	config Config
+
+	telemetry        *telemetryCtrl.Telemetry
+	telemetryResults map[string]*analyse.Figures
 }
 
 // notificationConfig is the configuration that is used by concourse to send notifications.

--- a/pkg/testrunner/template/template.go
+++ b/pkg/testrunner/template/template.go
@@ -76,6 +76,7 @@ func getInternalParametersFunc(parameters *Parameters) (func(string) *internalPa
 			FlavorConfigPath:    parameters.FlavorConfigPath,
 			ComponentDescriptor: componentDescriptor,
 			ChartPath:           chartPath,
+			Namespace:           parameters.Namespace,
 			GardenerKubeconfig:  gardenerKubeconfig,
 			GardenerVersion:     gardenerVersion,
 			Landscape:           parameters.Landscape,
@@ -87,7 +88,7 @@ func renderDefaultChart(renderer *templateRenderer, parameters *internalParamete
 	if parameters.ChartPath == "" {
 		return make(testrunner.RunList, 0), nil
 	}
-	return renderer.RenderChart(parameters, parameters.ChartPath, NewDefaultValueRenderer(parameters))
+	return renderer.Render(parameters, parameters.ChartPath, NewDefaultValueRenderer(parameters))
 }
 
 func renderChartWithShoot(log logr.Logger, renderer *templateRenderer, parameters *internalParameters, shootFlavors []*shootflavors.ExtendedFlavorInstance) (testrunner.RunList, error) {
@@ -103,7 +104,7 @@ func renderChartWithShoot(log logr.Logger, renderer *templateRenderer, parameter
 		}
 
 		valueRenderer := NewShootValueRenderer(log, flavor, parameters)
-		shootRuns, err := renderer.RenderChart(parameters, chartPath, valueRenderer)
+		shootRuns, err := renderer.Render(parameters, chartPath, valueRenderer)
 		if err != nil {
 			return nil, errors.Wrapf(err, "unable to render chart for flavor %v", flavor)
 		}

--- a/pkg/testrunner/template/types.go
+++ b/pkg/testrunner/template/types.go
@@ -40,6 +40,7 @@ type internalParameters struct {
 	FlavorConfigPath    string
 	ComponentDescriptor componentdescriptor.ComponentList
 	ChartPath           string
+	Namespace           string
 
 	GardenerKubeconfig []byte
 	GardenerVersion    string

--- a/pkg/testrunner/types.go
+++ b/pkg/testrunner/types.go
@@ -103,6 +103,10 @@ type Metadata struct {
 
 	// Represents how many retries the testrun had
 	Retries int `json:"retries,omitempty"`
+
+	// Contains the measured telemetry data
+	// Is only used for internal sharing.
+	TelemetryData *TelemetryData `json:"-"`
 }
 
 // TestrunMetadata represents the metadata of a testrun
@@ -129,12 +133,13 @@ type StepExportMetadata struct {
 
 // TestrunSummary is the result of the overall testrun.
 type TestrunSummary struct {
-	Metadata  *Metadata        `json:"tm,omitempty"`
-	Type      SummaryType      `json:"type,omitempty"`
-	Phase     argov1.NodePhase `json:"phase,omitempty"`
-	StartTime *metav1.Time     `json:"startTime,omitempty"`
-	Duration  int64            `json:"duration,omitempty"`
-	TestsRun  int              `json:"testsRun,omitempty"`
+	Metadata      *Metadata        `json:"tm,omitempty"`
+	Type          SummaryType      `json:"type,omitempty"`
+	Phase         argov1.NodePhase `json:"phase,omitempty"`
+	StartTime     *metav1.Time     `json:"startTime,omitempty"`
+	Duration      int64            `json:"duration,omitempty"`
+	TestsRun      int              `json:"testsRun,omitempty"`
+	TelemetryData *TelemetryData   `json:"telemetry,omitempty"`
 }
 
 // StepSummary is the result of a specific step.
@@ -169,4 +174,28 @@ type Dimension struct {
 	Cloudprovider     string `json:"cloudprovider,omitempty"`
 	KubernetesVersion string `json:"k8sVersion,omitempty"`
 	OperatingSystem   string `json:"operating_system,omitempty"`
+}
+
+// TelemetryData describes the measured telemetry data for the tested shoot
+type TelemetryData struct {
+	ResponseTime    *TelemetryResponseTimeDuration `json:"response_time,omitempty"`
+	DowntimePeriods *TelemetryDowntimePeriods      `json:"downtime,omitempty"`
+}
+
+// TelemetryResponseTimeDuration describes the response data of the telemetry measurement
+type TelemetryResponseTimeDuration struct {
+	Min    int   `json:"min"`
+	Max    int   `json:"max"`
+	Avg    int64 `json:"avg"`
+	Median int64 `json:"median"`
+	Std    int64 `json:"std"`
+}
+
+// TelemetryResponseTimeDuration describes the measured downtimes
+type TelemetryDowntimePeriods struct {
+	Min    int64 `json:"min"`
+	Max    int64 `json:"max"`
+	Avg    int64 `json:"avg"`
+	Median int64 `json:"median"`
+	Std    int64 `json:"std"`
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adjust the current integration of the telemetry controller to work with multiple shoot cluster in a single testrunner instance.

In order to work with multiple shoot cluster also our logic for the invocation of multiple testruns that creates shoots has to be adjusted.
Now every a new shoot name is calculated for every template. This is necessary as we need a unique shoot name to be created and we still need to know the name to scrape metrics for it.
(Currently a unique name is ensured by the template itself e.g it adds another value at the end of the shoot)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Integrate the telemetry controller into the testrunner
```
