### PR TITLE
Notify on retries

### DIFF
--- a/cmd/testrunner/cmd/collect/collect.go
+++ b/cmd/testrunner/cmd/collect/collect.go
@@ -98,7 +98,7 @@ var collectCmd = &cobra.Command{
 			Metadata: testrunner.MetadataFromTestrun(tr),
 		}
 
-		collector, err := result.New(logger.Log.WithName("collector"), collectConfig)
+		collector, err := result.New(logger.Log.WithName("collector"), collectConfig, tmKubeconfigPath)
 		if err != nil {
 			logger.Log.Error(err, "unable to initialize collector")
 			os.Exit(1)

--- a/cmd/testrunner/cmd/run_gardener/run.go
+++ b/cmd/testrunner/cmd/run_gardener/run.go
@@ -177,7 +177,7 @@ func init() {
 	runCmd.Flags().StringVar(&testrunNamePrefix, "testrun-prefix", "default-", "Testrun name prefix which is used to generate a unique testrun name.")
 	runCmd.Flags().StringVarP(&testrunnerConfig.Namespace, "namespace", "n", "default", "Namespace where the testrun should be deployed.")
 	runCmd.Flags().Var(cmdvalues.NewDurationValue(&testrunnerConfig.Timeout, time.Hour), "timeout", "Timout the testrunner to wait for the complete testrun to finish. Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'.")
-	runCmd.Flags().Var(cmdvalues.NewDurationValue(&testrunnerConfig.Interval, 20*time.Second), "interval", "Poll interval of the testrunner to poll for the testrun status. Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'.")
+	runCmd.Flags().String("interval", "20s", "[DEPRECTAED] Value has no effect on the testrunner")
 	runCmd.Flags().BoolVar(&failOnError, "fail-on-error", true, "Testrunners exits with 1 if one testruns failed.")
 
 	runCmd.Flags().StringVar(&collectConfig.OutputDir, "output-dir-path", "./testout", "The filepath where the summary should be written to.")

--- a/cmd/testrunner/cmd/run_gardener/run.go
+++ b/cmd/testrunner/cmd/run_gardener/run.go
@@ -141,7 +141,7 @@ var runCmd = &cobra.Command{
 
 		testrunName := fmt.Sprintf("%s-", testrunNamePrefix)
 
-		collector, err := result.New(logger.Log.WithName("collector"), collectConfig)
+		collector, err := result.New(logger.Log.WithName("collector"), collectConfig, tmKubeconfigPath)
 		if err != nil {
 			logger.Log.Error(err, "unable to initialize collector")
 			os.Exit(1)

--- a/cmd/testrunner/cmd/run_template/run_template.go
+++ b/cmd/testrunner/cmd/run_template/run_template.go
@@ -104,7 +104,7 @@ var runCmd = &cobra.Command{
 			os.Exit(0)
 		}
 
-		collector, err := result.New(logger.Log.WithName("collector"), collectConfig)
+		collector, err := result.New(logger.Log.WithName("collector"), collectConfig, tmKubeconfigPath)
 		if err != nil {
 			logger.Log.Error(err, "unable to initialize collector")
 			os.Exit(1)
@@ -114,7 +114,7 @@ var runCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		testrunner.ExecuteTestruns(logger.Log.WithName("Execute"), &testrunnerConfig, runs, testrunNamePrefix)
+		testrunner.ExecuteTestruns(logger.Log.WithName("Execute"), &testrunnerConfig, runs, testrunNamePrefix, collector.RunExecCh)
 
 		failed, err := collector.Collect(logger.Log.WithName("Collect"), testrunnerConfig.Watch.Client(), testrunnerConfig.Namespace, runs)
 		if err != nil {

--- a/cmd/testrunner/cmd/run_testrun/run_testrun.go
+++ b/cmd/testrunner/cmd/run_testrun/run_testrun.go
@@ -31,7 +31,6 @@ var (
 	tmKubeconfigPath     string
 	namespace            string
 	timeout              int64
-	interval             int64
 	testrunFlakeAttempts int
 
 	testrunPath       string
@@ -64,7 +63,6 @@ var runTestrunCmd = &cobra.Command{
 			Watch:         w,
 			Namespace:     namespace,
 			Timeout:       time.Duration(timeout) * time.Second,
-			Interval:      time.Duration(interval) * time.Second,
 			FlakeAttempts: testrunFlakeAttempts,
 		}
 
@@ -107,7 +105,7 @@ func init() {
 	runTestrunCmd.Flags().StringVarP(&namespace, "namespace", "n", "default", "Namespace where the testrun should be deployed.")
 
 	runTestrunCmd.Flags().Int64Var(&timeout, "timeout", 3600, "Timout in seconds of the testrunner to wait for the complete testrun to finish.")
-	runTestrunCmd.Flags().Int64Var(&interval, "interval", 20, "Poll interval in seconds of the testrunner to poll for the testrun status.")
+	runTestrunCmd.Flags().Int64("interval", 20, "[DEPRECTAED] Value has no effect")
 	runTestrunCmd.Flags().IntVar(&testrunFlakeAttempts, "testrun-flake-attempts", 0, "Max number of testruns until testrun is successful")
 
 	// parameter flags

--- a/pkg/testrunner/result/types.go
+++ b/pkg/testrunner/result/types.go
@@ -16,6 +16,7 @@ package result
 
 import (
 	"github.com/gardener/test-infra/pkg/shoot-telemetry/analyse"
+	"github.com/gardener/test-infra/pkg/testrunner"
 	telemetryCtrl "github.com/gardener/test-infra/pkg/testrunner/telemetry"
 	"github.com/go-logr/logr"
 )
@@ -59,11 +60,15 @@ type Config struct {
 }
 
 type Collector struct {
-	log    logr.Logger
-	config Config
+	log            logr.Logger
+	config         Config
+	kubeconfigPath string
 
 	telemetry        *telemetryCtrl.Telemetry
 	telemetryResults map[string]*analyse.Figures
+
+	// RunExecCh is called when a new testrun is executed
+	RunExecCh chan *testrunner.Run
 }
 
 // notificationConfig is the configuration that is used by concourse to send notifications.

--- a/pkg/testrunner/testrunner.go
+++ b/pkg/testrunner/testrunner.go
@@ -34,10 +34,10 @@ import (
 )
 
 // ExecuteTestruns deploys it to a testmachinery cluster and waits for the testruns results
-func ExecuteTestruns(log logr.Logger, config *Config, runs RunList, testrunNamePrefix string) {
+func ExecuteTestruns(log logr.Logger, config *Config, runs RunList, testrunNamePrefix string, notify ...chan *Run) {
 	log.V(3).Info(fmt.Sprintf("Config: %+v", util.PrettyPrintStruct(config)))
 
-	runs.Run(log.WithValues("namespace", config.Namespace), config, testrunNamePrefix)
+	runs.Run(log.WithValues("namespace", config.Namespace), config, testrunNamePrefix, notify...)
 }
 
 // StartWatchController starts a new controller that watches testruns

--- a/pkg/testrunner/types.go
+++ b/pkg/testrunner/types.go
@@ -34,13 +34,13 @@ type Config struct {
 	// Max wait time for a testrun to finish.
 	Timeout time.Duration
 
-	// Poll interval to check the testrun status
-	// DEPRECATED
-	Interval time.Duration
-
 	// Number of testrun retries after a failed run
 	FlakeAttempts int
 }
+
+// RunEventFunc is called everytime a new testrun is triggered
+// Also notifies for retries
+type RunEventFunc func(run *Run)
 
 // Run describes a testrun that is executed by the testrunner.
 // It consists of a testrun and its metadata

--- a/pkg/testrunner/types.go
+++ b/pkg/testrunner/types.go
@@ -38,7 +38,7 @@ type Config struct {
 	FlakeAttempts int
 }
 
-// RunEventFunc is called everytime a new testrun is triggered
+// RunEventFunc is called every time a new testrun is triggered
 // Also notifies for retries
 type RunEventFunc func(run *Run)
 

--- a/test/testrunner/run/testrunner_run_test.go
+++ b/test/testrunner/run/testrunner_run_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/gardener/test-infra/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"time"
 )
 
 var _ = Describe("Testrunner execution tests", func() {
@@ -34,7 +33,6 @@ var _ = Describe("Testrunner execution tests", func() {
 		testrunConfig = testrunner.Config{
 			Namespace: operation.TestNamespace(),
 			Timeout:   InitializationTimeout,
-			Interval:  5 * time.Second,
 		}
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds event cahnnels for execution runs.
Now it is possible to get notified if a new run is executed which enables the telemetry controller to alos act on shoots created during runtime.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Add events for execution of runs
```
