### PR TITLE
Add untrusted steps

### DIFF
--- a/docs/testmachinery/GetStarted.md
+++ b/docs/testmachinery/GetStarted.md
@@ -254,6 +254,10 @@ spec:
         label: default
         config: ...
         location: ...
+        # Specify if if tests are running trusted content.
+        # If the test is not trusted only the minimal configuration is mounted into test.
+        # Minimal configuration does currently only content the shoot kubeconfig.
+        untrusted: false 
       dependsOn: [ create-shoot ]
       useGlobalArtifacts: true # optional, default get from last "serial" step
       artifactsFrom: create-shoot # optional, default get from last "serial" step

--- a/pkg/apis/testmachinery/v1beta1/types.go
+++ b/pkg/apis/testmachinery/v1beta1/types.go
@@ -269,6 +269,10 @@ type StepDefinition struct {
 	// If this is empty the default location set is used
 	// +optional
 	LocationSet *string `json:"locationSet,omitempty"`
+
+	// Untrusted describes whether the step runs a trusted workload.
+	// +optional
+	Untrusted bool `json:"untrusted,omitempty"`
 }
 
 type Pause struct {

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -299,6 +299,13 @@ func schema_pkg_apis_testmachinery_v1beta1_StepDefinition(ref common.ReferenceCa
 							Format:      "",
 						},
 					},
+					"untrusted": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Untrusted describes whether the step runs a trusted workload.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},
@@ -978,7 +985,7 @@ func schema_pkg_apis_testmachinery_v1beta1_TestrunStatus(ref common.ReferenceCal
 					},
 					"ingested": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Ingested states whether the result of a testrun is already ingested into a persistant storage (db).",
+							Description: "Ingested states whether the result of a testrun is already ingested into a persistent storage (db).",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},

--- a/pkg/testmachinery/config.go
+++ b/pkg/testmachinery/config.go
@@ -76,6 +76,15 @@ const (
 
 	// Name of the argo suspend template name
 	PauseTemplateName = "suspend"
+
+	// ArtifactKubeconfigs is the name of the kubeconfigs artifact
+	ArtifactKubeconfigs = "kubeconfigs"
+
+	// ArtifactUntrustedKubeconfigs is the name of the kubeconfigs artifacts for untrusted steps
+	ArtifactUntrustedKubeconfigs = "untrustedKubeconfigs"
+
+	// ArtifactSharedFolder is the name of the shared folder artifact
+	ArtifactSharedFolder = "sharedFolder"
 )
 
 var (

--- a/pkg/testmachinery/testdefinition/testdefinition.go
+++ b/pkg/testmachinery/testdefinition/testdefinition.go
@@ -122,8 +122,6 @@ func New(def *tmv1beta1.TestDefinition, loc Location, fileName string) (*TestDef
 		outputArtifacts: make(ArtifactSet, 0),
 		config:          config.NewSet(config.New(def.Spec.Config, config.LevelTestDefinition)...),
 	}
-
-	td.AddInputArtifacts(GetStdInputArtifacts()...)
 	td.AddOutputArtifacts(outputArtifacts...)
 
 	return td, nil

--- a/pkg/testmachinery/testdefinition/types.go
+++ b/pkg/testmachinery/testdefinition/types.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gardener/test-infra/pkg/testmachinery"
 	"github.com/gardener/test-infra/pkg/testmachinery/config"
 	apiv1 "k8s.io/api/core/v1"
+	"path"
 )
 
 // TestDefinition represents a TestDefinition which was fetched from locations.
@@ -37,17 +38,29 @@ type Location interface {
 }
 
 // GetStdInputArtifacts returns the default input artifacts of testdefionitions.
-// Thes artifacts include kubeconfig and shared folder inputs
+// The artifacts include kubeconfigs and shared folder inputs
 func GetStdInputArtifacts() []argov1.Artifact {
 	return []argov1.Artifact{
 		{
-			Name:     "kubeconfigs",
+			Name:     testmachinery.ArtifactKubeconfigs,
 			Path:     testmachinery.TM_KUBECONFIG_PATH,
 			Optional: true,
 		},
 		{
-			Name:     "sharedFolder",
+			Name:     testmachinery.ArtifactSharedFolder,
 			Path:     testmachinery.TM_SHARED_PATH,
+			Optional: true,
+		},
+	}
+}
+
+// GetUntrustedInputArtifacts returns the untrusted input artifacts of testdefionitions.
+// The artifacts only include minimal configuration
+func GetUntrustedInputArtifacts() []argov1.Artifact {
+	return []argov1.Artifact{
+		{
+			Name:     testmachinery.ArtifactUntrustedKubeconfigs,
+			Path:     testmachinery.TM_KUBECONFIG_PATH,
 			Optional: true,
 		},
 	}
@@ -57,12 +70,17 @@ func GetStdInputArtifacts() []argov1.Artifact {
 // These artifacts include kubeconfigs and the shared folder.
 func GetStdOutputArtifacts(global bool) []argov1.Artifact {
 	kubeconfigArtifact := argov1.Artifact{
-		Name:     "kubeconfigs",
+		Name:     testmachinery.ArtifactKubeconfigs,
 		Path:     testmachinery.TM_KUBECONFIG_PATH,
 		Optional: true,
 	}
+	untrustedKubeconfigArtifact := argov1.Artifact{
+		Name:     testmachinery.ArtifactUntrustedKubeconfigs,
+		Path:     path.Join(testmachinery.TM_KUBECONFIG_PATH, "shoot.config"),
+		Optional: true,
+	}
 	sharedFolderArtifact := argov1.Artifact{
-		Name:     "sharedFolder",
+		Name:     testmachinery.ArtifactSharedFolder,
 		Path:     testmachinery.TM_SHARED_PATH,
 		Optional: true,
 	}
@@ -70,9 +88,12 @@ func GetStdOutputArtifacts(global bool) []argov1.Artifact {
 	if global {
 		kubeconfigArtifact.GlobalName = kubeconfigArtifact.Name
 		kubeconfigArtifact.Name = fmt.Sprintf("%s-global", kubeconfigArtifact.Name)
+		untrustedKubeconfigArtifact.GlobalName = untrustedKubeconfigArtifact.Name
+		untrustedKubeconfigArtifact.Name = fmt.Sprintf("%s-global", untrustedKubeconfigArtifact.Name)
+
 		sharedFolderArtifact.GlobalName = sharedFolderArtifact.Name
 		sharedFolderArtifact.Name = fmt.Sprintf("%s-global", sharedFolderArtifact.Name)
 	}
 
-	return []argov1.Artifact{kubeconfigArtifact, sharedFolderArtifact}
+	return []argov1.Artifact{kubeconfigArtifact, untrustedKubeconfigArtifact, sharedFolderArtifact}
 }

--- a/pkg/testmachinery/testflow/flow_operations.go
+++ b/pkg/testmachinery/testflow/flow_operations.go
@@ -143,6 +143,11 @@ func ApplyOutputScope(steps map[string]*Step) error {
 						return true
 					}
 					return !node.Step().Definition.ContinueOnError
+				}, func(node *node.Node) bool {
+					if node.Step() == nil {
+						return true
+					}
+					return !node.Step().Definition.Untrusted
 				})
 			}
 			if outputSourceNode != nil {

--- a/test/.test-defs/ItCheckFileNotExist.yaml
+++ b/test/.test-defs/ItCheckFileNotExist.yaml
@@ -1,0 +1,23 @@
+# Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: TestDefinition
+metadata:
+  name: check-file-not-exist-testdef
+spec:
+  owner: dummy@example.com
+  description: Tests mounting of file configuration.
+
+  command: [bash, -c]
+  args: ["./test/.test-defs/scripts/check-file-not"]

--- a/test/.test-defs/scripts/check-file-not
+++ b/test/.test-defs/scripts/check-file-not
@@ -1,0 +1,20 @@
+#! /bin/bash
+#
+# Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [[ -f $FILE ]]; then
+    echo "File $FILE exists"
+    exit 1
+fi


### PR DESCRIPTION
**What this PR does / why we need it**:
Add support to mark steps untrusted by enabling the flag `untrusted: true`.
If a step is untrusted only the shoot kubeconfig is passed to it. 
All other artifacts are not mounted into the test containers

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Add support to mark steps as untrusted. If a step is untrusted the Test Machinery only mounts the minimal set of artifacts to the test.
```
