### PR TITLE
add additional fields to tm-alerting elasticsearch index

### DIFF
--- a/pkg/alert/alerttypes.go
+++ b/pkg/alert/alerttypes.go
@@ -2,7 +2,7 @@ package alert
 
 import (
 	"encoding/json"
-	"golang.org/x/tools/go/ssa/interp/testdata/src/fmt"
+	"fmt"
 )
 
 // TestContextAggregation elasticsearch distinct names aggregation structure
@@ -44,8 +44,8 @@ type ESTestmachineryDoc struct {
 			K8sVersion      string `json:"k8s_version"`
 			OperatingSystem string `json:"operating_system"`
 			Landscape       string `json:"landscape"`
-			Testrun            struct {
-				ID   string `json:"id"`
+			Testrun         struct {
+				ID string `json:"id"`
 			} `json:"tr"`
 		} `json:"tm"`
 	} `json:"_source"`

--- a/pkg/alert/alerttypes.go
+++ b/pkg/alert/alerttypes.go
@@ -1,5 +1,10 @@
 package alert
 
+import (
+	"encoding/json"
+	"golang.org/x/tools/go/ssa/interp/testdata/src/fmt"
+)
+
 // TestContextAggregation elasticsearch distinct names aggregation structure
 type TestContextAggregation struct {
 	Aggs struct {
@@ -39,6 +44,9 @@ type ESTestmachineryDoc struct {
 			K8sVersion      string `json:"k8s_version"`
 			OperatingSystem string `json:"operating_system"`
 			Landscape       string `json:"landscape"`
+			Testrun            struct {
+				ID   string `json:"id"`
+			} `json:"tr"`
 		} `json:"tm"`
 	} `json:"_source"`
 }
@@ -47,9 +55,32 @@ type ESTestmachineryDoc struct {
 type AlertDocs struct {
 	Hits struct {
 		AlertItems []struct {
-			Source struct {
-				TestName string `json:"testContext"`
-			} `json:"_source"`
+			Source TestDetails `json:"_source"`
 		} `json:"hits"`
 	} `json:"hits"`
+}
+
+//TestDetails describes a test which is used for alert message
+type TestDetails struct {
+	Name                string  `json:"name"`                         //Name test name
+	Context             string  `json:"testContext"`                  //Context is the concatenation of name and several test dimensions
+	FailedContinuously  bool    `json:"failedContinuously,omitempty"` //FailedContinuously true if n recent test runs were failing in a row
+	LastFailedTimestamp string  `json:"lastTimeFailed"`               //LastFailedTimestamp timestamp of last failed test execution
+	SuccessRate         float64 `json:"successRate"`                  //SuccessRate of recent n days
+	FiledAlertDataTime  string  `json:"datetime"`                     //FiledAlertDataTime is the timestamp when the alert has been filed in slack
+	Successful          bool    `json:"-"`                            //Successful is true if success rate doesn't go below threshold and isn't failed continuously
+	Cloudprovider       string  `json:"cloudprovider,omitempty"`
+	OperatingSystem     string  `json:"operatingSystem,omitempty"`
+	Landscape           string  `json:"landscape"`
+	K8sVersion          string  `json:"k8sVersion,omitempty"`
+	TestrunID           string  `json:"testrunID"`
+}
+
+//ElasticsearchBulkString creates an elastic search bulk string for ingestion
+func (test TestDetails) ElasticsearchBulkString() (string, error) {
+	testDetailsMarshaled, err := json.Marshal(test)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(`{ "index":{} }`+"\n%s\n", string(testDetailsMarshaled)), nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
add additional fields to tm-alerting elasticsearch index

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```
add additional fields to tm-alerting elasticsearch index
```
