### PR TITLE
Fix input path of untrusted steps

### DIFF
--- a/pkg/testmachinery/testdefinition/types.go
+++ b/pkg/testmachinery/testdefinition/types.go
@@ -60,7 +60,7 @@ func GetUntrustedInputArtifacts() []argov1.Artifact {
 	return []argov1.Artifact{
 		{
 			Name:     testmachinery.ArtifactUntrustedKubeconfigs,
-			Path:     testmachinery.TM_KUBECONFIG_PATH,
+			Path:     path.Join(testmachinery.TM_KUBECONFIG_PATH, "shoot.config"),
 			Optional: true,
 		},
 	}

--- a/pkg/testmachinery/testflow/flow_operations_test.go
+++ b/pkg/testmachinery/testflow/flow_operations_test.go
@@ -368,6 +368,7 @@ var _ = Describe("flow operations", func() {
 			Expect(C.GetInputSource()).To(Equal(A))
 			Expect(D.GetInputSource()).To(Equal(A))
 			Expect(E.GetInputSource()).To(Equal(A))
+			Expect(D.HasOutput()).To(BeFalse())
 		})
 
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the mount path for the input artifact.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
The input path for the shoot kubeconfig in untrusted steps has been fixed
```
