### PR TITLE
Fix panic when no metadata is defined

### DIFF
--- a/cmd/testrunner/cmd/run_gardener/run.go
+++ b/cmd/testrunner/cmd/run_gardener/run.go
@@ -120,7 +120,7 @@ var runCmd = &cobra.Command{
 		runs := testrunner.RunList{
 			&testrunner.Run{
 				Testrun:  tr,
-				Metadata: nil,
+				Metadata: &testrunner.Metadata{},
 				Error:    nil,
 			},
 		}

--- a/pkg/testrunner/list.go
+++ b/pkg/testrunner/list.go
@@ -84,7 +84,9 @@ func (rl RunList) Run(log logr.Logger, config *Config, testrunNamePrefix string,
 				rl[i].SetRunID(runID)
 				triggerRunEvent(notify, rl[i])
 				rl[i].Exec(log, config, testrunNamePrefix)
-				rl[i].Metadata.Retries = attempt
+				if rl[i].Metadata != nil {
+					rl[i].Metadata.Retries = attempt
+				}
 
 				if rl[i].Error == nil && rl[i].Testrun.Status.Phase == tmv1beta1.PhaseStatusSuccess {
 					// testrun was successful, break retry loop

--- a/pkg/testrunner/run.go
+++ b/pkg/testrunner/run.go
@@ -30,7 +30,9 @@ func (r *Run) SetRunID(id string) {
 		r.Testrun.Labels = make(map[string]string, 1)
 	}
 	r.Testrun.Labels[common.LabelTestrunRunID] = id
-	r.Metadata.Testrun.RunId = id
+	if r.Metadata != nil {
+		r.Metadata.Testrun.RunId = id
+	}
 }
 
 func (r *Run) Exec(log logr.Logger, config *Config, prefix string) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a panic when no metadata object is defined for a testrun

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Fix panic when no metadata is defined for a testrun
```
