### PR TITLE
Add support for serial testrun execution

### DIFF
--- a/cmd/testrunner/cmd/run_gardener/run.go
+++ b/cmd/testrunner/cmd/run_gardener/run.go
@@ -147,7 +147,10 @@ var runCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		testrunner.ExecuteTestruns(logger.Log.WithName("Execute"), &testrunnerConfig, runs, testrunName)
+		if err = testrunner.ExecuteTestruns(logger.Log.WithName("Execute"), &testrunnerConfig, runs, testrunName); err != nil {
+			logger.Log.Error(err, "unable to run testruns")
+			os.Exit(1)
+		}
 		failed, err := collector.Collect(logger.Log.WithName("Collect"), testrunnerConfig.Watch.Client(), testrunnerConfig.Namespace, runs)
 		if err != nil {
 			logger.Log.Error(err, "unable to collect results")

--- a/cmd/testrunner/cmd/run_template/run_template.go
+++ b/cmd/testrunner/cmd/run_template/run_template.go
@@ -114,7 +114,10 @@ var runCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		testrunner.ExecuteTestruns(logger.Log.WithName("Execute"), &testrunnerConfig, runs, testrunNamePrefix, collector.RunExecCh)
+		if err := testrunner.ExecuteTestruns(logger.Log.WithName("Execute"), &testrunnerConfig, runs, testrunNamePrefix, collector.RunExecCh); err != nil {
+			logger.Log.Error(err, "unable to run testruns")
+			os.Exit(1)
+		}
 
 		failed, err := collector.Collect(logger.Log.WithName("Collect"), testrunnerConfig.Watch.Client(), testrunnerConfig.Namespace, runs)
 		if err != nil {
@@ -156,6 +159,7 @@ func init() {
 	runCmd.Flags().IntVar(&testrunFlakeAttempts, "testrun-flake-attempts", 0, "Max number of testruns until testrun is successful")
 	runCmd.Flags().BoolVar(&failOnError, "fail-on-error", true, "Testrunners exits with 1 if one testruns failed.")
 	runCmd.Flags().BoolVar(&collectConfig.EnableTelemetry, "enable-telemetry", false, "Enables the measurements of metrics during execution")
+	runCmd.Flags().BoolVar(&testrunnerConfig.Serial, "serial", false, "executes all testruns of a bucket only after the previous bucket has finished")
 	runCmd.Flags().IntVar(&testrunnerConfig.BackoffBucket, "backoff-bucket", 0, "Number of parallel created testruns per backoff period")
 	runCmd.Flags().DurationVar(&testrunnerConfig.BackoffPeriod, "backoff-period", 0, "Time to wait between the creation of testrun buckets")
 

--- a/cmd/testrunner/cmd/run_testrun/run_testrun.go
+++ b/cmd/testrunner/cmd/run_testrun/run_testrun.go
@@ -32,6 +32,7 @@ var (
 	namespace            string
 	timeout              int64
 	testrunFlakeAttempts int
+	serial               bool
 	backoffBucket        int
 	backoffPeriod        time.Duration
 
@@ -66,8 +67,11 @@ var runTestrunCmd = &cobra.Command{
 			Namespace:     namespace,
 			Timeout:       time.Duration(timeout) * time.Second,
 			FlakeAttempts: testrunFlakeAttempts,
-			BackoffBucket: backoffBucket,
-			BackoffPeriod: backoffPeriod,
+			ExecutorConfig: testrunner.ExecutorConfig{
+				Serial:        false,
+				BackoffBucket: backoffBucket,
+				BackoffPeriod: backoffPeriod,
+			},
 		}
 
 		tr, err := util.ParseTestrunFromFile(testrunPath)
@@ -111,6 +115,7 @@ func init() {
 	runTestrunCmd.Flags().Int64Var(&timeout, "timeout", 3600, "Timout in seconds of the testrunner to wait for the complete testrun to finish.")
 	runTestrunCmd.Flags().Int64("interval", 20, "[DEPRECATED] Value has no effect")
 	runTestrunCmd.Flags().IntVar(&testrunFlakeAttempts, "testrun-flake-attempts", 0, "Max number of testruns until testrun is successful")
+	runTestrunCmd.Flags().BoolVar(&serial, "serial", false, "executes all testruns of a bucket only after the previous bucket has finished")
 	runTestrunCmd.Flags().IntVar(&backoffBucket, "backoff-bucket", 0, "Number of parallel created testruns per backoff period")
 	runTestrunCmd.Flags().DurationVar(&backoffPeriod, "backoff-period", 0, "Time to wait between the creation of testrun buckets")
 

--- a/pkg/testrunner/execution.go
+++ b/pkg/testrunner/execution.go
@@ -1,0 +1,139 @@
+// Copyright 2020 Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testrunner
+
+import (
+	"container/list"
+	"fmt"
+	"github.com/gardener/test-infra/pkg/util"
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	"sync"
+	"time"
+)
+
+// ExecutorConfig configures the execution order of a execution
+type ExecutorConfig struct {
+	// Serial describes of the items should be executed in serial
+	Serial bool
+
+	// BackoffPeriod is the duration to wait between the creation of a bucket of testruns
+	// 0 means that all functions are started in parallel
+	BackoffPeriod time.Duration
+
+	// BackoffBucket is the number of parallel created testruns per backoff period
+	// 0 disables the backoff
+	BackoffBucket int
+}
+
+// Executor runs a set of functions in a preconfigured order
+type Executor interface {
+	AddItem(func())
+	Run()
+}
+
+type executor struct {
+	mut    sync.Mutex
+	log    logr.Logger
+	config ExecutorConfig
+	items  *list.List
+}
+
+// NewExecutor creates a new function executor
+func NewExecutor(log logr.Logger, config ExecutorConfig) (Executor, error) {
+	if config.BackoffBucket < 0 {
+		return nil, errors.New("a backoff bucket cannot be less than 0")
+	}
+	if config.BackoffPeriod < 0 {
+		return nil, errors.New("a backoff period cannot be less than 0")
+	}
+	return &executor{
+		mut:    sync.Mutex{},
+		log:    log.WithName("executor"),
+		config: config,
+		items:  list.New(),
+	}, nil
+}
+
+// pop returns the next element in the queue (first element of the list)
+// and removes the element from the list
+func (e *executor) pop() (func(), bool) {
+	e.mut.Lock()
+	defer e.mut.Unlock()
+	elem := e.items.Front()
+	e.items.Remove(elem)
+	f, ok := elem.Value.(func())
+	return f, ok
+}
+
+// len returns the thread safe length of the current queue
+func (e *executor) len() int {
+	e.mut.Lock()
+	defer e.mut.Unlock()
+	return e.items.Len()
+}
+
+// AddItem adds a item to the execution queue
+func (e *executor) AddItem(f func()) {
+	e.mut.Lock()
+	defer e.mut.Unlock()
+	e.items.PushBack(f)
+	return
+}
+
+// Run executes all added items in the configured order
+func (e *executor) Run() {
+	var wg sync.WaitGroup
+
+	var i = 0
+	for e.len() != 0 {
+		wg.Add(1)
+
+		f, ok := e.pop()
+		if !ok {
+			e.log.V(3).Info("unable to cast queue element to func")
+			continue
+		}
+
+		go func(i int, f func()) {
+			defer wg.Done()
+
+			// wait initial backoff before deploying the testrun
+			if e.config.BackoffBucket > 0 {
+				d := time.Duration(1)
+				if !e.config.Serial {
+					d = time.Duration(i / e.config.BackoffBucket)
+				}
+				time.Sleep(e.config.BackoffPeriod * d)
+			}
+
+			e.log.V(10).Info(fmt.Sprintf("running execution %d", i))
+			f()
+		}(i, f)
+
+		// wait for the current run to finish if
+		// - the runs should be executed in serial and item is the last of the current
+		// - or the function is the last element of the queue
+		if e.config.Serial && util.IsLastElementOfBucket(i, e.config.BackoffBucket) {
+			wg.Wait()
+		}
+		if e.len() == 0 {
+			wg.Wait()
+		}
+		i++
+	}
+	// not needed but to be sure that all goroutines are finished
+	wg.Wait()
+}

--- a/pkg/testrunner/execution_test.go
+++ b/pkg/testrunner/execution_test.go
@@ -1,0 +1,244 @@
+// Copyright 2020 Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testrunner_test
+
+import (
+	"github.com/gardener/test-infra/pkg/testrunner"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"time"
+)
+
+var _ = Describe("Executor tests", func() {
+
+	Context("basic", func() {
+		It("should run a set of functions in serial without backoff", func() {
+			executions := [3]*execution{}
+			executor, err := testrunner.NewExecutor(log.NullLogger{}, testrunner.ExecutorConfig{
+				Serial: true,
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			for i := 0; i < 3; i++ {
+				e := newExecution(i)
+				executions[i] = e
+				f := func() {
+					e.start = time.Now()
+					time.Sleep(1 * time.Second)
+				}
+				executor.AddItem(f)
+			}
+
+			executor.Run()
+
+			for i := 1; i < 3; i++ {
+				e := executions[i]
+				before := executions[i-1]
+				Expect(e.start.After(before.start)).To(BeTrue())
+
+				b := e.start.Sub(before.start)
+				Expect(b.Seconds()).To(BeNumerically("~", 1, 0.01))
+			}
+		})
+
+		It("should run all functions in parallel", func() {
+			executions := [3]*execution{}
+			executor, err := testrunner.NewExecutor(log.NullLogger{}, testrunner.ExecutorConfig{})
+			Expect(err).ToNot(HaveOccurred())
+
+			for i := 0; i < 3; i++ {
+				e := newExecution(i)
+				executions[i] = e
+				f := func() {
+					e.start = time.Now()
+					time.Sleep(1 * time.Second)
+				}
+				executor.AddItem(f)
+			}
+
+			executor.Run()
+
+			for i := 1; i < 3; i++ {
+				e := executions[i]
+				before := executions[i-1]
+
+				b := e.start.Sub(before.start)
+				Expect(b.Seconds()).To(BeNumerically("~", 0, 0.01))
+			}
+		})
+
+		It("should run 3 functions in serial with a backoff", func() {
+			executions := [3]*execution{}
+			executor, err := testrunner.NewExecutor(log.NullLogger{}, testrunner.ExecutorConfig{
+				Serial:        true,
+				BackoffBucket: 1,
+				BackoffPeriod: 2 * time.Second,
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			for i := 0; i < 3; i++ {
+				e := newExecution(i)
+				executions[i] = e
+				f := func() {
+					e.start = time.Now()
+				}
+				executor.AddItem(f)
+			}
+
+			executor.Run()
+			for i := 1; i < 3; i++ {
+				e := executions[i]
+				before := executions[i-1]
+				Expect(e.start.After(before.start)).To(BeTrue())
+
+				b := e.start.Sub(before.start)
+				Expect(b.Seconds()).To(BeNumerically("~", 2, 0.01))
+			}
+		})
+
+		It("should run 6 functions in parallel with a backoff in a bucket of 2", func() {
+			executions := [6]*execution{}
+			executor, err := testrunner.NewExecutor(log.NullLogger{}, testrunner.ExecutorConfig{
+				Serial:        false,
+				BackoffBucket: 2,
+				BackoffPeriod: 2 * time.Second,
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			for i := 0; i < 6; i++ {
+				e := newExecution(i)
+				executions[i] = e
+				f := func() {
+					e.start = time.Now()
+					time.Sleep(1 * time.Second)
+				}
+				executor.AddItem(f)
+			}
+
+			executor.Run()
+
+			expectExecutionsToBe(executions[0], executions[1], 0)
+			expectExecutionsToBe(executions[2], executions[3], 0)
+			expectExecutionsToBe(executions[4], executions[5], 0)
+
+			expectExecutionsToBe(executions[2], executions[0], 2)
+			expectExecutionsToBe(executions[4], executions[2], 2)
+		})
+
+		It("should run 6 functions in serial with a backoff in a bucket of 2", func() {
+			executions := [6]*execution{}
+			executor, err := testrunner.NewExecutor(log.NullLogger{}, testrunner.ExecutorConfig{
+				Serial:        true,
+				BackoffBucket: 2,
+				BackoffPeriod: 2 * time.Second,
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			for i := 0; i < 6; i++ {
+				e := newExecution(i)
+				executions[i] = e
+				f := func() {
+					e.start = time.Now()
+					time.Sleep(1 * time.Second)
+				}
+				executor.AddItem(f)
+			}
+
+			executor.Run()
+
+			expectExecutionsToBe(executions[0], executions[1], 0)
+			expectExecutionsToBe(executions[2], executions[3], 0)
+			expectExecutionsToBe(executions[4], executions[5], 0)
+
+			expectExecutionsToBe(executions[2], executions[0], 3)
+			expectExecutionsToBe(executions[4], executions[2], 3)
+		})
+	})
+
+	It("should add another test during execution", func() {
+		executions := [3]*execution{}
+		executor, err := testrunner.NewExecutor(log.NullLogger{}, testrunner.ExecutorConfig{
+			Serial: true,
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		addExecution := newExecution(4)
+
+		for i := 0; i < 3; i++ {
+			e := newExecution(i)
+			executions[i] = e
+			f := func() {
+				e.start = time.Now()
+				time.Sleep(1 * time.Second)
+				if e.value == 2 {
+					executor.AddItem(func() {
+						addExecution.start = time.Now()
+					})
+				}
+			}
+			executor.AddItem(f)
+		}
+
+		executor.Run()
+
+		Expect(addExecution.start.IsZero()).To(BeFalse())
+		expectExecutionsToBe(addExecution, executions[2], 1)
+
+	})
+
+	It("should add another test during execution in parallel steps", func() {
+		executions := [3]*execution{}
+		executor, err := testrunner.NewExecutor(log.NullLogger{}, testrunner.ExecutorConfig{})
+		Expect(err).ToNot(HaveOccurred())
+
+		addExecution := newExecution(4)
+
+		for i := 0; i < 3; i++ {
+			e := newExecution(i)
+			executions[i] = e
+			f := func() {
+				e.start = time.Now()
+				time.Sleep(1 * time.Second)
+				if e.value == 2 {
+					executor.AddItem(func() {
+						addExecution.start = time.Now()
+					})
+				}
+			}
+			executor.AddItem(f)
+		}
+
+		executor.Run()
+
+		Expect(addExecution.start.IsZero()).To(BeFalse())
+		expectExecutionsToBe(addExecution, executions[2], 1)
+	})
+
+})
+
+func expectExecutionsToBe(e1, e2 *execution, expDurationSeconds int) {
+	d := e1.start.Sub(e2.start)
+	ExpectWithOffset(1, d.Seconds()).To(BeNumerically("~", expDurationSeconds, 0.01), "duration is %fs but expected %ds", d.Seconds(), expDurationSeconds)
+}
+
+func newExecution(i int) *execution {
+	return &execution{value: i}
+}
+
+type execution struct {
+	start time.Time
+	value int
+}

--- a/pkg/testrunner/tesrunner_suite_test.go
+++ b/pkg/testrunner/tesrunner_suite_test.go
@@ -1,0 +1,26 @@
+// Copyright 2020 Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testrunner_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"testing"
+)
+
+func TestTestrunnerTemplate(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Testrunner Template Test Suite")
+}

--- a/pkg/testrunner/testrunner.go
+++ b/pkg/testrunner/testrunner.go
@@ -34,10 +34,10 @@ import (
 )
 
 // ExecuteTestruns deploys it to a testmachinery cluster and waits for the testruns results
-func ExecuteTestruns(log logr.Logger, config *Config, runs RunList, testrunNamePrefix string, notify ...chan *Run) {
+func ExecuteTestruns(log logr.Logger, config *Config, runs RunList, testrunNamePrefix string, notify ...chan *Run) error {
 	log.V(3).Info(fmt.Sprintf("Config: %+v", util.PrettyPrintStruct(config)))
 
-	runs.Run(log.WithValues("namespace", config.Namespace), config, testrunNamePrefix, notify...)
+	return runs.Run(log.WithValues("namespace", config.Namespace), config, testrunNamePrefix, notify...)
 }
 
 // StartWatchController starts a new controller that watches testruns

--- a/pkg/testrunner/types.go
+++ b/pkg/testrunner/types.go
@@ -37,11 +37,7 @@ type Config struct {
 	// Number of testrun retries after a failed run
 	FlakeAttempts int
 
-	// BackoffPeriod is the duration to wait between the creation of a bucket of testruns
-	BackoffPeriod time.Duration
-
-	// BackoffBucket is the number of parallel created testruns per backoff period
-	BackoffBucket int
+	ExecutorConfig
 }
 
 // RunEventFunc is called every time a new testrun is triggered

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pkg/errors"
 	"io"
 	"io/ioutil"
+	"math"
 	"math/rand"
 	"net/http"
 	"net/url"
@@ -301,6 +302,22 @@ func Unzip(archive, target string) error {
 	return nil
 }
 
+// IsIsEndOfBucket returns if the current value is the last integer value of its bucket
+// Examples (bucket size: 3):
+// 0: false
+// 1: false
+// 2: true
+// 3: false
+// 5: true
+func IsLastElementOfBucket(value, bucketSize int) bool {
+	if bucketSize == 0 {
+		return true
+	}
+	mod := float64(value+1) / float64(bucketSize)
+	return mod == math.Trunc(mod)
+}
+
+// Zipit zips a source file or directory and writes the archive to the specified target path
 func Zipit(source, target string) error {
 	zipfile, err := os.Create(target)
 	if err != nil {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -17,6 +17,7 @@ package util_test
 import (
 	"github.com/gardener/test-infra/pkg/util"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 )
 
@@ -32,4 +33,15 @@ var _ = Describe("util test", func() {
 			Expect(owner).To(Equal("gardener"))
 		})
 	})
+
+	DescribeTable("IsLastElementOfBucket",
+		func(value int, expected bool) {
+			Expect(util.IsLastElementOfBucket(value, 3)).To(Equal(expected))
+		},
+		Entry("0", 0, false),
+		Entry("0", 1, false),
+		Entry("2", 2, true),
+		Entry("3", 3, false),
+		Entry("4", 4, false),
+		Entry("5", 5, true))
 })

--- a/test/testrunner/run/testrunner_run_test.go
+++ b/test/testrunner/run/testrunner_run_test.go
@@ -51,8 +51,9 @@ var _ = Describe("Testrunner execution tests", func() {
 					Metadata: &testrunner.Metadata{},
 				},
 			}
-			testrunner.ExecuteTestruns(operation.Log(), &testrunConfig, run, "test-")
+			err = testrunner.ExecuteTestruns(operation.Log(), &testrunConfig, run, "test-")
 			defer utils.DeleteTestrun(operation.Client(), run[0].Testrun)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(run.HasErrors()).To(BeFalse())
 
 			Expect(len(run)).To(Equal(1))
@@ -78,9 +79,10 @@ var _ = Describe("Testrunner execution tests", func() {
 					Metadata: &testrunner.Metadata{},
 				},
 			}
-			testrunner.ExecuteTestruns(operation.Log(), &testrunConfig, run, "test-")
+			err = testrunner.ExecuteTestruns(operation.Log(), &testrunConfig, run, "test-")
 			defer utils.DeleteTestrun(operation.Client(), run[0].Testrun)
 			defer utils.DeleteTestrun(operation.Client(), run[1].Testrun)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(run.HasErrors()).To(BeFalse())
 
 			Expect(len(run)).To(Equal(2))


### PR DESCRIPTION
**What this PR does / why we need it**:
Added support for serial execution of testrun buckets in the testrunner.

If the `serial=true` flag is set, the testrunner will execute all testruns in a bucket in parallel but waits for the bucket to end (+ the backoff period) before the next bucket starts.

this means that when `bucketSize=1|0` and `serial=true` is specified, all testuns will be executed after another.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
It is now possible to specify the `serial` on the testrunner which will force the serial execution of testrun buckets
```
