### PR TITLE
add group purpose and minor dashboard improvements

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -41,11 +41,14 @@ const (
 	// AnnotationOperatingSystem is the annotation to specify the operating system of the shoot nodes the testrun is testing
 	AnnotationOperatingSystem = "testrunner.testmachinery.sapcloud.io/operating-system"
 
-	// AnnotationFlavorDescription is teh annotation to describe the test flavor of the current run testrun
+	// AnnotationFlavorDescription is the annotation to describe the test flavor of the current run testrun
 	AnnotationFlavorDescription = "testrunner.testmachinery.sapcloud.io/flavor-description"
 
 	// AnnotationDimension is the annotation to specify the dimension the testrun is testing
 	AnnotationDimension = "testrunner.testmachinery.sapcloud.io/dimension"
+
+	// AnnotationGroupPurpose is the annotation to describe a run group with an arbitrary string
+	AnnotationGroupPurpose = "testrunner.testmachinery.sapcloud.io/group-purpose"
 
 	// AnnotationSystemStep is the testflow step annotation to specify that the step is a testmachinery system step.
 	// It indicates that it should not be considered as a test and therefore should not count for a test to be failed.

--- a/pkg/tm-bot/ui/pages/Status.go
+++ b/pkg/tm-bot/ui/pages/Status.go
@@ -39,42 +39,64 @@ type IconWithTooltip struct {
 	Color   string
 }
 
-var PhaseIcon = map[v1alpha1.NodePhase]IconWithTooltip{
-	v1beta1.PhaseStatusInit: {
-		Icon:    "schedule",
-		Tooltip: fmt.Sprintf("%s phase: Testrun is waiting to be scheduled", v1beta1.PhaseStatusInit),
-		Color:   "grey",
-	},
-	v1beta1.PhaseStatusSkipped: {
-		Icon:    "remove",
-		Tooltip: fmt.Sprintf("%s phase: Testrun was skipped", v1beta1.PhaseStatusSkipped),
-		Color:   "grey",
-	},
-	v1beta1.PhaseStatusRunning: {
-		Icon:    "autorenew",
-		Tooltip: fmt.Sprintf("%s phase: Testrun is running", v1beta1.PhaseStatusRunning),
-		Color:   "orange",
-	},
-	v1beta1.PhaseStatusSuccess: {
-		Icon:    "done",
-		Tooltip: fmt.Sprintf("%s phase: Testrun succeeded", v1beta1.PhaseStatusSuccess),
-		Color:   "green",
-	},
-	v1beta1.PhaseStatusFailed: {
-		Icon:    "clear",
-		Tooltip: fmt.Sprintf("%s phase: Testrun failed", v1beta1.PhaseStatusFailed),
-		Color:   "red",
-	},
-	v1beta1.PhaseStatusError: {
-		Icon:    "clear",
-		Tooltip: fmt.Sprintf("%s phase: Testrun errored", v1beta1.PhaseStatusError),
-		Color:   "red",
-	},
-	v1beta1.PhaseStatusTimeout: {
-		Icon:    "clear",
-		Tooltip: fmt.Sprintf("%s phase: Testrun run longer than the specified timeout", v1beta1.PhaseStatusTimeout),
-		Color:   "red",
-	},
+var PhaseIcon = func(phase v1alpha1.NodePhase) IconWithTooltip {
+	switch phase {
+	case v1beta1.PhaseStatusInit:
+		return IconWithTooltip{
+			Icon:    "schedule",
+			Tooltip: fmt.Sprintf("%s phase: Testrun is waiting to be scheduled", v1beta1.PhaseStatusInit),
+			Color:   "grey",
+		}
+	case v1beta1.PhaseStatusSkipped:
+		return IconWithTooltip{
+			Icon:    "remove",
+			Tooltip: fmt.Sprintf("%s phase: Testrun was skipped", v1beta1.PhaseStatusSkipped),
+			Color:   "grey",
+		}
+	case v1beta1.PhaseStatusPending:
+		return IconWithTooltip{
+			Icon:    "schedule",
+			Tooltip: fmt.Sprintf("%s phase: Testrun is pending", v1beta1.PhaseStatusSkipped),
+			Color:   "orange",
+		}
+	case v1beta1.PhaseStatusRunning:
+		return IconWithTooltip{
+			Icon:    "autorenew",
+			Tooltip: fmt.Sprintf("%s phase: Testrun is running", v1beta1.PhaseStatusRunning),
+			Color:   "orange",
+		}
+	case v1beta1.PhaseStatusSuccess:
+		return IconWithTooltip{
+			Icon:    "done",
+			Tooltip: fmt.Sprintf("%s phase: Testrun succeeded", v1beta1.PhaseStatusSuccess),
+			Color:   "green",
+		}
+	case v1beta1.PhaseStatusFailed:
+		return IconWithTooltip{
+			Icon:    "clear",
+			Tooltip: fmt.Sprintf("%s phase: Testrun failed", v1beta1.PhaseStatusFailed),
+			Color:   "red",
+		}
+	case v1beta1.PhaseStatusError:
+		return IconWithTooltip{
+			Icon:    "clear",
+			Tooltip: fmt.Sprintf("%s phase: Testrun errored", v1beta1.PhaseStatusError),
+			Color:   "red",
+		}
+	case v1beta1.PhaseStatusTimeout:
+		return IconWithTooltip{
+			Icon:    "clear",
+			Tooltip: fmt.Sprintf("%s phase: Testrun run longer than the specified timeout", v1beta1.PhaseStatusTimeout),
+			Color:   "red",
+		}
+	default:
+		return IconWithTooltip{
+			Icon:    "info",
+			Tooltip: fmt.Sprintf("%s phase", phase),
+			Color:   "grey",
+		}
+
+	}
 }
 
 type runItem struct {
@@ -117,7 +139,7 @@ func NewPRStatusPage(p *Page) http.HandlerFunc {
 				Repository:   run.Event.GetRepositoryName(),
 				PR:           run.Event.ID,
 				Testrun:      run.Testrun.GetName(),
-				Phase:        PhaseIcon[util.TestrunStatusPhase(run.Testrun)],
+				Phase:        PhaseIcon(util.TestrunStatusPhase(run.Testrun)),
 				Progress:     util.TestrunProgress(run.Testrun),
 			}
 			if isAuthenticated {
@@ -178,7 +200,7 @@ func NewPRStatusDetailPage(logger logr.Logger, auth auth.Authentication, basePat
 				Repository:   run.Event.GetRepositoryName(),
 				PR:           run.Event.ID,
 				Testrun:      run.Testrun.GetName(),
-				Phase:        PhaseIcon[util.TestrunStatusPhase(run.Testrun)],
+				Phase:        PhaseIcon(util.TestrunStatusPhase(run.Testrun)),
 				Progress:     util.TestrunProgress(run.Testrun),
 			},
 			Author:    run.Event.GetAuthorName(),

--- a/pkg/tm-bot/ui/templates/testrun.html
+++ b/pkg/tm-bot/ui/templates/testrun.html
@@ -1,4 +1,10 @@
-{{define "title"}}<a href="/testruns" >Testruns</a> > {{ .page.ID }}{{end}}
+{{define "title"}}
+    <a href="/testruns" >Testruns</a>
+    {{ if .page.RunID }}
+        > <a id="run-id-title" href="/testruns?runID={{ .page.RunID }}">Execution Group</a>
+        <div class="mdl-tooltip" for="run-id-title">Show Execution Group<br>{{ .page.RunID }}</div>
+    {{ end }}
+    > {{ .page.ID }}{{end}}
 {{define "content"}}
     <div class="testrun-card-wide mdl-card mdl-shadow--2dp">
         <div class="mdl-card__title">

--- a/pkg/util/testrun.go
+++ b/pkg/util/testrun.go
@@ -29,7 +29,11 @@ func TestrunStatusPhase(tr *v1beta1.Testrun) argov1alpha1.NodePhase {
 		return v1beta1.PhaseStatusSuccess
 	}
 
+	stepsRun := false
 	for _, step := range tr.Status.Steps {
+		if !stepsRun && step.Phase != v1beta1.PhaseStatusInit {
+			stepsRun = true
+		}
 		if step.Phase == v1beta1.PhaseStatusInit || step.Phase == v1beta1.PhaseStatusSkipped {
 			continue
 		}
@@ -38,7 +42,11 @@ func TestrunStatusPhase(tr *v1beta1.Testrun) argov1alpha1.NodePhase {
 		}
 	}
 
-	return v1beta1.PhaseStatusInit
+	if stepsRun {
+		return v1beta1.PhaseStatusSuccess
+	}
+
+	return tr.Status.Phase
 }
 
 func IsSystemStep(step *v1beta1.StepStatus) bool {

--- a/pkg/util/testrun_test.go
+++ b/pkg/util/testrun_test.go
@@ -1,0 +1,80 @@
+// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util_test
+
+import (
+	"github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
+	"github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
+	"github.com/gardener/test-infra/pkg/common"
+	"github.com/gardener/test-infra/pkg/util"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("testrun util test", func() {
+
+	Context("TestrunStatusPhase", func() {
+		It("should return success when the testrun was successfull", func() {
+			tr := &v1beta1.Testrun{Status: v1beta1.TestrunStatus{Phase: v1beta1.PhaseStatusSuccess}}
+			Expect(util.TestrunStatusPhase(tr)).To(Equal(v1beta1.PhaseStatusSuccess))
+		})
+
+		It("should return success even if a system component failed", func() {
+			tr := &v1beta1.Testrun{Status: v1beta1.TestrunStatus{
+				Phase: v1beta1.PhaseStatusError,
+				Steps: []*v1beta1.StepStatus{
+					newStepStatus(v1beta1.PhaseStatusSuccess, false),
+					newStepStatus(v1beta1.PhaseStatusError, true),
+				},
+			}}
+			Expect(util.TestrunStatusPhase(tr)).To(Equal(v1beta1.PhaseStatusSuccess))
+		})
+
+		It("should return error if one non system step fails", func() {
+			tr := &v1beta1.Testrun{Status: v1beta1.TestrunStatus{
+				Phase: v1beta1.PhaseStatusError,
+				Steps: []*v1beta1.StepStatus{
+					newStepStatus(v1beta1.PhaseStatusSuccess, true),
+					newStepStatus(v1beta1.PhaseStatusError, false),
+				},
+			}}
+			Expect(util.TestrunStatusPhase(tr)).To(Equal(v1beta1.PhaseStatusError))
+		})
+
+		It("should return the testrun state of all steps are in init state", func() {
+			tr := &v1beta1.Testrun{Status: v1beta1.TestrunStatus{
+				Phase: v1beta1.PhaseStatusError,
+				Steps: []*v1beta1.StepStatus{
+					newStepStatus(v1beta1.PhaseStatusInit, true),
+					newStepStatus(v1beta1.PhaseStatusInit, false),
+				},
+			}}
+			Expect(util.TestrunStatusPhase(tr)).To(Equal(v1beta1.PhaseStatusError))
+		})
+	})
+})
+
+func newStepStatus(phase v1alpha1.NodePhase, system bool) *v1beta1.StepStatus {
+	step := &v1beta1.StepStatus{
+		Phase:       phase,
+		Annotations: map[string]string{},
+	}
+
+	if system {
+		step.Annotations[common.AnnotationSystemStep] = "true"
+	}
+
+	return step
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Added an annotation to define a purpose for a execution group (run group).
This purpose is then used in the dashboard to better display execution runs.

In addition minor improvements have been made:
- added Icon for pending testruns
- added link to execution if applicable
- improved the phase determination for testruns in pending or init state

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Add annotation for group purpose
```
