### PR TITLE
Refactor status of ingested and uploaded fields

### DIFF
--- a/pkg/apis/testmachinery/v1beta1/types.go
+++ b/pkg/apis/testmachinery/v1beta1/types.go
@@ -141,12 +141,6 @@ type TestrunStatus struct {
 	// Steps is the detailed summary of every step.
 	// It also shows all specific executed tests.
 	Steps []*StepStatus `json:"steps,omitempty"`
-
-	// Ingested states whether the result of a testrun is already ingested into a persistent storage (db).
-	Ingested bool `json:"ingested"`
-
-	// UploadedToGithub states whether the status of a testrun is already uploaded to github component
-	UploadedToGithub *bool `json:"uploadedToGithub"`
 }
 
 // StepStatus is the status of Testflow step

--- a/pkg/apis/testmachinery/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/testmachinery/v1beta1/zz_generated.deepcopy.go
@@ -557,11 +557,6 @@ func (in *TestrunStatus) DeepCopyInto(out *TestrunStatus) {
 			}
 		}
 	}
-	if in.UploadedToGithub != nil {
-		in, out := &in.UploadedToGithub, &out.UploadedToGithub
-		*out = new(bool)
-		**out = **in
-	}
 	return
 }
 

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -22,10 +22,6 @@ const (
 	// AnnotationTestrunPurpose is the annotation name to specify a purpose of the testrun
 	AnnotationTestrunPurpose = "testmachinery.sapcloud.io/purpose"
 
-	// LabelTestrunRunID is the annotation to specify the unique name of the run (multiple testuns) this test belongs to.
-	// A run represents all tests that are running from one testrunner.
-	LabelTestrunRunID = "testrunner.testmachinery.sapcloud.io/runID"
-
 	// AnnotationTemplateIDTestrun is the annotation to specify the name of the template the testun is rendered from
 	AnnotationTemplateIDTestrun = "testrunner.testmachinery.sapcloud.io/templateID"
 
@@ -53,6 +49,16 @@ const (
 	// AnnotationSystemStep is the testflow step annotation to specify that the step is a testmachinery system step.
 	// It indicates that it should not be considered as a test and therefore should not count for a test to be failed.
 	AnnotationSystemStep = "testmachinery.sapcloud.io/system-step"
+
+	// LabelTestrunRunID is the label to specify the unique name of the run (multiple testruns) this test belongs to.
+	// A run represents all tests that are running from one testrunner.
+	LabelTestrunRunID = "testrunner.testmachinery.sapcloud.io/runID"
+
+	// LabelIngested is the label that states whether the result of a testrun is already ingested into a persistent storage (db).
+	LabelIngested = "testrunner.testmachinery.sapcloud.io/ingested"
+
+	// LabelUploadedToGithub is the label to specify whether the testrun result was uploaded to github
+	LabelUploadedToGithub = "testrunner.testmachinery.sapcloud.io/uploaded-to-github"
 
 	// images
 	DockerImageGardenerApiServer = "eu.gcr.io/gardener-project/gardener/apiserver"

--- a/pkg/openapi/api_violations.report
+++ b/pkg/openapi/api_violations.report
@@ -3,6 +3,7 @@ API rule violation: list_type_missing,github.com/gardener/test-infra/pkg/apis/te
 API rule violation: list_type_missing,github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1,StepDefinition,Config
 API rule violation: list_type_missing,github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1,StepStatusPosition,DependsOn
 API rule violation: list_type_missing,github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1,StepStatusTestDefinition,Config
+API rule violation: list_type_missing,github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1,StepStatusTestDefinition,Labels
 API rule violation: list_type_missing,github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1,StepStatusTestDefinition,RecipientsOnFailure
 API rule violation: list_type_missing,github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1,TestDefSpec,Args
 API rule violation: list_type_missing,github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1,TestDefSpec,Behavior

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -996,22 +996,7 @@ func schema_pkg_apis_testmachinery_v1beta1_TestrunStatus(ref common.ReferenceCal
 							},
 						},
 					},
-					"ingested": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Ingested states whether the result of a testrun is already ingested into a persistent storage (db).",
-							Type:        []string{"boolean"},
-							Format:      "",
-						},
-					},
-					"uploadedToGithub": {
-						SchemaProps: spec.SchemaProps{
-							Description: "UploadedToGithub states whether the status of a testrun is already uploaded to github component",
-							Type:        []string{"boolean"},
-							Format:      "",
-						},
-					},
 				},
-				Required: []string{"ingested", "uploadedToGithub"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/testrunner/elasticsearch/elasticsearchbulk.go
+++ b/pkg/testrunner/elasticsearch/elasticsearchbulk.go
@@ -112,7 +112,7 @@ func parseExportedBulkFormat(log logr.Logger, name string, stepMeta interface{},
 		var jsonBody map[string]interface{}
 		err := json.Unmarshal(doc, &jsonBody)
 		if err != nil {
-			log.V(3).Info(fmt.Sprintf("cannot unmarshal document %s", err.Error()))
+			log.V(5).Info(fmt.Sprintf("cannot unmarshal document %s", err.Error()))
 			continue
 		}
 

--- a/pkg/testrunner/result/collect.go
+++ b/pkg/testrunner/result/collect.go
@@ -89,6 +89,9 @@ func (c *Collector) ingestIntoElasticsearch(cfg Config, runLogger logr.Logger, t
 	if cfg.OutputDir == "" && cfg.ESConfigName == "" {
 		return nil
 	}
+	if util.HasLabel(run.Testrun.ObjectMeta, common.LabelIngested) {
+		return nil
+	}
 	err := IngestDir(runLogger, cfg.OutputDir, cfg.ESConfigName)
 	if err != nil {
 		return errors.Wrapf(err, "cannot persist file %s", cfg.OutputDir)

--- a/pkg/testrunner/result/ingest.go
+++ b/pkg/testrunner/result/ingest.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"fmt"
 	"github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/gardener/test-infra/pkg/common"
+	"github.com/gardener/test-infra/pkg/util"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"io/ioutil"
@@ -69,7 +71,7 @@ func MarkTestrunsAsIngested(log logr.Logger, tmClient client.Client, tr *tmv1bet
 	defer ctx.Done()
 
 	patched := tr.DeepCopy()
-	patched.Status.Ingested = true
+	util.SetMetaDataLabel(&patched.ObjectMeta, common.LabelIngested, "true")
 	patch, err := kubernetes.CreateTwoWayMergePatch(tr, patched)
 	if err != nil {
 		return errors.Wrap(err, "unable to create patch update for ingestion")

--- a/pkg/testrunner/result/status-uploader.go
+++ b/pkg/testrunner/result/status-uploader.go
@@ -443,8 +443,7 @@ func MarkTestrunsAsUploadedToGithub(log logr.Logger, tmClient client.Client, run
 
 	for _, run := range runs {
 		tr := run.Testrun
-		enabled := true
-		tr.Status.UploadedToGithub = &enabled
+		util.SetMetaDataLabel(&tr.ObjectMeta, common.LabelUploadedToGithub, "true")
 		err := tmClient.Update(ctx, tr)
 		if err != nil {
 			return errors.Wrapf(err, "unable to update status of testrun %s in namespace: %s", tr.Name, tr.Namespace)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pkg/errors"
 	"io"
 	"io/ioutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"math"
 	"math/rand"
 	"net/http"
@@ -218,20 +219,34 @@ func StringDefault(value, def string) string {
 	return value
 }
 
+// HasAnnotation returns a bool if passed in label exists
+func HasLabel(obj metav1.ObjectMeta, label string) bool {
+	_, found := obj.Labels[label]
+	return found
+}
+
+// SetMetaDataLabel sets the label and value
+func SetMetaDataLabel(obj *metav1.ObjectMeta, label string, value string) {
+	if obj.Labels == nil {
+		obj.Labels = make(map[string]string)
+	}
+	obj.Labels[label] = value
+}
+
 // GitHub helper functions
 
+// ParseRepoURLFromString returns the repository owner and name of a github repo url
 func ParseRepoURLFromString(repoURL string) (repoOwner, repoName string, err error) {
 	u, err := url.Parse(repoURL)
 	if err != nil {
 		return "", "", err
 	}
 
-	repoNameComponents := strings.Split(u.Path, "/")
-	repoOwner = repoNameComponents[1]
-	repoName = strings.Replace(repoNameComponents[2], ".git", "", 1)
-	return
+	repoOwner, repoName = ParseRepoURL(u)
+	return repoOwner, repoName, nil
 }
 
+// ParseRepoURL returns the repository owner and name of a github repo url
 func ParseRepoURL(url *url.URL) (repoOwner, repoName string) {
 	repoNameComponents := strings.Split(url.Path, "/")
 	repoOwner = repoNameComponents[1]
@@ -239,6 +254,7 @@ func ParseRepoURL(url *url.URL) (repoOwner, repoName string) {
 	return
 }
 
+// GetGitHubClient returns a new github enterprise client with basic auth and optional tls verification
 func GetGitHubClient(apiURL, username, password, uploadURL string, skipTLS bool) (*github.Client, error) {
 	client, err := github.NewEnterpriseClient(apiURL, uploadURL, GetHTTPClient(username, password, skipTLS))
 	if err != nil {
@@ -247,6 +263,7 @@ func GetGitHubClient(apiURL, username, password, uploadURL string, skipTLS bool)
 	return client, nil
 }
 
+// GetHTTPClient returns a new http client with basic auth and optional tls verification
 func GetHTTPClient(username, password string, skipTLS bool) *http.Client {
 	if username != "" && password != "" {
 		basicAuth := github.BasicAuthTransport{
@@ -265,6 +282,8 @@ func GetHTTPClient(username, password string, skipTLS bool) *http.Client {
 		},
 	}
 }
+
+// Unzip unpacks the given archive to the specified target path
 func Unzip(archive, target string) error {
 	reader, err := zip.OpenReader(archive)
 	if err != nil {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -219,7 +219,7 @@ func StringDefault(value, def string) string {
 	return value
 }
 
-// HasAnnotation returns a bool if passed in label exists
+// HasLabel returns a bool if passed in label exists
 func HasLabel(obj metav1.ObjectMeta, label string) bool {
 	_, found := obj.Labels[label]
 	return found


### PR DESCRIPTION
**What this PR does / why we need it**:

The `ingestion` and `github upload` state are removed from the status of the testrun.
These tes are replaced by 2 labels:
- `testrunner.testmachinery.sapcloud.io/ingested`
- `testrunner.testmachinery.sapcloud.io/uploaded-to-github`

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
⚠️ The `ingested` and `uploadedToGithHub` attributes in the state are removed and replaced by the labels `testrunner.testmachinery.sapcloud.io/ingested` and `testrunner.testmachinery.sapcloud.io/uploaded-to-github`
```
