### PR TITLE
add new run to execution queue

### DIFF
--- a/pkg/testrunner/list.go
+++ b/pkg/testrunner/list.go
@@ -78,9 +78,9 @@ func (rl RunList) Run(log logr.Logger, config *Config, testrunNamePrefix string,
 		var (
 			trI     = i
 			attempt = 0
+			f       func()
 		)
-
-		executor.AddItem(func() {
+		f = func() {
 			rl[trI].SetRunID(runID)
 			triggerRunEvent(notify, rl[trI])
 			rl[trI].Exec(log, config, testrunNamePrefix)
@@ -108,7 +108,9 @@ func (rl RunList) Run(log logr.Logger, config *Config, testrunNamePrefix string,
 			}
 			*rl[trI] = *newRun
 			attempt++
-		})
+			executor.AddItem(f)
+		}
+		executor.AddItem(f)
 	}
 
 	executor.Run()


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the retries with the new executor by re-adding the current function to the queue

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Fix retries with new executor
```
