### PR TITLE
Use dimension function for status uploader in order to avoid missing dimensions

### DIFF
--- a/pkg/testrunner/metadata.go
+++ b/pkg/testrunner/metadata.go
@@ -28,15 +28,15 @@ func (m *Metadata) CreateAnnotations() map[string]string {
 		common.AnnotationCloudProvider:     m.CloudProvider,
 		common.AnnotationOperatingSystem:   m.OperatingSystem,
 		common.AnnotationFlavorDescription: m.FlavorDescription,
-		common.AnnotationDimension:         m.GetDimensionFromMetadata(),
+		common.AnnotationDimension:         m.GetDimensionFromMetadata("/"),
 	}
 }
 
 // GetDimensionFromMetadata returns a string describing the dimension of the metadata
-func (m *Metadata) GetDimensionFromMetadata() string {
-	d := fmt.Sprintf("%s/%s/%s", m.CloudProvider, m.KubernetesVersion, m.OperatingSystem)
+func (m *Metadata) GetDimensionFromMetadata(sep string) string {
+	d := fmt.Sprintf("%s" + sep + "%s" + sep + "%s", m.CloudProvider, m.KubernetesVersion, m.OperatingSystem)
 	if m.FlavorDescription != "" {
-		d = fmt.Sprintf("%s-%s", d, m.FlavorDescription)
+		d = fmt.Sprintf("%s" + sep + "%s", d, m.FlavorDescription)
 	}
 	return d
 }

--- a/pkg/testrunner/result/status-uploader.go
+++ b/pkg/testrunner/result/status-uploader.go
@@ -222,7 +222,7 @@ func storeRunsStatusAsFiles(log logr.Logger, runs testrunner.RunList, dest strin
 
 func generateTestrunAssetName(testrun testrunner.Run) string {
 	md := testrun.Metadata
-	return fmt.Sprintf("%s%s-%s-%s-%s.txt", prefix, md.Landscape, md.CloudProvider, md.OperatingSystem, md.KubernetesVersion)
+	return fmt.Sprintf("%s%s-%s.txt", prefix, md.Landscape, md.GetDimensionFromMetadata("-"))
 }
 
 // compares overview file items with given testrun list to identify whether any testrun is missing or needs to be updated

--- a/pkg/tm-bot/ui/pages/Runs.go
+++ b/pkg/tm-bot/ui/pages/Runs.go
@@ -127,7 +127,7 @@ func NewTestrunsPage(p *Page) http.HandlerFunc {
 				StartTime: startTime,
 				Duration:  d.String(),
 				Progress:  util.TestrunProgress(&tr),
-				Dimension: metadata.GetDimensionFromMetadata(),
+				Dimension: metadata.GetDimensionFromMetadata("/"),
 			}
 			if argoHostURL != "" {
 				testrunsList[i].ArgoURL = testrunner.GetArgoURLFromHost(argoHostURL, &tr)
@@ -195,7 +195,7 @@ func NewTestrunPage(p *Page) http.HandlerFunc {
 				StartTime: startTime,
 				Duration:  d.String(),
 				Progress:  util.TestrunProgress(tr),
-				Dimension: metadata.GetDimensionFromMetadata(),
+				Dimension: metadata.GetDimensionFromMetadata("/"),
 			},
 			Steps:     make(testrunStepStatusItemList, len(tr.Status.Steps)),
 			RawStatus: statusTable.String(),


### PR DESCRIPTION
**What this PR does / why we need it**:
Use dimension function for status uploader in order to avoid missing dimensions

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```
NONE
```
