### PR TITLE
Fix status calculation in tm dashboard

### DIFF
--- a/pkg/testrunner/metadata.go
+++ b/pkg/testrunner/metadata.go
@@ -34,9 +34,9 @@ func (m *Metadata) CreateAnnotations() map[string]string {
 
 // GetDimensionFromMetadata returns a string describing the dimension of the metadata
 func (m *Metadata) GetDimensionFromMetadata(sep string) string {
-	d := fmt.Sprintf("%s" + sep + "%s" + sep + "%s", m.CloudProvider, m.KubernetesVersion, m.OperatingSystem)
+	d := fmt.Sprintf("%s"+sep+"%s"+sep+"%s", m.CloudProvider, m.KubernetesVersion, m.OperatingSystem)
 	if m.FlavorDescription != "" {
-		d = fmt.Sprintf("%s" + sep + "%s", d, m.FlavorDescription)
+		d = fmt.Sprintf("%s"+sep+"%s", d, m.FlavorDescription)
 	}
 	return d
 }

--- a/pkg/util/testrun.go
+++ b/pkg/util/testrun.go
@@ -31,7 +31,7 @@ func TestrunStatusPhase(tr *v1beta1.Testrun) argov1alpha1.NodePhase {
 
 	stepsRun := false
 	for _, step := range tr.Status.Steps {
-		if !stepsRun && step.Phase != v1beta1.PhaseStatusInit {
+		if !stepsRun && (step.Phase != v1beta1.PhaseStatusInit && step.Phase != v1beta1.PhaseStatusSkipped) {
 			stepsRun = true
 		}
 		if step.Phase == v1beta1.PhaseStatusInit || step.Phase == v1beta1.PhaseStatusSkipped {

--- a/pkg/util/testrun_test.go
+++ b/pkg/util/testrun_test.go
@@ -53,12 +53,23 @@ var _ = Describe("testrun util test", func() {
 			Expect(util.TestrunStatusPhase(tr)).To(Equal(v1beta1.PhaseStatusError))
 		})
 
-		It("should return the testrun state of all steps are in init state", func() {
+		It("should return the testrun state if all steps are in init state", func() {
 			tr := &v1beta1.Testrun{Status: v1beta1.TestrunStatus{
 				Phase: v1beta1.PhaseStatusError,
 				Steps: []*v1beta1.StepStatus{
 					newStepStatus(v1beta1.PhaseStatusInit, true),
 					newStepStatus(v1beta1.PhaseStatusInit, false),
+				},
+			}}
+			Expect(util.TestrunStatusPhase(tr)).To(Equal(v1beta1.PhaseStatusError))
+		})
+
+		It("should return the testrun state if all steps are in skipped state", func() {
+			tr := &v1beta1.Testrun{Status: v1beta1.TestrunStatus{
+				Phase: v1beta1.PhaseStatusError,
+				Steps: []*v1beta1.StepStatus{
+					newStepStatus(v1beta1.PhaseStatusSkipped, true),
+					newStepStatus(v1beta1.PhaseStatusSkipped, false),
 				},
 			}}
 			Expect(util.TestrunStatusPhase(tr)).To(Equal(v1beta1.PhaseStatusError))


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
A bug in the TM Dashboard has been fixed that reported a wrong testrun status if all tests are skipped
```
