### PR TITLE
Remove raw kubeconfig from argo workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ remove-controller:
 
 .PHONY: install-prerequisites
 install-prerequisites:
-	helm template --namespace ${NS} ./charts/bootstrap_tm_prerequisites --set="argo.containerRuntimeExecutor=pns" | kubectl apply -f -
+	helm template --namespace ${NS} ./charts/bootstrap_tm_prerequisites | kubectl apply -f -
 
 .PHONY: remove-prerequisites
 remove-prerequisites:

--- a/charts/bootstrap_tm_prerequisites/templates/crds.yaml
+++ b/charts/bootstrap_tm_prerequisites/templates/crds.yaml
@@ -20,6 +20,10 @@ metadata:
   name: testruns.testmachinery.sapcloud.io
 spec:
   group: testmachinery.sapcloud.io
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
   version: v1beta1
   scope: Namespaced
   names:
@@ -27,6 +31,8 @@ spec:
     plural: testruns
     shortNames:
     - tr
+  subresources:
+    status: {}
   additionalPrinterColumns:
   - name: Workflow
     type: string
@@ -44,7 +50,6 @@ spec:
     type: number
     description: The Duration inidcates the complete duration of the workflow.
     JSONPath: .status.duration
-  # TODO: add validation
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/charts/testmachinery/templates/deployment-tm-controller.yaml
+++ b/charts/testmachinery/templates/deployment-tm-controller.yaml
@@ -49,6 +49,7 @@ spec:
         - --key-file=/etc/testmachinery-controller/srv/tls.key
         - --github-cache-dir=/cache
         - --namespace={{ .Release.Namespace }}
+        - --max-concurrent-syncs={{ .Values.controller.maxConcurrentSyncs }}
         - --enable-pod-gc={{ .Values.cleanup.enabled }}
         - -v={{ .Values.controller.verbosity }}
         {{- if .Values.secrets.github.data }}

--- a/charts/testmachinery/templates/rbac.yaml
+++ b/charts/testmachinery/templates/rbac.yaml
@@ -23,6 +23,7 @@ rules:
   - secrets
   verbs:
   - get
+  - create
   - list
   - watch
 - apiGroups:
@@ -44,6 +45,7 @@ rules:
   - testmachinery.sapcloud.io
   resources:
   - testruns
+  - testruns/status
   - testruns/finalizers
   verbs:
   - "*"

--- a/charts/testmachinery/values.yaml
+++ b/charts/testmachinery/values.yaml
@@ -22,6 +22,7 @@ controller:
   pullPolicy: IfNotPresent
   imagePullSecretName: ""
   testDefPath: ""
+  maxConcurrentSyncs: 5
   verbosity: 2
 
   serviceAccountName: testmachinery-controller

--- a/cmd/testmachinery-controller/main.go
+++ b/cmd/testmachinery-controller/main.go
@@ -38,6 +38,7 @@ import (
 var (
 	metricsAddr          string
 	enableLeaderElection bool
+	maxConcurrentSyncs   int
 
 	setupLogger = ctrl.Log.WithName("setup")
 )
@@ -59,7 +60,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	_, err = controller.NewTestMachineryController(mgr, ctrl.Log)
+	_, err = controller.NewTestMachineryController(mgr, ctrl.Log, &maxConcurrentSyncs)
 	if err != nil {
 		setupLogger.Error(err, "unable to create controller", "controllers", "Testrun")
 		os.Exit(1)
@@ -83,6 +84,7 @@ func init() {
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
+	flag.IntVar(&maxConcurrentSyncs, "max-concurrent-syncs", 1, "Max number of concurrent reconciliations.")
 	logger.InitFlags(nil)
 	testmachinery.InitFlags(nil)
 	server.InitFlags(nil)

--- a/go.mod
+++ b/go.mod
@@ -69,7 +69,7 @@ require (
 	k8s.io/helm v2.14.2+incompatible
 	k8s.io/klog v1.0.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a
-	k8s.io/utils v0.0.0-20191114200735-6ca3b61696b6 // indirect
+	k8s.io/utils v0.0.0-20191114200735-6ca3b61696b6
 	sigs.k8s.io/controller-runtime v0.4.0
 	sigs.k8s.io/yaml v1.1.0
 )

--- a/pkg/apis/testmachinery/v1beta1/types.go
+++ b/pkg/apis/testmachinery/v1beta1/types.go
@@ -142,6 +142,10 @@ type TestrunStatus struct {
 	// Steps is the detailed summary of every step.
 	// It also shows all specific executed tests.
 	Steps []*StepStatus `json:"steps,omitempty"`
+
+	// ObservedGeneration is the most recent generation observed for this testrun.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // StepStatus is the status of Testflow step

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -1046,6 +1046,13 @@ func schema_pkg_apis_testmachinery_v1beta1_TestrunStatus(ref common.ReferenceCal
 							},
 						},
 					},
+					"observedGeneration": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ObservedGeneration is the most recent generation observed for this testrun.",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/testmachinery/controller/reconciler/testrun_control_update.go
+++ b/pkg/testmachinery/controller/reconciler/testrun_control_update.go
@@ -66,8 +66,8 @@ func (r *TestmachineryReconciler) updateStatus(ctx context.Context, rCtx *reconc
 	}
 
 	if rCtx.updated {
-		err := r.Update(ctx, rCtx.tr)
-		if err != nil {
+		rCtx.tr.Status.ObservedGeneration = rCtx.tr.Generation
+		if err := r.Status().Update(ctx, rCtx.tr); err != nil {
 			log.Error(err, "unable to update testrun status")
 			return reconcile.Result{}, err
 		}

--- a/pkg/testmachinery/prepare/prepare.go
+++ b/pkg/testmachinery/prepare/prepare.go
@@ -15,25 +15,19 @@
 package prepare
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/gardener/test-infra/pkg/common"
-	"github.com/gardener/test-infra/pkg/testmachinery/locations/location"
-	"github.com/pkg/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"net/url"
-	"path"
-
-	"github.com/gardener/test-infra/pkg/testmachinery/config"
-	"github.com/gardener/test-infra/pkg/testmachinery/testdefinition"
-	"github.com/gardener/test-infra/pkg/util/strconf"
-
 	argov1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
 	tmv1beta1 "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
+	"github.com/gardener/test-infra/pkg/common"
 	"github.com/gardener/test-infra/pkg/testmachinery"
+	"github.com/gardener/test-infra/pkg/testmachinery/locations/location"
+	"github.com/gardener/test-infra/pkg/testmachinery/testdefinition"
 	"github.com/gardener/test-infra/pkg/util"
-	apiv1 "k8s.io/api/core/v1"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"net/url"
 )
 
 // New creates the TM prepare step
@@ -49,15 +43,15 @@ func New(name string, addGlobalInput, addGlobalOutput bool) (*Definition, error)
 		Name: fmt.Sprintf("%s-%s", name, util.RandomString(5)),
 		Metadata: argov1.Metadata{
 			Annotations: map[string]string{
-				"testmachinery.sapcloud.io/TestDefinition": "Prepare",
-				common.AnnotationSystemStep:                "true",
+				common.AnnotationTestDefName: "Prepare",
+				common.AnnotationSystemStep:  "true",
 			},
 		},
 		ActiveDeadlineSeconds: &testdefinition.DefaultActiveDeadlineSeconds,
-		Container: &apiv1.Container{
+		Container: &corev1.Container{
 			Image:   testmachinery.PREPARE_IMAGE,
 			Command: []string{"/tm/prepare", PrepareConfigPath},
-			Env: []apiv1.EnvVar{
+			Env: []corev1.EnvVar{
 				{
 					Name:  testmachinery.TM_PHASE_NAME,
 					Value: "{{inputs.parameters.phase}}",
@@ -127,57 +121,6 @@ func (p *Definition) AddRepositoriesAsArtifacts() error {
 	})
 
 	return nil
-}
-
-// AddKubeconfig adds all defined kubeconfigs as files to the prepare pod
-func (p *Definition) AddKubeconfigs(kubeconfigs tmv1beta1.TestrunKubeconfigs) error {
-	if kubeconfigs.Gardener != nil {
-		if err := p.addKubeconfig("gardener", kubeconfigs.Gardener); err != nil {
-			return err
-		}
-	}
-	if kubeconfigs.Seed != nil {
-		if err := p.addKubeconfig("seed", kubeconfigs.Seed); err != nil {
-			return err
-		}
-	}
-	if kubeconfigs.Shoot != nil {
-		if err := p.addKubeconfig("shoot", kubeconfigs.Shoot); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (p *Definition) addKubeconfig(name string, kubeconfig *strconf.StringOrConfig) error {
-	kubeconfigPath := fmt.Sprintf("%s/%s.config", testmachinery.TM_KUBECONFIG_PATH, name)
-	if kubeconfig.Type == strconf.String {
-		kubeconfig, err := base64.StdEncoding.DecodeString(kubeconfig.String())
-		if err != nil {
-			return errors.Wrapf(err, "unable to parse kubeconfig")
-		}
-		p.TestDefinition.AddInputArtifacts(argov1.Artifact{
-			Name: name,
-			Path: kubeconfigPath,
-			ArtifactLocation: argov1.ArtifactLocation{
-				Raw: &argov1.RawArtifact{
-					Data: string(kubeconfig),
-				},
-			},
-		})
-		return nil
-	}
-	if kubeconfig.Type == strconf.Config {
-		cfg := config.NewElement(&tmv1beta1.ConfigElement{
-			Type:      tmv1beta1.ConfigTypeFile,
-			Name:      name,
-			Path:      kubeconfigPath,
-			ValueFrom: kubeconfig.Config(),
-		}, config.LevelTestDefinition)
-		p.TestDefinition.AddVolumeMount(cfg.Name(), kubeconfigPath, path.Base(kubeconfigPath), true)
-		return p.TestDefinition.AddVolumeFromConfig(cfg)
-	}
-	return fmt.Errorf("undefined StringSecType %s", string(kubeconfig.Type))
 }
 
 func (p *Definition) addNetrcFile() error {

--- a/pkg/testmachinery/testrun/kubeconfigs.go
+++ b/pkg/testmachinery/testrun/kubeconfigs.go
@@ -1,0 +1,100 @@
+// Copyright 2020 Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testrun
+
+import (
+	"fmt"
+	tmv1beta1 "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
+	"github.com/gardener/test-infra/pkg/testmachinery"
+	"github.com/gardener/test-infra/pkg/testmachinery/config"
+	"github.com/gardener/test-infra/pkg/util/strconf"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
+)
+
+// ParseKubeconfigs parses the kubeconfigs defined in the testrun and returns respective configs and k8s secrets.
+func ParseKubeconfigs(tr *tmv1beta1.Testrun) ([]*config.Element, []runtime.Object, error) {
+	configs := make([]*config.Element, 0)
+	secrets := make([]runtime.Object, 0)
+	if tr.Spec.Kubeconfigs.Gardener != nil {
+		if err := addKubeconfig(&configs, &secrets, tr, "gardener", tr.Spec.Kubeconfigs.Gardener); err != nil {
+			return nil, nil, err
+		}
+	}
+	if tr.Spec.Kubeconfigs.Seed != nil {
+		if err := addKubeconfig(&configs, &secrets, tr, "seed", tr.Spec.Kubeconfigs.Seed); err != nil {
+			return nil, nil, err
+		}
+	}
+	if tr.Spec.Kubeconfigs.Shoot != nil {
+		if err := addKubeconfig(&configs, &secrets, tr, "shoot", tr.Spec.Kubeconfigs.Shoot); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	return configs, secrets, nil
+}
+
+func addKubeconfig(configs *[]*config.Element, secrets *[]runtime.Object, tr *tmv1beta1.Testrun, name string, kubeconfig *strconf.StringOrConfig) error {
+	kubeconfigPath := fmt.Sprintf("%s/%s.config", testmachinery.TM_KUBECONFIG_PATH, name)
+	if kubeconfig.Type == strconf.String {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-%s", tr.Name, name),
+				Namespace: tr.Namespace,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion:         tr.GroupVersionKind().Group,
+						Kind:               tr.Kind,
+						Name:               tr.GetName(),
+						UID:                tr.GetUID(),
+						BlockOwnerDeletion: pointer.BoolPtr(true),
+						Controller:         pointer.BoolPtr(false),
+					},
+				},
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				"kubeconfig": []byte(kubeconfig.String()),
+			},
+		}
+		*secrets = append(*secrets, secret)
+
+		*configs = append(*configs, config.NewElement(&tmv1beta1.ConfigElement{
+			Type: tmv1beta1.ConfigTypeFile,
+			Name: secret.Name,
+			Path: kubeconfigPath,
+			ValueFrom: &strconf.ConfigSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: secret.Name},
+					Key:                  "kubeconfig",
+				},
+			},
+		}, config.LevelTestDefinition))
+		return nil
+	}
+	if kubeconfig.Type == strconf.Config {
+		*configs = append(*configs, config.NewElement(&tmv1beta1.ConfigElement{
+			Type:      tmv1beta1.ConfigTypeFile,
+			Name:      name,
+			Path:      kubeconfigPath,
+			ValueFrom: kubeconfig.Config(),
+		}, config.LevelTestDefinition))
+		return nil
+	}
+	return fmt.Errorf("undefined StringSecType %s", string(kubeconfig.Type))
+}

--- a/pkg/testmachinery/testrun/types.go
+++ b/pkg/testmachinery/testrun/types.go
@@ -16,11 +16,13 @@ package testrun
 import (
 	tmv1beta1 "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
 	"github.com/gardener/test-infra/pkg/testmachinery/testflow"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // Testrun is the internal representation of a testrun crd
 type Testrun struct {
-	Info           *tmv1beta1.Testrun
-	Testflow       *testflow.Testflow
-	OnExitTestflow *testflow.Testflow
+	Info            *tmv1beta1.Testrun
+	Testflow        *testflow.Testflow
+	OnExitTestflow  *testflow.Testflow
+	HelperResources []runtime.Object
 }

--- a/pkg/testrunner/execution_test.go
+++ b/pkg/testrunner/execution_test.go
@@ -256,7 +256,7 @@ var _ = Describe("Executor tests", func() {
 
 		Expect(addExecution.start.IsZero()).To(BeFalse())
 		expectExecutionsToBe(addExecution, executions[0], 1)
-	})
+	}, 10)
 
 	It("should add same test during execution in parallel steps", func() {
 		executions := [3]*execution{}

--- a/pkg/testrunner/testrunner_suite_test.go
+++ b/pkg/testrunner/testrunner_suite_test.go
@@ -22,5 +22,5 @@ import (
 
 func TestTestrunnerTemplate(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Testrunner Template Test Suite")
+	RunSpecs(t, "Testrunner Test Suite")
 }

--- a/pkg/util/strconf/strconf.go
+++ b/pkg/util/strconf/strconf.go
@@ -35,7 +35,7 @@ const (
 	Config             // The IntOrString holds a string.
 )
 
-// FromString creates a StringOrConfoig from a string.
+// FromString creates a StringOrConfig from a string.
 func FromString(s string) *StringOrConfig {
 	return &StringOrConfig{
 		Type:   String,


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Removed the raw kkubeconfig from argo workflow to now use dynamically created secrets 
```
