### PR TITLE
increase memory limits for k8s e2e test steps

### DIFF
--- a/.test-defs/allE2eTestgrid.yaml
+++ b/.test-defs/allE2eTestgrid.yaml
@@ -54,3 +54,8 @@ spec:
     export GARDEN_KUBECONFIG_PATH=$TM_KUBECONFIG_PATH/gardener.config &&
     go run --mod=vendor ./integration-tests/e2e --cleanUpAfterwards=true --flakeAttempts=5 --retryFailedTestcases=true
   image: golang:1.13
+  resources:
+    requests:
+      memory: "500Mi"
+    limits:
+      memory: "8Gi"

--- a/.test-defs/conformanceTestgrid.yaml
+++ b/.test-defs/conformanceTestgrid.yaml
@@ -57,3 +57,8 @@ spec:
     export GARDEN_KUBECONFIG_PATH=$TM_KUBECONFIG_PATH/gardener.config &&
     go run -mod=vendor ./integration-tests/e2e --cleanUpAfterwards=true --flakeAttempts=5
   image: golang:1.13
+  resources:
+    requests:
+      memory: "500Mi"
+    limits:
+      memory: "8Gi"

--- a/.test-defs/conformanceTestgridParallel.yaml
+++ b/.test-defs/conformanceTestgridParallel.yaml
@@ -41,3 +41,8 @@ spec:
     export GARDEN_KUBECONFIG_PATH=$TM_KUBECONFIG_PATH/gardener.config &&
     go run -mod=vendor ./integration-tests/e2e --cleanUpAfterwards=true --flakeAttempts=5 --retryFailedTestcases=true
   image: golang:1.13
+  resources:
+    requests:
+      memory: "500Mi"
+    limits:
+      memory: "8Gi"

--- a/.test-defs/e2eFast.yaml
+++ b/.test-defs/e2eFast.yaml
@@ -41,3 +41,8 @@ spec:
     export GARDEN_KUBECONFIG_PATH=$TM_KUBECONFIG_PATH/gardener.config &&
     go run -mod=vendor ./integration-tests/e2e --cleanUpAfterwards=true --flakeAttempts=5 --retryFailedTestcases=true
   image: golang:1.13
+  resources:
+    requests:
+      memory: "500Mi"
+    limits:
+      memory: "8Gi"

--- a/.test-defs/e2eSlow.yaml
+++ b/.test-defs/e2eSlow.yaml
@@ -42,3 +42,8 @@ spec:
     export GARDEN_KUBECONFIG_PATH=$TM_KUBECONFIG_PATH/gardener.config &&
     go run -mod=vendor ./integration-tests/e2e --cleanUpAfterwards=true --flakeAttempts=5 --retryFailedTestcases=true
   image: golang:1.13
+  resources:
+    requests:
+      memory: "500Mi"
+    limits:
+      memory: "8Gi"

--- a/.test-defs/e2eUntracked.yaml
+++ b/.test-defs/e2eUntracked.yaml
@@ -48,3 +48,8 @@ spec:
     export GARDEN_KUBECONFIG_PATH=$TM_KUBECONFIG_PATH/gardener.config &&
     go run -mod=vendor ./integration-tests/e2e --cleanUpAfterwards=true --flakeAttempts=5
   image: golang:1.13
+  resources:
+    requests:
+      memory: "500Mi"
+    limits:
+      memory: "8Gi"


### PR DESCRIPTION
**What this PR does / why we need it**:
increase memory limits for k8s e2e test steps, because sometimes an OOM appeared

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```
NONE
```
