### PR TITLE
prevent redundant elasticsearch ingestions

### DIFF
--- a/cmd/testrunner/cmd/collect/collect.go
+++ b/cmd/testrunner/cmd/collect/collect.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gardener/test-infra/pkg/logger"
 	"github.com/gardener/test-infra/pkg/testmachinery"
 	"github.com/gardener/test-infra/pkg/testrunner/result"
+	"github.com/gardener/test-infra/pkg/util/elasticsearch"
 	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -48,6 +49,7 @@ var (
 	githubPassword          string
 	uploadStatusAsset       bool
 	assetPrefix             string
+	esConfig = elasticsearch.Config{}
 )
 
 // AddCommand adds collect to a command.
@@ -76,6 +78,11 @@ var collectCmd = &cobra.Command{
 			UploadStatusAsset:       uploadStatusAsset,
 			AssetPrefix:             assetPrefix,
 		}
+
+		if esConfig.Endpoint != "" {
+			collectConfig.ESConfig = &esConfig
+		}
+
 		logger.Log.V(3).Info(util.PrettyPrintStruct(collectConfig))
 
 		tmClient, err := kubernetes.NewClientFromFile("", tmKubeconfigPath, kubernetes.WithClientOptions(client.Options{
@@ -129,7 +136,10 @@ func init() {
 
 	// parameter flags
 	collectCmd.Flags().StringVarP(&outputDirPath, "output-dir-path", "o", "./testout", "The filepath where the summary should be written to.")
-	collectCmd.Flags().StringVar(&elasticSearchConfigName, "es-config-name", "", "The elasticsearch secret-server config name.")
+	collectCmd.Flags().StringVar(&elasticSearchConfigName, "es-config-name", "", "DEPRECATED: The elasticsearch secret-server config name.")
+	collectCmd.Flags().StringVar(&esConfig.Endpoint, "es-endpoint", "", "endpoint of the elasticsearch instance")
+	collectCmd.Flags().StringVar(&esConfig.Username, "es-username", "", "username to authenticate against a elasticsearch instance")
+	collectCmd.Flags().StringVar(&esConfig.Password, "es-password", "", "password to authenticate against a elasticsearch instance")
 	collectCmd.Flags().StringVar(&s3Endpoint, "s3-endpoint", os.Getenv("S3_ENDPOINT"), "S3 endpoint of the testmachinery cluster.")
 	collectCmd.Flags().BoolVar(&s3SSL, "s3-ssl", false, "S3 has SSL enabled.")
 	collectCmd.Flags().StringVar(&concourseOnErrorDir, "concourse-onError-dir", os.Getenv("ON_ERROR_DIR"), "On error dir which is used by Concourse.")

--- a/cmd/testrunner/cmd/run_template/run_template.go
+++ b/cmd/testrunner/cmd/run_template/run_template.go
@@ -171,7 +171,7 @@ func init() {
 	runCmd.Flags().DurationVar(&testrunnerConfig.BackoffPeriod, "backoff-period", 0, "Time to wait between the creation of testrun buckets")
 
 	runCmd.Flags().StringVar(&collectConfig.OutputDir, "output-dir-path", "./testout", "The filepath where the summary should be written to.")
-	runCmd.Flags().StringVar(&collectConfig.ESConfigName, "es-config-name", "sap_internal", "DEPRECTED: The elasticsearch secret-server config name.")
+	runCmd.Flags().StringVar(&collectConfig.ESConfigName, "es-config-name", "sap_internal", "DEPRECATED: The elasticsearch secret-server config name.")
 	runCmd.Flags().StringVar(&esConfig.Endpoint, "es-endpoint", "", "endpoint of the elasticsearch instance")
 	runCmd.Flags().StringVar(&esConfig.Username, "es-username", "", "username to authenticate against a elasticsearch instance")
 	runCmd.Flags().StringVar(&esConfig.Password, "es-password", "", "password to authenticate against a elasticsearch instance")

--- a/pkg/testrunner/result/collect.go
+++ b/pkg/testrunner/result/collect.go
@@ -16,22 +16,21 @@ package result
 
 import (
 	"fmt"
+	tmv1beta1 "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
 	"github.com/gardener/test-infra/pkg/common"
 	telemetrycommon "github.com/gardener/test-infra/pkg/shoot-telemetry/common"
+	"github.com/gardener/test-infra/pkg/testrunner"
+	"github.com/gardener/test-infra/pkg/testrunner/componentdescriptor"
+	trerrors "github.com/gardener/test-infra/pkg/testrunner/error"
 	"github.com/gardener/test-infra/pkg/tm-bot/plugins/errors"
+	"github.com/gardener/test-infra/pkg/util"
 	"github.com/gardener/test-infra/pkg/util/output"
+	"github.com/go-logr/logr"
+	"github.com/hashicorp/go-multierror"
 	"math"
 	"os"
 	"path/filepath"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	tmv1beta1 "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
-	"github.com/gardener/test-infra/pkg/testrunner"
-	"github.com/gardener/test-infra/pkg/testrunner/componentdescriptor"
-	trerrors "github.com/gardener/test-infra/pkg/testrunner/error"
-	"github.com/gardener/test-infra/pkg/util"
-	"github.com/go-logr/logr"
-	"github.com/hashicorp/go-multierror"
 )
 
 // Collect collects results of all testruns and writes them to a file.
@@ -90,6 +89,9 @@ func (c *Collector) ingestIntoElasticsearch(cfg Config, runLogger logr.Logger, t
 		return nil
 	}
 	if util.HasLabel(run.Testrun.ObjectMeta, common.LabelIngested) {
+		return nil
+	}
+	if util.DocExists(runLogger, cfg.ESConfig, run.Metadata.Testrun.ID, run.Testrun.Status.StartTime.UTC().Format("2006-01-02T15:04:05Z")) {
 		return nil
 	}
 	err := IngestDir(runLogger, cfg.OutputDir, cfg.ESConfigName, cfg.ESConfig)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -404,7 +404,7 @@ func Zipit(source, target string) error {
 
 // DocExists checks whether an elasticsearch doc of a testrun exists in index testmachinery-* index
 func DocExists(log logr.Logger, esConfig *elasticsearch.Config, testrunID, testrunStartTime string) (docExists bool) {
-	log.Info("check if docs have already been ingested")
+	log.V(2).Info("check if docs have already been ingested")
 
 	payload := fmt.Sprintf(`{
 			"size": 0,


### PR DESCRIPTION
**What this PR does / why we need it**:
prevent redundant elasticsearch ingestions

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```
NONE
```
