### PR TITLE
order steps in testrunner table output

### DIFF
--- a/pkg/testrunner/list.go
+++ b/pkg/testrunner/list.go
@@ -152,6 +152,7 @@ func (rl RunList) RenderTable() string {
 		}
 		dimensions[dimension] = append(dimensions[dimension], []string{"", name})
 
+		util.OrderStepsStatus(tr.Status.Steps)
 		for _, s := range tr.Status.Steps {
 			d := time.Duration(s.Duration) * time.Second
 			dimensions[dimension] = append(dimensions[dimension], []string{"", "", s.TestDefinition.Name, s.Position.Step, string(s.Phase), d.String()})

--- a/pkg/tm-bot/ui/pages/Runs.go
+++ b/pkg/tm-bot/ui/pages/Runs.go
@@ -121,7 +121,7 @@ func NewTestrunsPage(p *Page) http.HandlerFunc {
 			d := time.Duration(tr.Status.Duration) * time.Second
 			if tr.Status.Duration == 0 {
 				d = time.Now().Sub(tr.Status.StartTime.Time)
-				d = d/time.Second*time.Second // remove unnecessary milliseconds
+				d = d / time.Second * time.Second // remove unnecessary milliseconds
 			}
 
 			testrunsList[i] = testrunItem{
@@ -187,7 +187,7 @@ func NewTestrunPage(p *Page) http.HandlerFunc {
 		d := time.Duration(tr.Status.Duration) * time.Second
 		if tr.Status.Duration == 0 {
 			d = time.Now().Sub(tr.Status.StartTime.Time)
-			d = d/time.Second*time.Second // remove unnecessary milliseconds
+			d = d / time.Second * time.Second // remove unnecessary milliseconds
 		}
 
 		statusTable := &strings.Builder{}

--- a/pkg/tm-bot/ui/pages/Runs.go
+++ b/pkg/tm-bot/ui/pages/Runs.go
@@ -117,7 +117,13 @@ func NewTestrunsPage(p *Page) http.HandlerFunc {
 			if tr.Status.StartTime != nil {
 				startTime = tr.Status.StartTime.Format(time.RFC822)
 			}
+
 			d := time.Duration(tr.Status.Duration) * time.Second
+			if tr.Status.Duration == 0 {
+				d = time.Now().Sub(tr.Status.StartTime.Time)
+				d = d/time.Second*time.Second // remove unnecessary milliseconds
+			}
+
 			testrunsList[i] = testrunItem{
 				testrun:   &testrun,
 				ID:        tr.GetName(),
@@ -179,6 +185,10 @@ func NewTestrunPage(p *Page) http.HandlerFunc {
 			startTime = tr.Status.StartTime.Format(time.RFC822)
 		}
 		d := time.Duration(tr.Status.Duration) * time.Second
+		if tr.Status.Duration == 0 {
+			d = time.Now().Sub(tr.Status.StartTime.Time)
+			d = d/time.Second*time.Second // remove unnecessary milliseconds
+		}
 
 		statusTable := &strings.Builder{}
 		if len(tr.Status.Steps) != 0 {

--- a/pkg/tm-bot/ui/pages/Runs.go
+++ b/pkg/tm-bot/ui/pages/Runs.go
@@ -223,6 +223,10 @@ func NewTestrunPage(p *Page) http.HandlerFunc {
 				startTime = step.StartTime.Format(time.RFC822)
 			}
 			d := time.Duration(step.Duration) * time.Second
+			if step.Duration == 0 {
+				d = time.Now().Sub(step.StartTime.Time)
+				d = d / time.Second * time.Second // remove unnecessary milliseconds
+			}
 			item.Steps[i] = testrunStepStatusItem{
 				step:      step,
 				Name:      step.TestDefinition.Name,

--- a/pkg/tm-bot/ui/static/style.css
+++ b/pkg/tm-bot/ui/static/style.css
@@ -67,6 +67,10 @@ ul.noBullets li {
     border: #fff 1px solid;
 }
 
+.mdl-layout__header .username {
+    margin-right: 10px;
+}
+
 .commandhelp-card-wide {
     width: 50%;
     margin: 10px auto;

--- a/pkg/tm-bot/ui/templates/base.html
+++ b/pkg/tm-bot/ui/templates/base.html
@@ -23,7 +23,8 @@
             <span class="mdl-layout-title header-title">{{block "pageTitle" .Arguments}}{{template "title" .}}{{end}}</span>
             <div class="mdl-layout-spacer"></div>
             {{ if .Authenticated }}
-                <div>{{ .User.Name }}</div>
+                <div class="username">{{ .User.Name }}</div>
+                <a class="mdl-button mdl-js-button login-btn" href="/logout">Logout</a>
             {{ else }}
                 <a class="mdl-button mdl-js-button login-btn" href="/login">Login</a>
             {{ end }}

--- a/pkg/tm-bot/ui/ui.go
+++ b/pkg/tm-bot/ui/ui.go
@@ -30,6 +30,7 @@ func Serve(log logr.Logger, runs *tests.Runs, basePath string, a auth.Provider, 
 
 	r.HandleFunc("/oauth/redirect", a.Redirect)
 	r.HandleFunc("/login", a.Login)
+	r.HandleFunc("/logout", a.Logout)
 
 	page := pages.New(log, runs, a, basePath)
 

--- a/pkg/util/testrun.go
+++ b/pkg/util/testrun.go
@@ -18,38 +18,39 @@ import (
 	"context"
 	"fmt"
 	argov1alpha1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
-	"github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
+	tmv1beta1 "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
 	"github.com/gardener/test-infra/pkg/common"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sort"
 )
 
 // TestrunStatusPhase determines the real testrun phase of a testrun by ignoring exit handler failures and system component failures if all other tests passed.
-func TestrunStatusPhase(tr *v1beta1.Testrun) argov1alpha1.NodePhase {
-	if tr.Status.Phase == v1beta1.PhaseStatusSuccess {
-		return v1beta1.PhaseStatusSuccess
+func TestrunStatusPhase(tr *tmv1beta1.Testrun) argov1alpha1.NodePhase {
+	if tr.Status.Phase == tmv1beta1.PhaseStatusSuccess {
+		return tmv1beta1.PhaseStatusSuccess
 	}
 
 	stepsRun := false
 	for _, step := range tr.Status.Steps {
-		if !stepsRun && (step.Phase != v1beta1.PhaseStatusInit && step.Phase != v1beta1.PhaseStatusSkipped) {
+		if !stepsRun && (step.Phase != tmv1beta1.PhaseStatusInit && step.Phase != tmv1beta1.PhaseStatusSkipped) {
 			stepsRun = true
 		}
-		if step.Phase == v1beta1.PhaseStatusInit || step.Phase == v1beta1.PhaseStatusSkipped {
+		if step.Phase == tmv1beta1.PhaseStatusInit || step.Phase == tmv1beta1.PhaseStatusSkipped {
 			continue
 		}
-		if step.Phase != v1beta1.PhaseStatusSuccess && step.Annotations[common.AnnotationSystemStep] != "true" {
+		if step.Phase != tmv1beta1.PhaseStatusSuccess && step.Annotations[common.AnnotationSystemStep] != "true" {
 			return step.Phase
 		}
 	}
 
 	if stepsRun {
-		return v1beta1.PhaseStatusSuccess
+		return tmv1beta1.PhaseStatusSuccess
 	}
 
 	return tr.Status.Phase
 }
 
-func IsSystemStep(step *v1beta1.StepStatus) bool {
+func IsSystemStep(step *tmv1beta1.StepStatus) bool {
 	if len(step.Annotations) == 0 {
 		return false
 	}
@@ -60,7 +61,7 @@ func IsSystemStep(step *v1beta1.StepStatus) bool {
 }
 
 // Resume testruns resumes a testrun by adding the appropriate annotation to it
-func ResumeTestrun(ctx context.Context, k8sClient client.Client, tr *v1beta1.Testrun) error {
+func ResumeTestrun(ctx context.Context, k8sClient client.Client, tr *tmv1beta1.Testrun) error {
 	obj, err := client.ObjectKeyFromObject(tr)
 	if err != nil {
 		return err
@@ -80,17 +81,33 @@ func ResumeTestrun(ctx context.Context, k8sClient client.Client, tr *v1beta1.Tes
 }
 
 // TestrunProgress returns the progress of a testrun
-func TestrunProgress(tr *v1beta1.Testrun) string {
+func TestrunProgress(tr *tmv1beta1.Testrun) string {
 	allSteps := 0
 	completedSteps := 0
 	for _, step := range tr.Status.Steps {
 		if step.Annotations[common.AnnotationSystemStep] != "true" {
 			allSteps++
-			if step.Phase != v1beta1.PhaseStatusSkipped && Completed(step.Phase) {
+			if step.Phase != tmv1beta1.PhaseStatusSkipped && Completed(step.Phase) {
 				completedSteps++
 			}
 		}
 	}
 
 	return fmt.Sprintf("%d/%d", completedSteps, allSteps)
+}
+
+// OrderStepsStatus orders a list of step status of a testrun
+func OrderStepsStatus(steps []*tmv1beta1.StepStatus) {
+	sort.Sort(stepStatusList(steps))
+}
+
+type stepStatusList []*tmv1beta1.StepStatus
+
+func (l stepStatusList) Len() int      { return len(l) }
+func (l stepStatusList) Swap(i, j int) { l[i], l[j] = l[j], l[i] }
+func (l stepStatusList) Less(i, j int) bool {
+	if l[i].StartTime == nil || l[j].StartTime == nil {
+		return true
+	}
+	return l[j].StartTime.Before(l[i].StartTime)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Improved multiple minor things:
- testruns status teps are now ordered in the testrunner table
- when the duration of testruns is 0 the TM Dashboard now shows the elapsed time since the starttime
- add the possibility to logout of the TM Dashboard
- set the maxAge for tm dashboard cookies to 48h

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
Status steps are now ordered by their starttime
```
```improvement user
Status steps are now ordered by their starttime
```
```improvement user
The TestMachinery Dashboard does now show the elapsed time in the duration field of the testruns table
```
```improvement user
TestMachinery Dashboard users can now logout themselves
```
