### PR TITLE
Support multiple set values for template rendering

### DIFF
--- a/cmd/testrunner/cmd/run_template/run_template.go
+++ b/cmd/testrunner/cmd/run_template/run_template.go
@@ -212,7 +212,7 @@ func init() {
 	runCmd.Flags().StringVar(&shootParameters.ComponentDescriptorPath, "component-descriptor-path", "", "Path to the component descriptor (BOM) of the current landscape.")
 	runCmd.Flags().StringVar(&shootParameters.Landscape, "landscape", "", "Current gardener landscape.")
 
-	runCmd.Flags().StringVar(&shootParameters.SetValues, "set", "", "setValues additional helm values")
+	runCmd.Flags().StringArrayVar(&shootParameters.SetValues, "set", make([]string, 0), "setValues additional helm values")
 	runCmd.Flags().StringArrayVarP(&shootParameters.FileValues, "values", "f", make([]string, 0), "yaml value files to override template values")
 
 	// DEPRECATED FLAGS

--- a/pkg/testrunner/template/renderer.go
+++ b/pkg/testrunner/template/renderer.go
@@ -38,7 +38,7 @@ type renderState struct {
 	parameters *internalParameters
 }
 
-func newTemplateRenderer(log logr.Logger, setValues string, fileValues []string) (*templateRenderer, error) {
+func newTemplateRenderer(log logr.Logger, setValues, fileValues []string) (*templateRenderer, error) {
 	chartRenderer := engine.New()
 	values, err := determineDefaultValues(setValues, fileValues)
 	if err != nil {
@@ -169,16 +169,19 @@ func (s *renderState) Rerender(tr *v1beta1.Testrun) (*testrunner.Run, error) {
 
 // determineDefaultValues fetches values from all specified files and set values.
 // The values are merged whereas set values overwrite file values.
-func determineDefaultValues(setValues string, fileValues []string) (map[string]interface{}, error) {
+func determineDefaultValues(setValues []string, fileValues []string) (map[string]interface{}, error) {
 	values, err := readFileValues(fileValues)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to read values from file")
 	}
-	newSetValues, err := strvals.ParseString(setValues)
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to parse set values")
+
+	for _, val := range setValues {
+		newSetValues, err := strvals.ParseString(val)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to parse set values")
+		}
+		values = utils.MergeMaps(values, newSetValues)
 	}
-	values = utils.MergeMaps(values, newSetValues)
 	return values, nil
 }
 

--- a/pkg/testrunner/template/template_test.go
+++ b/pkg/testrunner/template/template_test.go
@@ -40,7 +40,18 @@ var _ = Describe("default templates", func() {
 			GardenKubeconfigPath:    gardenerKubeconfig,
 			DefaultTestrunChartPath: filepath.Join(defaultTestdataDir, "add-values"),
 			ComponentDescriptorPath: componentDescriptorPath,
-			SetValues:               "addValue1=test,addValue2=test2",
+			SetValues:               []string{"addValue1=test,addValue2=test2"},
+		}
+		_, err := RenderTestruns(log.NullLogger{}, params, nil)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should render multiple additional values to the chart", func() {
+		params := &Parameters{
+			GardenKubeconfigPath:    gardenerKubeconfig,
+			DefaultTestrunChartPath: filepath.Join(defaultTestdataDir, "add-values"),
+			ComponentDescriptorPath: componentDescriptorPath,
+			SetValues:               []string{"addValue1=test", "addValue2=test2"},
 		}
 		_, err := RenderTestruns(log.NullLogger{}, params, nil)
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/testrunner/template/types.go
+++ b/pkg/testrunner/template/types.go
@@ -32,7 +32,7 @@ type Parameters struct {
 	Landscape               string
 	ComponentDescriptorPath string
 
-	SetValues  string
+	SetValues  []string
 	FileValues []string
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Support for multiple set values has been added. Values can now be specified by multiple set flags: `testrunner run-template --set="value1=test" --set="value2=true"`
```
