### PR TITLE
Fix git checkout issue if brnach is also a file

### DIFF
--- a/cmd/prepare/prepare.go
+++ b/cmd/prepare/prepare.go
@@ -130,7 +130,7 @@ func cloneRepository(log logr.Logger, repo *prepare.Repository, repoBasePath str
 		return err
 	}
 
-	if err := runCommand(log, repoPath, "git", "checkout", repo.Revision); err != nil {
+	if err := runCommand(log, repoPath, "git", "checkout", repo.Revision, "--"); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a git checkout error that occurs when the specified revision is also a valid file.
Now using `--` will specify that no file is matched.

`Please use -- (and optionally --no-guess) to disambiguate`

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Fix a git checkout issue if the revision name is also a valid path
```
