### PR TITLE
Various testrunner improvements

### DIFF
--- a/charts/testmachinery/templates/deployment-tm-controller.yaml
+++ b/charts/testmachinery/templates/deployment-tm-controller.yaml
@@ -68,13 +68,13 @@ spec:
             path: /healthz
             port: {{.Values.controller.healthEndpointPort}}
           initialDelaySeconds: 3
-          periodSeconds: 5
+          periodSeconds: 60
         readinessProbe:
           httpGet:
             path: /healthz
             port: {{.Values.controller.healthEndpointPort}}
           initialDelaySeconds: 3
-          periodSeconds: 3
+          periodSeconds: 60
         volumeMounts:
         - name: config
           mountPath: /etc/testmachinery/config

--- a/cmd/testrunner/cmd/notify/notify.go
+++ b/cmd/testrunner/cmd/notify/notify.go
@@ -129,9 +129,13 @@ func parseOverviewToTableItems(overview result.AssetOverview) (tableItems util.T
 			// skip gardener tests
 			continue
 		} else {
+			status := util.StatusSymbolFailure
+			if overviewItem.Successful {
+				status = util.StatusSymbolSuccess
+			}
 			item := &util.TableItem{
-				Meta:    util.ItemMeta{CloudProvider: meta.Cloudprovider, TestrunID: overviewItem.Name, OperatingSystem: meta.OperatingSystem, KubernetesVersion: meta.KubernetesVersion, FlavorDescription: meta.Description},
-				Success: overviewItem.Successful,
+				Meta:         util.ItemMeta{CloudProvider: meta.Cloudprovider, TestrunID: overviewItem.Name, OperatingSystem: meta.OperatingSystem, KubernetesVersion: meta.KubernetesVersion, FlavorDescription: meta.Description},
+				StatusSymbol: status,
 			}
 			tableItems = append(tableItems, item)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Made various improvements to the testrunner to be more resilient.

Also added more status symbols to indicate testmachinery failures.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Status symbols for test execution and unknown errors were added to the status table for slack alerting
```

```improvement user
The testrunner now retires create operation for tests for 5 minutes to be more resilient against temporary testmachinery controller unavailability.
```
