### PR TITLE
Improve status uploader error reporting and ignore file deletion error if file does not exist

### DIFF
--- a/cmd/testrunner/cmd/notify/notify.go
+++ b/cmd/testrunner/cmd/notify/notify.go
@@ -73,7 +73,7 @@ var notifyCmd = &cobra.Command{
 			os.Exit(1)
 		}
 		if len(overview.AssetOverviewItems) == 0 {
-			logger.Log.Error(nil, "overview sset does not exist")
+			logger.Log.Error(nil, "overview asset does not exist")
 			os.Exit(1)
 		}
 

--- a/pkg/testrunner/result/collect.go
+++ b/pkg/testrunner/result/collect.go
@@ -105,10 +105,13 @@ func (c *Collector) uploadStatusAssets(cfg Config, log logr.Logger, runs testrun
 		log.Error(err, "unable to get component for upload")
 		return
 	}
-	if err := UploadStatusToGithub(log.WithName("github-upload"), runs, componentsForUpload, cfg.GithubUser, cfg.GithubPassword, cfg.AssetPrefix); err == nil {
-		if err := MarkTestrunsAsUploadedToGithub(log, tmClient, runs); err != nil {
-			log.Error(err, "unable to mark testrun status as uploaded to github")
-		}
+	if err := UploadStatusToGithub(log.WithName("github-upload"), runs, componentsForUpload, cfg.GithubUser, cfg.GithubPassword, cfg.AssetPrefix); err != nil {
+		log.Error(err, "unable to upload status to github")
+		return
+	}
+
+	if err := MarkTestrunsAsUploadedToGithub(log, tmClient, runs); err != nil {
+		log.Error(err, "unable to mark testrun status as uploaded to github")
 	}
 	return
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
- silent errors now correctly report the error while github asset upload.
- fixed wrong error handling for non existing files that should be removed

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Error reporting for the github asset uploaded has been improved
```
