### PR TITLE
Left align slack status upload table

### DIFF
--- a/pkg/util/slack-table-post.go
+++ b/pkg/util/slack-table-post.go
@@ -23,6 +23,9 @@ import (
 	"strings"
 )
 
+// SymbolOffset is the offset that the symbol is prefixed for better readability
+const SymbolOffset = " "
+
 // StatusSymbol is a unicode symbol for dieplaying in a table
 type StatusSymbol string
 
@@ -97,7 +100,8 @@ func RenderTableForSlack(log logr.Logger, items TableItems) (string, error) {
 
 	table.SetHeader(header)
 	table.AppendBulk(res.GetContent())
-	table.SetAlignment(tablewriter.ALIGN_CENTER)
+	table.SetHeaderAlignment(tablewriter.ALIGN_CENTER)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
 	table.Render()
 	return writer.String(), nil
 }
@@ -113,14 +117,14 @@ func (r *results) AddResult(meta ItemMeta, symbol StatusSymbol) {
 		content := make([]string, len(r.header)+1)
 		content[0] = key
 		for i := 1; i < len(content); i++ {
-			content[i] = string(StatusSymbolNA)
+			content[i] = SymbolOffset + string(StatusSymbolNA)
 		}
 		r.content[key] = resultRow{
 			dimension: meta,
 			content:   content,
 		}
 	}
-	r.content[key].content[cpIndex] = string(symbol)
+	r.content[key].content[cpIndex] = SymbolOffset + string(symbol)
 }
 
 func computeDimensionKey(meta ItemMeta) string {


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
The content of teh slack status table for execution groups is now left aligned
```
