### PR TITLE
Add validation to reject testrun where a label is defined that does not match any testdef

### DIFF
--- a/pkg/testmachinery/testflow/validation.go
+++ b/pkg/testmachinery/testflow/validation.go
@@ -81,6 +81,11 @@ func Validate(identifier string, tf tmv1beta1.TestFlow, locs locations.Locations
 			return err
 		}
 
+		// fail if there are no testdefinitions found
+		if len(testDefinitions) == 0 {
+			return fmt.Errorf("%s.Definition: no TestDefinition found", identifier)
+		}
+
 		for _, td := range testDefinitions {
 			if err := testdefinition.Validate(fmt.Sprintf("%s; Location: \"%s\"; File: \"%s\"", identifier, td.Location.Name(), td.FileName), td.Info); err != nil {
 				return err

--- a/pkg/testmachinery/testflow/validation_test.go
+++ b/pkg/testmachinery/testflow/validation_test.go
@@ -50,6 +50,24 @@ var _ = Describe("Testflow", func() {
 			Expect(testflow.Validate("identifier", tf, defaultMockLocation, true)).To(HaveOccurred())
 		})
 
+		It("should fail when a test step specifies a label with non existent testdefinitions", func() {
+			tf := tmv1beta1.TestFlow{
+				{
+					Name: "int-test",
+					Definition: tmv1beta1.StepDefinition{
+						Label: "somelabel",
+					},
+				},
+				{
+					Name: "int-test",
+					Definition: tmv1beta1.StepDefinition{
+						Name: "testdefname",
+					},
+				},
+			}
+			Expect(testflow.Validate("identifier", tf, emptyMockLocation, true)).To(HaveOccurred())
+		})
+
 		It("should fail when dependent steps do not exist", func() {
 			tf := tmv1beta1.TestFlow{
 				{
@@ -292,6 +310,12 @@ func (l *locationMock) SetTestDefs(_ map[string]*testdefinition.TestDefinition) 
 
 func (l *locationMock) GetLocation() *tmv1beta1.TestLocation {
 	return nil
+}
+
+var emptyMockLocation = &testDefinitionsMock{
+	getTestDefinitions: func(step tmv1beta1.StepDefinition) ([]*testdefinition.TestDefinition, error) {
+		return []*testdefinition.TestDefinition{}, nil
+	},
 }
 
 var defaultMockLocation = &testDefinitionsMock{


### PR DESCRIPTION
**What this PR does / why we need it**:

Partially fixes https://github.com/gardener/test-infra/issues/270 but we should definitely think of just ignoring steps that do not contain a test

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
Users are no unable to create testruns with a step that contains not tests
```
