### PR TITLE
add allowPrivilegedContainers to flavors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ run-it-tests:
 
 .PHONY: validate
 validate:
-	@go run cmd/local-validator/main.go -testrun=${TESTRUN}
+	@go run cmd/local-validator/main.go --testrun=${TESTRUN}
 
 
 ##################################

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -69,6 +69,9 @@ const (
 	// AnnotationZone is the annotation to specify the zone of the shoot the testrun is testing
 	AnnotationZone = "metadata.testmachinery.gardener.cloud/zone"
 
+	// AnnotationAllowPrivilegedContainers is the annotation describing whether and how created shoots will have allowPrivilegedContainers configured
+	AnnotationAllowPrivilegedContainers = "metadata.testmachinery.gardener.cloud/allow-privileged-containers"
+
 	// AnnotationFlavorDescription is the annotation to describe the test flavor of the current run testrun
 	AnnotationFlavorDescription = "metadata.testmachinery.gardener.cloud/flavor-description"
 

--- a/pkg/common/types_shootflavor.go
+++ b/pkg/common/types_shootflavor.go
@@ -47,6 +47,9 @@ type Shoot struct {
 	// Kubernetes versions to test
 	KubernetesVersion gardencorev1beta1.ExpirableVersion
 
+	// AllowPrivilegedContainers defines whether privileged containers will be allowed in the given shoot or not
+	AllowPrivilegedContainers string
+
 	// Worker pools to test
 	Workers []gardencorev1beta1.Worker
 }
@@ -62,6 +65,10 @@ type ShootFlavor struct {
 
 	// Kubernetes versions to test
 	KubernetesVersions ShootKubernetesVersionFlavor `json:"kubernetes"`
+
+	// AllowPrivilegedContainers defines whether privileged containers will be allowed in the given shoot or not
+	// +optional
+	AllowPrivilegedContainers string `json:"allowPrivilegedContainers"`
 
 	// Worker pools to test
 	Workers []ShootWorkerFlavor `json:"workers"`

--- a/pkg/common/types_shootflavor.go
+++ b/pkg/common/types_shootflavor.go
@@ -48,7 +48,7 @@ type Shoot struct {
 	KubernetesVersion gardencorev1beta1.ExpirableVersion
 
 	// AllowPrivilegedContainers defines whether privileged containers will be allowed in the given shoot or not
-	AllowPrivilegedContainers string
+	AllowPrivilegedContainers *bool
 
 	// Worker pools to test
 	Workers []gardencorev1beta1.Worker
@@ -68,7 +68,7 @@ type ShootFlavor struct {
 
 	// AllowPrivilegedContainers defines whether privileged containers will be allowed in the given shoot or not
 	// +optional
-	AllowPrivilegedContainers string `json:"allowPrivilegedContainers"`
+	AllowPrivilegedContainers *bool `json:"allowPrivilegedContainers"`
 
 	// Worker pools to test
 	Workers []ShootWorkerFlavor `json:"workers"`

--- a/pkg/shootflavors/extendedflavors.go
+++ b/pkg/shootflavors/extendedflavors.go
@@ -91,10 +91,11 @@ func NewExtended(k8sClient client.Client, rawFlavors []*common.ExtendedShootFlav
 				shoots = append(shoots, &ExtendedFlavorInstance{
 					shoot: &common.ExtendedShoot{
 						Shoot: common.Shoot{
-							Description:       rawFlavor.Description,
-							Provider:          rawFlavor.Provider,
-							KubernetesVersion: k8sVersion,
-							Workers:           pools,
+							Description:               rawFlavor.Description,
+							Provider:                  rawFlavor.Provider,
+							KubernetesVersion:         k8sVersion,
+							AllowPrivilegedContainers: rawFlavor.AllowPrivilegedContainers,
+							Workers:                   pools,
 						},
 						ExtendedShootConfiguration: common.ExtendedShootConfiguration{
 							Name:                  fmt.Sprintf("%s%s", shootPrefix, util.RandomString(3)),

--- a/pkg/shootflavors/extendedflavors_test.go
+++ b/pkg/shootflavors/extendedflavors_test.go
@@ -85,6 +85,7 @@ var _ = Describe("extended flavor test", func() {
 		rawFlavors := []*common.ExtendedShootFlavor{{
 			ExtendedConfiguration: defaultExtendedCfg,
 			ShootFlavor: common.ShootFlavor{
+				AllowPrivilegedContainers: "true",
 				Provider: common.CloudProviderGCP,
 				KubernetesVersions: common.ShootKubernetesVersionFlavor{
 					Versions: &[]gardencorev1beta1.ExpirableVersion{
@@ -109,6 +110,7 @@ var _ = Describe("extended flavor test", func() {
 		shoot := flavors.GetShoots()[0]
 		Expect(shoot.Get().Shoot).To(Equal(common.Shoot{
 			Provider:          common.CloudProviderGCP,
+			AllowPrivilegedContainers: "true",
 			KubernetesVersion: gardencorev1beta1.ExpirableVersion{Version: "1.15"},
 			Workers:           []gardencorev1beta1.Worker{{Name: "wp1"}},
 		}))

--- a/pkg/shootflavors/extendedflavors_test.go
+++ b/pkg/shootflavors/extendedflavors_test.go
@@ -85,7 +85,7 @@ var _ = Describe("extended flavor test", func() {
 		rawFlavors := []*common.ExtendedShootFlavor{{
 			ExtendedConfiguration: defaultExtendedCfg,
 			ShootFlavor: common.ShootFlavor{
-				AllowPrivilegedContainers: "true",
+				AllowPrivilegedContainers: pointer.BoolPtr(true),
 				Provider: common.CloudProviderGCP,
 				KubernetesVersions: common.ShootKubernetesVersionFlavor{
 					Versions: &[]gardencorev1beta1.ExpirableVersion{
@@ -110,7 +110,7 @@ var _ = Describe("extended flavor test", func() {
 		shoot := flavors.GetShoots()[0]
 		Expect(shoot.Get().Shoot).To(Equal(common.Shoot{
 			Provider:          common.CloudProviderGCP,
-			AllowPrivilegedContainers: "true",
+			AllowPrivilegedContainers: pointer.BoolPtr(true),
 			KubernetesVersion: gardencorev1beta1.ExpirableVersion{Version: "1.15"},
 			Workers:           []gardencorev1beta1.Worker{{Name: "wp1"}},
 		}))

--- a/pkg/shootflavors/flavors.go
+++ b/pkg/shootflavors/flavors.go
@@ -84,6 +84,7 @@ func New(rawFlavors []*common.ShootFlavor) (*Flavors, error) {
 					shoots = append(shoots, &common.Shoot{
 						Provider:          rawFlavor.Provider,
 						KubernetesVersion: k8sVersion,
+						AllowPrivilegedContainers: rawFlavor.AllowPrivilegedContainers,
 						Workers:           workers.WorkerPools,
 					})
 				}
@@ -92,6 +93,7 @@ func New(rawFlavors []*common.ShootFlavor) (*Flavors, error) {
 			shoots = append(shoots, &common.Shoot{
 				Provider:          rawFlavor.Provider,
 				KubernetesVersion: k8sVersion,
+				AllowPrivilegedContainers: rawFlavor.AllowPrivilegedContainers,
 			})
 		}
 	}

--- a/pkg/shootflavors/flavors_test.go
+++ b/pkg/shootflavors/flavors_test.go
@@ -76,6 +76,32 @@ var _ = Describe("flavor test", func() {
 		))
 	})
 
+	It("should return one shoot with disabled allowPrivilegeContainers", func() {
+		rawFlavors := []*common.ShootFlavor{
+			{
+				Provider: common.CloudProviderGCP,
+				AllowPrivilegedContainers: "false",
+				KubernetesVersions: common.ShootKubernetesVersionFlavor{
+					Versions: &[]gardencorev1beta1.ExpirableVersion{
+						{
+							Version: "1.15",
+						},
+					},
+				},
+			},
+		}
+		flavors, err := New(rawFlavors)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(flavors.GetShoots()).To(HaveLen(1))
+		Expect(flavors.GetShoots()).To(ConsistOf(
+			&common.Shoot{
+				Provider:          common.CloudProviderGCP,
+				AllowPrivilegedContainers: "false",
+				KubernetesVersion: gardencorev1beta1.ExpirableVersion{Version: "1.15"},
+			},
+		))
+	})
+
 	It("should return 2 gcp shoots with the specified 2 versions", func() {
 		rawFlavors := []*common.ShootFlavor{
 			{

--- a/pkg/shootflavors/flavors_test.go
+++ b/pkg/shootflavors/flavors_test.go
@@ -80,7 +80,7 @@ var _ = Describe("flavor test", func() {
 		rawFlavors := []*common.ShootFlavor{
 			{
 				Provider: common.CloudProviderGCP,
-				AllowPrivilegedContainers: "false",
+				AllowPrivilegedContainers: pointer.BoolPtr(false),
 				KubernetesVersions: common.ShootKubernetesVersionFlavor{
 					Versions: &[]gardencorev1beta1.ExpirableVersion{
 						{
@@ -96,7 +96,7 @@ var _ = Describe("flavor test", func() {
 		Expect(flavors.GetShoots()).To(ConsistOf(
 			&common.Shoot{
 				Provider:          common.CloudProviderGCP,
-				AllowPrivilegedContainers: "false",
+				AllowPrivilegedContainers: pointer.BoolPtr(false),
 				KubernetesVersion: gardencorev1beta1.ExpirableVersion{Version: "1.15"},
 			},
 		))

--- a/pkg/testmachinery/metadata/types.go
+++ b/pkg/testmachinery/metadata/types.go
@@ -26,9 +26,10 @@ type Metadata struct {
 	Region            string `json:"region,omitempty"`
 
 	// todo: schrodit - add support to better persist multiple worker pools with multiple oss, versions and zones
-	OperatingSystem        string `json:"operating_system,omitempty"`
-	OperatingSystemVersion string `json:"operating_system_version,omitempty"`
-	Zone                   string `json:"zone,omitempty"`
+	OperatingSystem           string `json:"operating_system,omitempty"`
+	OperatingSystemVersion    string `json:"operating_system_version,omitempty"`
+	Zone                      string `json:"zone,omitempty"`
+	AllowPrivilegedContainers *bool  `json:"allow_privileged_containers,omitempty"`
 
 	// ComponentDescriptor describes the current component_descriptor of the direct landscape-setup components.
 	// It is formatted as an array of components: { name: "my_component", version: "0.0.1" }

--- a/pkg/testrun_renderer/default/default.go
+++ b/pkg/testrun_renderer/default/default.go
@@ -104,9 +104,10 @@ func Render(cfg *Config) (*v1beta1.Testrun, error) {
 			Suffix:    fmt.Sprintf("%s-%s", flavor.Provider, util.RandomString(3)),
 			TestsFunc: cfg.Shoots.DefaultTest,
 			Config: &templates.CreateShootConfig{
-				ShootName:  fmt.Sprintf("%s-%s", flavor.Provider, util.RandomString(3)),
-				Namespace:  cfg.Shoots.Namespace,
-				K8sVersion: flavor.KubernetesVersion.Version,
+				ShootName:                 fmt.Sprintf("%s-%s", flavor.Provider, util.RandomString(3)),
+				Namespace:                 cfg.Shoots.Namespace,
+				K8sVersion:                flavor.KubernetesVersion.Version,
+				AllowPrivilegedContainers: flavor.AllowPrivilegedContainers,
 			},
 		})
 		for _, test := range cfg.Shoots.Tests {
@@ -115,9 +116,10 @@ func Render(cfg *Config) (*v1beta1.Testrun, error) {
 				Suffix:    fmt.Sprintf("%s-%s", flavor.Provider, util.RandomString(3)),
 				TestsFunc: test,
 				Config: &templates.CreateShootConfig{
-					ShootName:  fmt.Sprintf("%s-%s", flavor.Provider, util.RandomString(3)),
-					Namespace:  cfg.Shoots.Namespace,
-					K8sVersion: flavor.KubernetesVersion.Version,
+					ShootName:                 fmt.Sprintf("%s-%s", flavor.Provider, util.RandomString(3)),
+					Namespace:                 cfg.Shoots.Namespace,
+					K8sVersion:                flavor.KubernetesVersion.Version,
+					AllowPrivilegedContainers: flavor.AllowPrivilegedContainers,
 				},
 			})
 		}

--- a/pkg/testrun_renderer/templates/shoots.go
+++ b/pkg/testrun_renderer/templates/shoots.go
@@ -29,15 +29,16 @@ const (
 	ConfigControlplaneProviderPathName   = "CONTROLPLANE_PROVIDER_CONFIG_FILEPATH"
 	ConfigInfrastructureProviderPathName = "INFRASTRUCTURE_PROVIDER_CONFIG_FILEPATH"
 
-	ConfigShootName            = "SHOOT_NAME"
-	ConfigProjectNamespaceName = "PROJECT_NAMESPACE"
-	ConfigK8sVersionName       = "K8S_VERSION"
-	ConfigCloudproviderName    = "CLOUDPROVIDER"
-	ConfigProviderTypeName     = "PROVIDER_TYPE"
-	ConfigCloudprofileName     = "CLOUDPROFILE"
-	ConfigSecretBindingName    = "SECRET_BINDING"
-	ConfigRegionName           = "REGION"
-	ConfigZoneName             = "ZONE"
+	ConfigShootName                 = "SHOOT_NAME"
+	ConfigProjectNamespaceName      = "PROJECT_NAMESPACE"
+	ConfigK8sVersionName            = "K8S_VERSION"
+	ConfigCloudproviderName         = "CLOUDPROVIDER"
+	ConfigProviderTypeName          = "PROVIDER_TYPE"
+	ConfigAllowPrivilegedContainers = "ALLOW_PRIVILEGED_CONTAINERS"
+	ConfigCloudprofileName          = "CLOUDPROFILE"
+	ConfigSecretBindingName         = "SECRET_BINDING"
+	ConfigRegionName                = "REGION"
+	ConfigZoneName                  = "ZONE"
 )
 
 var (
@@ -47,9 +48,10 @@ var (
 
 // CreateShootConfig describes the configuration for a create-shoot step
 type CreateShootConfig struct {
-	ShootName  string
-	Namespace  string
-	K8sVersion string
+	ShootName                 string
+	Namespace                 string
+	K8sVersion                string
+	AllowPrivilegedContainers string
 }
 
 // GetStepCreateShoot generates the shoot creation step for a specific cloudprovider

--- a/pkg/testrun_renderer/templates/shoots.go
+++ b/pkg/testrun_renderer/templates/shoots.go
@@ -51,7 +51,7 @@ type CreateShootConfig struct {
 	ShootName                 string
 	Namespace                 string
 	K8sVersion                string
-	AllowPrivilegedContainers string
+	AllowPrivilegedContainers *bool
 }
 
 // GetStepCreateShoot generates the shoot creation step for a specific cloudprovider

--- a/pkg/testrun_renderer/templates/shoots_v1beta1.go
+++ b/pkg/testrun_renderer/templates/shoots_v1beta1.go
@@ -76,7 +76,7 @@ var defaultProviderConfig = []v1beta1.ConfigElement{
 }
 
 func defaultShootConfig(cfg *CreateShootConfig) []v1beta1.ConfigElement {
-	return []v1beta1.ConfigElement{
+	var defaultShootConfig = []v1beta1.ConfigElement{
 		{
 			Type:  v1beta1.ConfigTypeEnv,
 			Name:  ConfigShootName,
@@ -98,6 +98,17 @@ func defaultShootConfig(cfg *CreateShootConfig) []v1beta1.ConfigElement {
 			Value: ConfigSeedValue,
 		},
 	}
+
+	if cfg.AllowPrivilegedContainers != "" {
+		ce := v1beta1.ConfigElement{
+			Type:  v1beta1.ConfigTypeEnv,
+			Name:  ConfigAllowPrivilegedContainers,
+			Value: cfg.AllowPrivilegedContainers,
+		}
+		defaultShootConfig = append(defaultShootConfig, ce)
+	}
+
+	return defaultShootConfig
 }
 
 func v1beta1GCPShootConfig(name string, dependencies []string, cfg []v1beta1.ConfigElement) (*v1beta1.DAGStep, []v1beta1.ConfigElement) {

--- a/pkg/testrun_renderer/templates/shoots_v1beta1.go
+++ b/pkg/testrun_renderer/templates/shoots_v1beta1.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
 	"github.com/gardener/test-infra/pkg/common"
+	"strconv"
 )
 
 func stepCreateShootV1beta1(cloudprovider common.CloudProvider, name string, dependencies []string, cfg *CreateShootConfig) ([]*v1beta1.DAGStep, string, error) {
@@ -99,11 +100,11 @@ func defaultShootConfig(cfg *CreateShootConfig) []v1beta1.ConfigElement {
 		},
 	}
 
-	if cfg.AllowPrivilegedContainers != "" {
+	if cfg.AllowPrivilegedContainers != nil {
 		ce := v1beta1.ConfigElement{
 			Type:  v1beta1.ConfigTypeEnv,
 			Name:  ConfigAllowPrivilegedContainers,
-			Value: cfg.AllowPrivilegedContainers,
+			Value: strconv.FormatBool(*cfg.AllowPrivilegedContainers),
 		}
 		defaultShootConfig = append(defaultShootConfig, ce)
 	}

--- a/pkg/testrun_renderer/tests.go
+++ b/pkg/testrun_renderer/tests.go
@@ -16,7 +16,7 @@ package testrun_renderer
 
 import "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
 
-// WithTests connects mumtiple test functions to one
+// WithTests connects multiple test functions to one
 func WithTests(funcs ...TestsFunc) TestsFunc {
 	return func(suffix string, parents []string) ([]*v1beta1.DAGStep, []string, error) {
 		steps := make([]*v1beta1.DAGStep, 0)

--- a/pkg/testrunner/template/shoot_template_test.go
+++ b/pkg/testrunner/template/shoot_template_test.go
@@ -35,9 +35,10 @@ var _ = Describe("shoot templates", func() {
 		shoots = []*shootflavors.ExtendedFlavorInstance{
 			shootflavors.NewExtendedFlavorInstance(&common.ExtendedShoot{
 				Shoot: common.Shoot{
-					Provider:          common.CloudProviderGCP,
-					KubernetesVersion: gardencorev1beta1.ExpirableVersion{Version: "1.15.2"},
-					Workers:           []gardencorev1beta1.Worker{{Name: "wp1", Machine: gardencorev1beta1.Machine{Image: &gardencorev1beta1.ShootMachineImage{Name: "core-os"}}}},
+					Provider:                  common.CloudProviderGCP,
+					KubernetesVersion:         gardencorev1beta1.ExpirableVersion{Version: "1.15.2"},
+					Workers:                   []gardencorev1beta1.Worker{{Name: "wp1", Machine: gardencorev1beta1.Machine{Image: &gardencorev1beta1.ShootMachineImage{Name: "core-os"}}}},
+					AllowPrivilegedContainers: "false",
 				},
 				ExtendedShootConfiguration: common.ExtendedShootConfiguration{
 					Name:         "test-name",
@@ -74,6 +75,7 @@ var _ = Describe("shoot templates", func() {
 			Expect(tr.Annotations).To(HaveKeyWithValue("shoot.secretBinding", "test-sb"))
 			Expect(tr.Annotations).To(HaveKeyWithValue("shoot.region", "region-1"))
 			Expect(tr.Annotations).To(HaveKeyWithValue("shoot.zone", "region-1-1"))
+			Expect(tr.Annotations).To(HaveKeyWithValue("shoot.allowPrivilegedContainers", "false"))
 			Expect(tr.Annotations).To(HaveKeyWithValue("shoot.k8sVersion", "1.15.2"))
 			Expect(tr.Annotations).To(HaveKeyWithValue("shoot.k8sPrevPrePatchVersion", "1.15.2"))
 			Expect(tr.Annotations).To(HaveKeyWithValue("shoot.k8sPrevPatchVersion", "1.15.2"))

--- a/pkg/testrunner/template/shoot_template_test.go
+++ b/pkg/testrunner/template/shoot_template_test.go
@@ -100,6 +100,7 @@ var _ = Describe("shoot templates", func() {
 			Expect(meta.CloudProvider).To(Equal("gcp"))
 			Expect(meta.Region).To(Equal("region-1"))
 			Expect(meta.Zone).To(Equal("region-1-1"))
+			Expect(meta.AllowPrivilegedContainers).To(Equal(pointer.BoolPtr(false)))
 			Expect(meta.OperatingSystem).To(Equal("core-os"))
 		})
 

--- a/pkg/testrunner/template/shoot_template_test.go
+++ b/pkg/testrunner/template/shoot_template_test.go
@@ -17,6 +17,7 @@ package template
 import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/test-infra/pkg/shootflavors"
+	"k8s.io/utils/pointer"
 	"path/filepath"
 
 	"github.com/gardener/test-infra/pkg/common"
@@ -38,7 +39,7 @@ var _ = Describe("shoot templates", func() {
 					Provider:                  common.CloudProviderGCP,
 					KubernetesVersion:         gardencorev1beta1.ExpirableVersion{Version: "1.15.2"},
 					Workers:                   []gardencorev1beta1.Worker{{Name: "wp1", Machine: gardencorev1beta1.Machine{Image: &gardencorev1beta1.ShootMachineImage{Name: "core-os"}}}},
-					AllowPrivilegedContainers: "false",
+					AllowPrivilegedContainers: pointer.BoolPtr(false),
 				},
 				ExtendedShootConfiguration: common.ExtendedShootConfiguration{
 					Name:         "test-name",

--- a/pkg/testrunner/template/testdata/shoot/basic/templates/testrun.yaml
+++ b/pkg/testrunner/template/testdata/shoot/basic/templates/testrun.yaml
@@ -12,6 +12,9 @@ metadata:
         shoot.secretBinding: {{ required "secretBinding is required" .Values.shoot.secretBinding }}
         shoot.region: {{ required "region is required" .Values.shoot.region }}
         shoot.zone: {{ required "zone is required" .Values.shoot.zone }}
+        {{- if .Values.shoot.allowPrivilegedContainers }}
+        shoot.allowPrivilegedContainers: "{{ .Values.shoot.allowPrivilegedContainers }}"
+        {{- end }}
         shoot.workers: {{ required "workers is required" .Values.shoot.workers }}
         shoot.k8sVersion: {{ required "k8sVersion is required" .Values.shoot.k8sVersion }}
         shoot.k8sPrevPrePatchVersion: {{ required "k8sPrevPrePatchVersion is required" .Values.shoot.k8sPrevPrePatchVersion }}

--- a/pkg/testrunner/template/testdata/shoot/basic/templates/testrun.yaml
+++ b/pkg/testrunner/template/testdata/shoot/basic/templates/testrun.yaml
@@ -12,7 +12,7 @@ metadata:
         shoot.secretBinding: {{ required "secretBinding is required" .Values.shoot.secretBinding }}
         shoot.region: {{ required "region is required" .Values.shoot.region }}
         shoot.zone: {{ required "zone is required" .Values.shoot.zone }}
-        {{- if .Values.shoot.allowPrivilegedContainers }}
+        {{- if  hasKey .Values.shoot "allowPrivilegedContainers" }}
         shoot.allowPrivilegedContainers: "{{ .Values.shoot.allowPrivilegedContainers }}"
         {{- end }}
         shoot.workers: {{ required "workers is required" .Values.shoot.workers }}

--- a/pkg/testrunner/template/values.go
+++ b/pkg/testrunner/template/values.go
@@ -150,7 +150,7 @@ func (r *shootValueRenderer) GetValues(shoot *common.ExtendedShoot, defaultValue
 			"gardener": string(r.parameters.GardenerKubeconfig),
 		},
 	}
-	if shoot.AllowPrivilegedContainers != "" {
+	if shoot.AllowPrivilegedContainers != nil {
 		values["shoot"].(map[string]interface{})["allowPrivilegedContainers"] = shoot.AllowPrivilegedContainers
 	}
 	return utils.MergeMaps(defaultValues, values), nil

--- a/pkg/testrunner/template/values.go
+++ b/pkg/testrunner/template/values.go
@@ -126,22 +126,22 @@ func (r *shootValueRenderer) GetValues(shoot *common.ExtendedShoot, defaultValue
 
 	values := map[string]interface{}{
 		"shoot": map[string]interface{}{
-			"name":                   shoot.Name,
-			"projectNamespace":       shoot.Namespace,
-			"cloudprovider":          shoot.Provider,
-			"cloudprofile":           shoot.CloudprofileName,
-			"secretBinding":          shoot.SecretBinding,
-			"region":                 shoot.Region,
-			"zone":                   shoot.Zone,
-			"workers":                workers,
-			"k8sVersion":             shoot.KubernetesVersion.Version,
-			"k8sPrevPrePatchVersion": prevPrePatchVersion.Version,
-			"k8sPrevPatchVersion":    prevPatchVersion.Version,
-			"floatingPoolName":       shoot.FloatingPoolName,
-			"loadbalancerProvider":   shoot.LoadbalancerProvider,
-			"infrastructureConfig":   infrastructure,
-			"networkingConfig":       networkingConfig,
-			"controlplaneConfig":     controlplane,
+			"name":                      shoot.Name,
+			"projectNamespace":          shoot.Namespace,
+			"cloudprovider":             shoot.Provider,
+			"cloudprofile":              shoot.CloudprofileName,
+			"secretBinding":             shoot.SecretBinding,
+			"region":                    shoot.Region,
+			"zone":                      shoot.Zone,
+			"workers":                   workers,
+			"k8sVersion":                shoot.KubernetesVersion.Version,
+			"k8sPrevPrePatchVersion":    prevPrePatchVersion.Version,
+			"k8sPrevPatchVersion":       prevPatchVersion.Version,
+			"floatingPoolName":          shoot.FloatingPoolName,
+			"loadbalancerProvider":      shoot.LoadbalancerProvider,
+			"infrastructureConfig":      infrastructure,
+			"networkingConfig":          networkingConfig,
+			"controlplaneConfig":        controlplane,
 		},
 		"gardener": map[string]interface{}{
 			"version": r.parameters.GardenerVersion,
@@ -149,6 +149,9 @@ func (r *shootValueRenderer) GetValues(shoot *common.ExtendedShoot, defaultValue
 		"kubeconfigs": map[string]interface{}{
 			"gardener": string(r.parameters.GardenerKubeconfig),
 		},
+	}
+	if shoot.AllowPrivilegedContainers != "" {
+		values["shoot"].(map[string]interface{})["allowPrivilegedContainers"] = shoot.AllowPrivilegedContainers
 	}
 	return utils.MergeMaps(defaultValues, values), nil
 }

--- a/pkg/testrunner/template/values.go
+++ b/pkg/testrunner/template/values.go
@@ -126,22 +126,22 @@ func (r *shootValueRenderer) GetValues(shoot *common.ExtendedShoot, defaultValue
 
 	values := map[string]interface{}{
 		"shoot": map[string]interface{}{
-			"name":                      shoot.Name,
-			"projectNamespace":          shoot.Namespace,
-			"cloudprovider":             shoot.Provider,
-			"cloudprofile":              shoot.CloudprofileName,
-			"secretBinding":             shoot.SecretBinding,
-			"region":                    shoot.Region,
-			"zone":                      shoot.Zone,
-			"workers":                   workers,
-			"k8sVersion":                shoot.KubernetesVersion.Version,
-			"k8sPrevPrePatchVersion":    prevPrePatchVersion.Version,
-			"k8sPrevPatchVersion":       prevPatchVersion.Version,
-			"floatingPoolName":          shoot.FloatingPoolName,
-			"loadbalancerProvider":      shoot.LoadbalancerProvider,
-			"infrastructureConfig":      infrastructure,
-			"networkingConfig":          networkingConfig,
-			"controlplaneConfig":        controlplane,
+			"name":                   shoot.Name,
+			"projectNamespace":       shoot.Namespace,
+			"cloudprovider":          shoot.Provider,
+			"cloudprofile":           shoot.CloudprofileName,
+			"secretBinding":          shoot.SecretBinding,
+			"region":                 shoot.Region,
+			"zone":                   shoot.Zone,
+			"workers":                workers,
+			"k8sVersion":             shoot.KubernetesVersion.Version,
+			"k8sPrevPrePatchVersion": prevPrePatchVersion.Version,
+			"k8sPrevPatchVersion":    prevPatchVersion.Version,
+			"floatingPoolName":       shoot.FloatingPoolName,
+			"loadbalancerProvider":   shoot.LoadbalancerProvider,
+			"infrastructureConfig":   infrastructure,
+			"networkingConfig":       networkingConfig,
+			"controlplaneConfig":     controlplane,
 		},
 		"gardener": map[string]interface{}{
 			"version": r.parameters.GardenerVersion,
@@ -162,14 +162,15 @@ func (r *shootValueRenderer) GetMetadata(shoot *common.ExtendedShoot) (*metadata
 		operatingsystemversion = *shoot.Workers[0].Machine.Image.Version
 	}
 	return &metadata.Metadata{
-		FlavorDescription:      shoot.Description,
-		Landscape:              r.parameters.Landscape,
-		ComponentDescriptor:    r.parameters.ComponentDescriptor.JSON(),
-		CloudProvider:          string(shoot.Provider),
-		KubernetesVersion:      shoot.KubernetesVersion.Version,
-		Region:                 shoot.Region,
-		Zone:                   shoot.Zone,
-		OperatingSystem:        shoot.Workers[0].Machine.Image.Name, // todo: check if there a possible multiple workerpools with different images
-		OperatingSystemVersion: operatingsystemversion,
+		FlavorDescription:         shoot.Description,
+		Landscape:                 r.parameters.Landscape,
+		ComponentDescriptor:       r.parameters.ComponentDescriptor.JSON(),
+		CloudProvider:             string(shoot.Provider),
+		KubernetesVersion:         shoot.KubernetesVersion.Version,
+		Region:                    shoot.Region,
+		Zone:                      shoot.Zone,
+		AllowPrivilegedContainers: shoot.AllowPrivilegedContainers,
+		OperatingSystem:           shoot.Workers[0].Machine.Image.Name, // todo: check if there a possible multiple workerpools with different images
+		OperatingSystemVersion:    operatingsystemversion,
 	}, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds `allowPrivilegedContainers` as an additional option in the flavor configuration. Gardener shoots default to `true` is this option is not set, hence you can use it to disable privileged containers for certain tests or have your tests run against both: shoots with `allowPrivilegedContainers="true"` and shoots with `allowPrivilegedContainers="false"`

**Release note**:
```improvement user
`allowPrivilegedContainers` can now be customized in the flavor configuration.
```
