### PR TITLE
Update pattern for exclusion of git_repo e2e test

### DIFF
--- a/integration-tests/e2e/kubetest/description/1.10/skip.json
+++ b/integration-tests/e2e/kubetest/description/1.10/skip.json
@@ -483,7 +483,7 @@
   { "testcase": "[sig-storage] PersistentVolumes-local  [Volume type: block] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" },
   { "testcase": "[sig-storage] PersistentVolumes-local  StatefulSet with pod affinity [Slow] should use volumes spread across nodes when pod management is parallel and pod has anti-affinity" },
   { "testcase": "[sig-storage] PersistentVolumes-local  StatefulSet with pod affinity [Slow] should use volumes spread across nodes when pod has anti-affinity" },
-  { "testcase": "[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo", "description": "Fails on GL (not investigated why), but test looks for a race condition in K8S which was fixed in K8S v1.9.x and uses GitRepo type volumes which are deprecated since K8S v1.11.0" },
+  { "testcase": "[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo [Serial] [Slow]", "description": "Fails on GL (not investigated why), but test looks for a race condition in K8S which was fixed in K8S v1.9.x and uses GitRepo type volumes which are deprecated since K8S v1.11.0" },
   { "testcase": "[sig-scheduling] TaintBasedEvictions [Serial] Checks that the node becomes unreachable" },
   { "testcase": "[Driver: gcepd]" },
   { "testcase": "[Driver: pd.csi.storage.gke.io]" },

--- a/integration-tests/e2e/kubetest/description/1.10/working.json
+++ b/integration-tests/e2e/kubetest/description/1.10/working.json
@@ -139,7 +139,6 @@
   { "testcase": "[sig-scheduling] SchedulerPredicates [Serial] validates that there exists conflict between pods with same hostPort and protocol but one using 0.0.0.0 hostIP", "groups": ["slow"] },
   { "testcase": "[sig-scheduling] SchedulerPredicates [Serial] validates that there is no conflict between pods with same hostPort but different hostIP and protocol", "groups": ["slow"] },
   { "testcase": "[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with different parameters [Slow]", "groups": ["slow"] },
-  { "testcase": "[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo [Serial] [Slow]", "groups": ["slow"] },
   { "testcase": "[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 4 PVs and 2 PVCs: test write access [Slow]", "groups": ["slow"] },
   { "testcase": "[sig-storage] PersistentVolumes-local  Local volume that cannot be mounted [Slow] should fail due to non-existent path", "groups": ["slow"] },
   { "testcase": "[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should implement legacy replacement when the update strategy is OnDelete", "groups": ["slow"] },

--- a/integration-tests/e2e/kubetest/description/1.11/skip.json
+++ b/integration-tests/e2e/kubetest/description/1.11/skip.json
@@ -483,7 +483,7 @@
   { "testcase": "[sig-storage] PersistentVolumes-local  [Volume type: block] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" },
   { "testcase": "[sig-storage] PersistentVolumes-local  StatefulSet with pod affinity [Slow] should use volumes spread across nodes when pod management is parallel and pod has anti-affinity" },
   { "testcase": "[sig-storage] PersistentVolumes-local  StatefulSet with pod affinity [Slow] should use volumes spread across nodes when pod has anti-affinity" },
-  { "testcase": "[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo", "description": "Fails on GL (not investigated why), but test looks for a race condition in K8S which was fixed in K8S v1.9.x and uses GitRepo type volumes which are deprecated since K8S v1.11.0" },
+  { "testcase": "[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo [Serial] [Slow]", "description": "Fails on GL (not investigated why), but test looks for a race condition in K8S which was fixed in K8S v1.9.x and uses GitRepo type volumes which are deprecated since K8S v1.11.0" },
   { "testcase": "[sig-scheduling] TaintBasedEvictions [Serial] Checks that the node becomes unreachable" },
   { "testcase": "[Driver: gcepd]" },
   { "testcase": "[Driver: pd.csi.storage.gke.io]" },

--- a/integration-tests/e2e/kubetest/description/1.11/working.json
+++ b/integration-tests/e2e/kubetest/description/1.11/working.json
@@ -209,7 +209,6 @@
   { "testcase": "[sig-scheduling] SchedulerPreemption [Serial] validates pod anti-affinity works in preemption", "groups": ["slow"] },
   { "testcase": "[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with different parameters [Slow]", "groups": ["slow"] },
   { "testcase": "[sig-storage] Dynamic Provisioning DynamicProvisioner External should let an external dynamic provisioner create and delete persistent volumes [Slow]", "groups": ["slow"] },
-  { "testcase": "[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo [Serial] [Slow]", "groups": ["slow"] },
   { "testcase": "[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 4 PVs and 2 PVCs: test write access [Slow]", "groups": ["slow"] },
   { "testcase": "[sig-storage] PersistentVolumes-local  Local volume provisioner [Serial] should create and recreate local persistent volume", "groups": ["slow"] },
   { "testcase": "[sig-storage] PersistentVolumes-local  Local volume provisioner [Serial] should not create local persistent volume for filesystem volume that was not bind mounted", "groups": ["slow"] },

--- a/integration-tests/e2e/kubetest/description/1.12/skip.json
+++ b/integration-tests/e2e/kubetest/description/1.12/skip.json
@@ -483,7 +483,7 @@
   { "testcase": "[sig-storage] PersistentVolumes-local  [Volume type: block] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" },
   { "testcase": "[sig-storage] PersistentVolumes-local  StatefulSet with pod affinity [Slow] should use volumes spread across nodes when pod management is parallel and pod has anti-affinity" },
   { "testcase": "[sig-storage] PersistentVolumes-local  StatefulSet with pod affinity [Slow] should use volumes spread across nodes when pod has anti-affinity" },
-  { "testcase": "[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo", "description": "Fails on GL (not investigated why), but test looks for a race condition in K8S which was fixed in K8S v1.9.x and uses GitRepo type volumes which are deprecated since K8S v1.11.0" },
+  { "testcase": "[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo [Serial] [Slow]", "description": "Fails on GL (not investigated why), but test looks for a race condition in K8S which was fixed in K8S v1.9.x and uses GitRepo type volumes which are deprecated since K8S v1.11.0" },
   { "testcase": "[sig-scheduling] TaintBasedEvictions [Serial] Checks that the node becomes unreachable" },
   { "testcase": "[Driver: gcepd]" },
   { "testcase": "[Driver: pd.csi.storage.gke.io]" },

--- a/integration-tests/e2e/kubetest/description/1.12/working.json
+++ b/integration-tests/e2e/kubetest/description/1.12/working.json
@@ -299,7 +299,6 @@
   { "testcase": "[sig-scheduling] SchedulerPreemption [Serial] validates pod anti-affinity works in preemption", "groups": ["slow"] },
   { "testcase": "[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with different parameters", "groups": ["slow"] },
   { "testcase": "[sig-storage] Dynamic Provisioning DynamicProvisioner External should let an external dynamic provisioner create and delete persistent volumes [Slow]", "groups": ["slow"] },
-  { "testcase": "[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo [Serial] [Slow]", "groups": ["slow"] },
   { "testcase": "[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 4 PVs and 2 PVCs: test write access [Slow]", "groups": ["slow"] },
   { "testcase": "[sig-storage] PersistentVolumes-local  Local volume provisioner [Serial] should create and recreate local persistent volume", "groups": ["slow"] },
   { "testcase": "[sig-storage] PersistentVolumes-local  Local volume provisioner [Serial] should discover dynamically created local persistent volume mountpoint in discovery directory", "groups": ["slow"] },

--- a/integration-tests/e2e/kubetest/description/1.13/skip.json
+++ b/integration-tests/e2e/kubetest/description/1.13/skip.json
@@ -490,7 +490,7 @@
   { "testcase": "[sig-storage] PersistentVolumes-local  [Volume type: block] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" },
   { "testcase": "[sig-storage] PersistentVolumes-local  StatefulSet with pod affinity [Slow] should use volumes spread across nodes when pod management is parallel and pod has anti-affinity" },
   { "testcase": "[sig-storage] PersistentVolumes-local  StatefulSet with pod affinity [Slow] should use volumes spread across nodes when pod has anti-affinity" },
-  { "testcase": "[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo", "description": "Fails on GL (not investigated why), but test looks for a race condition in K8S which was fixed in K8S v1.9.x and uses GitRepo type volumes which are deprecated since K8S v1.11.0" },
+  { "testcase": "[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo [Serial] [Slow]", "description": "Fails on GL (not investigated why), but test looks for a race condition in K8S which was fixed in K8S v1.9.x and uses GitRepo type volumes which are deprecated since K8S v1.11.0" },
   { "testcase": "[sig-scheduling] TaintBasedEvictions [Serial] Checks that the node becomes unreachable" },
   { "testcase": "[Driver: gcepd]" },
   { "testcase": "[Driver: pd.csi.storage.gke.io]" },

--- a/integration-tests/e2e/kubetest/description/1.13/working.json
+++ b/integration-tests/e2e/kubetest/description/1.13/working.json
@@ -345,7 +345,6 @@
   { "testcase": "[sig-storage] Dynamic Provisioning DynamicProvisioner delayed binding [Slow] should create persistent volumes in the same zone as node after a pod mounting the claims is started", "groups": ["slow"] },
   { "testcase": "[sig-storage] Dynamic Provisioning DynamicProvisioner delayed binding with allowedTopologies [Slow] should create persistent volumes in the same zone as specified in allowedTopologies after a pod mounting the claims is started", "groups": ["slow"] },
   { "testcase": "[sig-storage] Dynamic Provisioning DynamicProvisioner External should let an external dynamic provisioner create and delete persistent volumes [Slow]", "groups": ["slow"] },
-  { "testcase": "[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo [Serial] [Slow]", "groups": ["slow"] },
   { "testcase": "[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 4 PVs and 2 PVCs: test write access [Slow]", "groups": ["slow"] },
   { "testcase": "[sig-storage] PersistentVolumes-local  Local volume provisioner [Serial] should create and recreate local persistent volume", "groups": ["slow"] },
   { "testcase": "[sig-storage] PersistentVolumes-local  Local volume provisioner [Serial] should discover dynamically created local persistent volume mountpoint in discovery directory", "groups": ["slow"] },

--- a/integration-tests/e2e/kubetest/description/1.14/skip.json
+++ b/integration-tests/e2e/kubetest/description/1.14/skip.json
@@ -670,6 +670,6 @@
   { "testcase": "[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for read-only PD with pod delete grace period of \"immediate (0s)\""},
   { "testcase": "[sig-storage] Zone Support Verify a pod is created on a non-Workspace zone and attached to a dynamically created PV, based on the allowed zones and storage policy specified in storage class"},
   { "testcase": "[sig-storage] PersistentVolumes-local  [Volume type: dir-link] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted"},
-  { "testcase": "[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo", "description": "Fails on GL (not investigated why), but test looks for a race condition in K8S which was fixed in K8S v1.9.x and uses GitRepo type volumes which are deprecated since K8S v1.11.0" },
+  { "testcase": "[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo [Serial] [Slow]", "description": "Fails on GL (not investigated why), but test looks for a race condition in K8S which was fixed in K8S v1.9.x and uses GitRepo type volumes which are deprecated since K8S v1.11.0" },
   { "testcase": "[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] regular resource usage tracking resource tracking for 100 pods per node", "comment": "false positive: we already have some system pods running on some nodes, hence adding 100 pods exceeds the podlimit of 110 sometimes, hence this test cannot work" }
 ]

--- a/integration-tests/e2e/kubetest/description/1.14/working.json
+++ b/integration-tests/e2e/kubetest/description/1.14/working.json
@@ -303,7 +303,6 @@
   { "testcase": "[sig-storage] Dynamic Provisioning DynamicProvisioner delayed binding [Slow] should create persistent volumes in the same zone as node after a pod mounting the claims is started", "groups": ["slow", "slow2"] },
   { "testcase": "[sig-storage] Dynamic Provisioning DynamicProvisioner delayed binding with allowedTopologies [Slow] should create persistent volumes in the same zone as specified in allowedTopologies after a pod mounting the claims is started", "groups": ["slow", "slow2"] },
   { "testcase": "[sig-storage] Dynamic Provisioning DynamicProvisioner External should let an external dynamic provisioner create and delete persistent volumes [Slow]", "groups": ["slow", "slow2"] },
-  { "testcase": "[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo [Serial] [Slow]", "groups": ["slow", "slow2"] },
   { "testcase": "[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 4 PVs and 2 PVCs: test write access [Slow]", "groups": ["slow", "slow2"] },
   { "testcase": "[sig-storage] PersistentVolumes-local  Local volume that cannot be mounted [Slow] should fail due to non-existent path", "groups": ["slow", "slow2"] },
   { "testcase": "[sig-storage] PersistentVolumes-local  Local volume that cannot be mounted [Slow] should fail due to wrong node", "groups": ["slow", "slow2"] },

--- a/integration-tests/e2e/kubetest/description/1.15/skip.json
+++ b/integration-tests/e2e/kubetest/description/1.15/skip.json
@@ -670,6 +670,6 @@
   { "testcase": "[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for read-only PD with pod delete grace period of \"immediate (0s)\""},
   { "testcase": "[sig-storage] Zone Support Verify a pod is created on a non-Workspace zone and attached to a dynamically created PV, based on the allowed zones and storage policy specified in storage class"},
   { "testcase": "[sig-storage] PersistentVolumes-local  [Volume type: dir-link] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted"},
-  { "testcase": "[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo", "description": "Fails on GL (not investigated why), but test looks for a race condition in K8S which was fixed in K8S v1.9.x and uses GitRepo type volumes which are deprecated since K8S v1.11.0" },
+  { "testcase": "[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo [Serial] [Slow]", "description": "Fails on GL (not investigated why), but test looks for a race condition in K8S which was fixed in K8S v1.9.x and uses GitRepo type volumes which are deprecated since K8S v1.11.0" },
   { "testcase": "[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] regular resource usage tracking resource tracking for 100 pods per node", "comment": "false positive: we already have some system pods running on some nodes, hence adding 100 pods exceeds the podlimit of 110 sometimes, hence this test cannot work" }
 ]

--- a/integration-tests/e2e/kubetest/description/1.15/working.json
+++ b/integration-tests/e2e/kubetest/description/1.15/working.json
@@ -292,7 +292,6 @@
   { "testcase": "[sig-storage] Dynamic Provisioning DynamicProvisioner delayed binding [Slow] should create persistent volumes in the same zone as node after a pod mounting the claims is started", "groups": ["slow", "slow2"] },
   { "testcase": "[sig-storage] Dynamic Provisioning DynamicProvisioner delayed binding with allowedTopologies [Slow] should create persistent volumes in the same zone as specified in allowedTopologies after a pod mounting the claims is started", "groups": ["slow", "slow2"] },
   { "testcase": "[sig-storage] Dynamic Provisioning DynamicProvisioner External should let an external dynamic provisioner create and delete persistent volumes [Slow]", "groups": ["slow", "slow2"] },
-  { "testcase": "[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo [Serial] [Slow]", "groups": ["slow", "slow2"] },
   { "testcase": "[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 4 PVs and 2 PVCs: test write access [Slow]", "groups": ["slow", "slow2"] },
   { "testcase": "[sig-storage] PersistentVolumes-local  Local volume that cannot be mounted [Slow] should fail due to non-existent path", "groups": ["slow", "slow2"] },
   { "testcase": "[sig-storage] PersistentVolumes-local  Local volume that cannot be mounted [Slow] should fail due to wrong node", "groups": ["slow", "slow2"] },

--- a/integration-tests/e2e/kubetest/description/1.16/skip.json
+++ b/integration-tests/e2e/kubetest/description/1.16/skip.json
@@ -669,5 +669,5 @@
   { "testcase": "[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for read-only PD with pod delete grace period of \"immediate (0s)\""},
   { "testcase": "[sig-storage] Zone Support Verify a pod is created on a non-Workspace zone and attached to a dynamically created PV, based on the allowed zones and storage policy specified in storage class"},
   { "testcase": "[sig-storage] PersistentVolumes-local  [Volume type: dir-link] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted"},
-  { "testcase": "[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo", "description": "Fails on GL (not investigated why), but test looks for a race condition in K8S which was fixed in K8S v1.9.x and uses GitRepo type volumes which are deprecated since K8S v1.11.0" }
+  { "testcase": "[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo [Serial] [Slow]", "description": "Fails on GL (not investigated why), but test looks for a race condition in K8S which was fixed in K8S v1.9.x and uses GitRepo type volumes which are deprecated since K8S v1.11.0" }
 ]

--- a/integration-tests/e2e/kubetest/description/1.16/working.json
+++ b/integration-tests/e2e/kubetest/description/1.16/working.json
@@ -209,7 +209,6 @@
   { "testcase": "[sig-storage] Dynamic Provisioning DynamicProvisioner delayed binding [Slow] should create persistent volumes in the same zone as node after a pod mounting the claims is started", "groups": ["slow", "slow2"] },
   { "testcase": "[sig-storage] Dynamic Provisioning DynamicProvisioner delayed binding with allowedTopologies [Slow] should create persistent volumes in the same zone as specified in allowedTopologies after a pod mounting the claims is started", "groups": ["slow", "slow2"] },
   { "testcase": "[sig-storage] Dynamic Provisioning DynamicProvisioner External should let an external dynamic provisioner create and delete persistent volumes [Slow]", "groups": ["slow", "slow2"] },
-  { "testcase": "[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo [Serial] [Slow]", "groups": ["slow", "slow2"] },
   { "testcase": "[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 4 PVs and 2 PVCs: test write access [Slow]", "groups": ["slow", "slow2"] },
   { "testcase": "[sig-storage] PersistentVolumes-local  Local volume that cannot be mounted [Slow] should fail due to non-existent path", "groups": ["slow", "slow2"] },
   { "testcase": "[sig-storage] PersistentVolumes-local  Local volume that cannot be mounted [Slow] should fail due to wrong node", "groups": ["slow", "slow2"] },

--- a/integration-tests/e2e/kubetest/description/1.17/skip.json
+++ b/integration-tests/e2e/kubetest/description/1.17/skip.json
@@ -669,5 +669,5 @@
   { "testcase": "[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for read-only PD with pod delete grace period of \"immediate (0s)\""},
   { "testcase": "[sig-storage] Zone Support Verify a pod is created on a non-Workspace zone and attached to a dynamically created PV, based on the allowed zones and storage policy specified in storage class"},
   { "testcase": "[sig-storage] PersistentVolumes-local  [Volume type: dir-link] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted"},
-  { "testcase": "[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo", "description": "Fails on GL (not investigated why), but test looks for a race condition in K8S which was fixed in K8S v1.9.x and uses GitRepo type volumes which are deprecated since K8S v1.11.0" }
+  { "testcase": "[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo [Serial] [Slow]", "description": "Fails on GL (not investigated why), but test looks for a race condition in K8S which was fixed in K8S v1.9.x and uses GitRepo type volumes which are deprecated since K8S v1.11.0" }
 ]

--- a/integration-tests/e2e/kubetest/description/1.17/working.json
+++ b/integration-tests/e2e/kubetest/description/1.17/working.json
@@ -192,7 +192,6 @@
   { "testcase": "[sig-storage] ConfigMap Should fail non-optional pod creation due to the key in the configMap object does not exist [Slow]", "groups": ["slow", "slow2"] },
   { "testcase": "[sig-storage] Dynamic Provisioning DynamicProvisioner [Slow] should provision storage with different parameters", "groups": ["slow", "slow2"] },
   { "testcase": "[sig-storage] Dynamic Provisioning DynamicProvisioner External should let an external dynamic provisioner create and delete persistent volumes [Slow]", "groups": ["slow", "slow2"] },
-  { "testcase": "[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo [Serial] [Slow]", "groups": ["slow", "slow2"] },
   { "testcase": "[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 4 PVs and 2 PVCs: test write access [Slow]", "groups": ["slow", "slow2"] },
   { "testcase": "[sig-storage] PersistentVolumes-local  Local volume that cannot be mounted [Slow] should fail due to non-existent path", "groups": ["slow", "slow2"] },
   { "testcase": "[sig-storage] PersistentVolumes-local  Local volume that cannot be mounted [Slow] should fail due to wrong node", "groups": ["slow", "slow2"] },

--- a/integration-tests/e2e/kubetest/description/1.18/skip.json
+++ b/integration-tests/e2e/kubetest/description/1.18/skip.json
@@ -669,5 +669,5 @@
   { "testcase": "[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for read-only PD with pod delete grace period of \"immediate (0s)\""},
   { "testcase": "[sig-storage] Zone Support Verify a pod is created on a non-Workspace zone and attached to a dynamically created PV, based on the allowed zones and storage policy specified in storage class"},
   { "testcase": "[sig-storage] PersistentVolumes-local  [Volume type: dir-link] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted"},
-  { "testcase": "[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo", "description": "Fails on GL (not investigated why), but test looks for a race condition in K8S which was fixed in K8S v1.9.x and uses GitRepo type volumes which are deprecated since K8S v1.11.0" }
+  { "testcase": "[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo [Serial] [Slow]", "description": "Fails on GL (not investigated why), but test looks for a race condition in K8S which was fixed in K8S v1.9.x and uses GitRepo type volumes which are deprecated since K8S v1.11.0" }
 ]

--- a/integration-tests/e2e/kubetest/description/1.18/working.json
+++ b/integration-tests/e2e/kubetest/description/1.18/working.json
@@ -192,7 +192,6 @@
   { "testcase": "[sig-storage] ConfigMap Should fail non-optional pod creation due to the key in the configMap object does not exist [Slow]", "groups": ["slow", "slow2"] },
   { "testcase": "[sig-storage] Dynamic Provisioning DynamicProvisioner [Slow] should provision storage with different parameters", "groups": ["slow", "slow2"] },
   { "testcase": "[sig-storage] Dynamic Provisioning DynamicProvisioner External should let an external dynamic provisioner create and delete persistent volumes [Slow]", "groups": ["slow", "slow2"] },
-  { "testcase": "[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo [Serial] [Slow]", "groups": ["slow", "slow2"] },
   { "testcase": "[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 4 PVs and 2 PVCs: test write access [Slow]", "groups": ["slow", "slow2"] },
   { "testcase": "[sig-storage] PersistentVolumes-local  Local volume that cannot be mounted [Slow] should fail due to non-existent path", "groups": ["slow", "slow2"] },
   { "testcase": "[sig-storage] PersistentVolumes-local  Local volume that cannot be mounted [Slow] should fail due to wrong node", "groups": ["slow", "slow2"] },


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the pattern for the exclusion of the git_repo e2e test which tests a feature deprecated since k81 v1.11.0