### PR TITLE
Enh/tm health cehck

### DIFF
--- a/charts/testmachinery/templates/deployment-tm-controller.yaml
+++ b/charts/testmachinery/templates/deployment-tm-controller.yaml
@@ -68,13 +68,15 @@ spec:
             path: /healthz
             port: {{.Values.controller.healthEndpointPort}}
           initialDelaySeconds: 3
-          periodSeconds: 60
+          periodSeconds: 30
+          failureThreshold: 5
         readinessProbe:
           httpGet:
             path: /healthz
             port: {{.Values.controller.healthEndpointPort}}
           initialDelaySeconds: 3
-          periodSeconds: 60
+          periodSeconds: 30
+          failureThreshold: 5
         volumeMounts:
         - name: config
           mountPath: /etc/testmachinery/config

--- a/pkg/testmachinery/controller/dependencies/ensurer.go
+++ b/pkg/testmachinery/controller/dependencies/ensurer.go
@@ -52,7 +52,7 @@ func New(log logr.Logger, cw *configwatcher.ConfigWatcher) (*DependencyEnsurer, 
 		renderer: chartrenderer.New(engine.New(), nil),
 	}
 
-	tmhealth.AddHealthCondition("bootsrap", b)
+	tmhealth.AddHealthCondition("bootstrap", b)
 
 	return b, nil
 }
@@ -122,11 +122,7 @@ func (e *DependencyEnsurer) CheckHealth(ctx context.Context) error {
 		}
 	}
 
-	mr := &v1alpha1.ManagedResource{}
-	if err := e.client.Get(ctx, client.ObjectKey{Name: intconfig.ArgoManagedResourceName, Namespace: namespace}, mr); err != nil {
-		return err
-	}
-	return health.CheckManagedResourceHealthy(mr)
+	return nil
 }
 
 // Reconcile ensures the correct state defined by the configuration.


### PR DESCRIPTION
**What this PR does / why we need it**:

The argo controller has been removed from the health probe as the webhooks failed to often with this requirement.

Also increased the threshold before the testmachinery is considered unhealthy.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Argo controller has been removed from the testmachinery health probe
```
