### PR TITLE
Fix/pagination

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -48,6 +48,9 @@ const (
 	// AnnotationRetries is the annotation to specify the retry count of the current testrun
 	AnnotationRetries = "testrunner.testmachinery.gardener.cloud/retries"
 
+	// AnnotationPreviousAttempt is the testrun id if the previous testrun
+	AnnotationPreviousAttempt = "testrunner.testmachinery.gardener.cloud/previous-attempt"
+
 	// AnnotationLandscape is the annotation to specify the landscape this testrun is testing
 	AnnotationLandscape = "metadata.testmachinery.gardener.cloud/landscape"
 

--- a/pkg/testmachinery/controller/watch/watch_test.go
+++ b/pkg/testmachinery/controller/watch/watch_test.go
@@ -102,7 +102,6 @@ var _ = Describe("Watch", func() {
 		}
 		err := fakeClient.Create(context.TODO(), tr)
 		Expect(err).ToNot(HaveOccurred())
-		//fakeClient = fake.NewFakeClientWithScheme(tmScheme, tr)
 	})
 
 	AfterEach(func() {

--- a/pkg/testrunner/list.go
+++ b/pkg/testrunner/list.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gardener/test-infra/pkg/util"
 	"github.com/google/uuid"
 	"github.com/hashicorp/go-multierror"
+	"strconv"
 	"strings"
 	"time"
 
@@ -115,8 +116,15 @@ func (rl RunList) Run(log logr.Logger, config *Config, testrunNamePrefix string,
 				log.Error(err, "unable to rerender testrun")
 				return
 			}
-			*rl[trI] = *newRun
+
 			attempt++
+
+			// update retry metadata and annotation
+			newRun.Metadata.Retries = attempt
+			newRun.Testrun.Annotations[common.AnnotationRetries] = strconv.Itoa(attempt)
+			newRun.Testrun.Annotations[common.AnnotationPreviousAttempt] = rl[trI].Testrun.Name
+
+			*rl[trI] = *newRun
 			executor.AddItem(f)
 		}
 		executor.AddItem(f)

--- a/pkg/tm-bot/ui/pages/pagination/pagination.go
+++ b/pkg/tm-bot/ui/pages/pagination/pagination.go
@@ -15,10 +15,12 @@
 package pagination
 
 import (
-	"github.com/gardener/test-infra/pkg/common"
+	"errors"
 	"net/url"
 	"sort"
 	"strconv"
+
+	"github.com/gardener/test-infra/pkg/common"
 )
 
 type Interface interface {
@@ -37,50 +39,142 @@ type Page struct {
 	To   int
 }
 
-const itemsPerPage = 50
+// defaultItems that are displayed on one page - 1
+const defaultItemsPerPage = 49
 
 // SliceFromValues slices the given list into the values gathered form the url values
 func SliceFromValues(list Interface, values url.Values) (Interface, Pages) {
 	sort.Sort(list)
+
+	var (
+		pages = Pages{Pages: []Page{}, Current: 0, ItemCount: list.Len()}
+		itemsPerPage = defaultItemsPerPage
+	)
+
+	from, to, err := parseRange(values)
+	if err == nil {
+		itemsPerPage = to - from
+	}
+	if from <= 0 {
+		from = 1
+	}
+	if to <= 0 {
+		to = from + itemsPerPage
+	}
+
+
+
 	if list.Len() < itemsPerPage {
 		return list, Pages{Pages: []Page{}, Current: 0, ItemCount: list.Len()}
 	}
 
-	indexLength := list.Len() - 1
-
-	pages := Pages{Pages: []Page{}, Current: 0, ItemCount: list.Len()}
-	for i := 0; i <= (pages.ItemCount / itemsPerPage); i++ {
-		from := i * itemsPerPage
-		to := from + itemsPerPage - 1
-		if to > indexLength {
-			to = indexLength
-		}
-		pages.Pages = append(pages.Pages, Page{
-			From: from,
-			To:   to,
-		})
+	// get following pages
+	page := Page{
+		From: from,
+		To:   to,
 	}
 
+	pages.Pages = previousPages(page, 1, itemsPerPage)
+	pages.Pages = append(pages.Pages, page)
+	pages.Current = len(pages.Pages) - 1
+
+	pages.Pages = append(pages.Pages, nextPages(page, pages.ItemCount, itemsPerPage)...)
+
+	// convert page number to index
+	from = from - 1
+	to = to - 1
+
+	return list.GetPaginatedList(from, to), pages
+}
+
+func nextPages(base Page, max, itemsPerPage int) []Page {
+	pages := make([]Page, 0)
+	page := getNextPage(base.To+1, max, itemsPerPage)
+	for page != nil {
+		pages = append(pages, *page)
+		page = getNextPage(page.To+1, max, itemsPerPage)
+	}
+	return pages
+}
+
+func getNextPage(start, max, itemsPerPage int) *Page {
+	if start > max {
+		return nil
+	}
+	end := start + itemsPerPage
+	if end > max {
+		end = max
+	}
+	return &Page{
+		From: start,
+		To:   end,
+	}
+}
+
+func previousPages(base Page, min, itemsPerPage int) []Page {
+	if base.From <= min {
+		return nil
+	}
+	pages := make([]Page, 0)
+	page := getPreviousPage(base.From-1, min, itemsPerPage)
+	for page != nil {
+		pages = append([]Page{*page}, pages...)
+		page = getPreviousPage(page.From-1, min, itemsPerPage)
+	}
+	return pages
+}
+
+// getPreviousPage returns the next previous page from the end
+func getPreviousPage(end, min, itemsPerPage int) *Page {
+	if end < min {
+		return nil
+	}
+	start := end - itemsPerPage
+	if start < min {
+		start = min
+	}
+	return &Page{
+		From: start,
+		To:   end,
+	}
+}
+
+func parseRange(values url.Values) (from, to int, err error) {
 	fromString, ok := values[common.DashboardPaginationFrom]
 	if !ok {
-		return list.GetPaginatedList(0, itemsPerPage), pages
+		err = errors.New("from not found")
+		return
 	}
 
 	toString, ok := values[common.DashboardPaginationTo]
 	if !ok {
-		return list.GetPaginatedList(0, itemsPerPage), pages
+		err = errors.New("to not found")
+		return
 	}
 
-	from, err := strconv.Atoi(fromString[0])
+	from, err = strconv.Atoi(fromString[0])
 	if err != nil {
-		return list.GetPaginatedList(0, itemsPerPage), pages
+		return
 	}
-	to, err := strconv.Atoi(toString[0])
+	if from <= 0 {
+		err = errors.New("index out of range")
+		return
+	}
+
+	to, err = strconv.Atoi(toString[0])
 	if err != nil {
-		return list.GetPaginatedList(0, itemsPerPage), pages
+		return
+	}
+	if to <= 0 {
+		err = errors.New("index out of range")
+		return
 	}
 
-	pages.Current = from / itemsPerPage
+	if to < from {
+		to = 0
+		from = 0
+		err = errors.New("to greater than from")
+	}
 
-	return list.GetPaginatedList(from, to), pages
+	return
 }

--- a/pkg/tm-bot/ui/pages/pagination/pagination.go
+++ b/pkg/tm-bot/ui/pages/pagination/pagination.go
@@ -47,7 +47,7 @@ func SliceFromValues(list Interface, values url.Values) (Interface, Pages) {
 	sort.Sort(list)
 
 	var (
-		pages = Pages{Pages: []Page{}, Current: 0, ItemCount: list.Len()}
+		pages        = Pages{Pages: []Page{}, Current: 0, ItemCount: list.Len()}
 		itemsPerPage = defaultItemsPerPage
 	)
 
@@ -61,8 +61,6 @@ func SliceFromValues(list Interface, values url.Values) (Interface, Pages) {
 	if to <= 0 {
 		to = from + itemsPerPage
 	}
-
-
 
 	if list.Len() < itemsPerPage {
 		return list, Pages{Pages: []Page{}, Current: 0, ItemCount: list.Len()}

--- a/pkg/tm-bot/ui/pages/pagination/pagination_test.go
+++ b/pkg/tm-bot/ui/pages/pagination/pagination_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gardener/test-infra/pkg/common"
 	"github.com/gardener/test-infra/pkg/tm-bot/ui/pages/pagination"
 )
+
 func TestConfig(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "UI Pagination Suite")
@@ -35,7 +36,7 @@ var _ = Describe("pagination", func() {
 		It("should return items 1-3", func() {
 			values := url.Values(map[string][]string{
 				common.DashboardPaginationFrom: []string{"1"},
-				common.DashboardPaginationTo: []string{"3"},
+				common.DashboardPaginationTo:   []string{"3"},
 			})
 
 			list := pagInterface([]string{"a", "b", "c", "d", "e"})
@@ -57,7 +58,7 @@ var _ = Describe("pagination", func() {
 		It("should return items 2-3", func() {
 			values := url.Values(map[string][]string{
 				common.DashboardPaginationFrom: []string{"2"},
-				common.DashboardPaginationTo: []string{"3"},
+				common.DashboardPaginationTo:   []string{"3"},
 			})
 			list := pagInterface([]string{"a", "b", "c", "d", "e"})
 
@@ -69,7 +70,7 @@ var _ = Describe("pagination", func() {
 		It("should return items 3-4", func() {
 			values := url.Values(map[string][]string{
 				common.DashboardPaginationFrom: []string{"3"},
-				common.DashboardPaginationTo: []string{"4"},
+				common.DashboardPaginationTo:   []string{"4"},
 			})
 			list := pagInterface([]string{"a", "b", "c", "d", "e"})
 
@@ -83,7 +84,7 @@ var _ = Describe("pagination", func() {
 		It("should return 5 pages with a items per page of 1", func() {
 			values := url.Values(map[string][]string{
 				common.DashboardPaginationFrom: []string{"1"},
-				common.DashboardPaginationTo: []string{"1"},
+				common.DashboardPaginationTo:   []string{"1"},
 			})
 			list := pagInterface([]string{"a", "b", "c", "d", "e"})
 
@@ -101,7 +102,7 @@ var _ = Describe("pagination", func() {
 		It("should return 2 pages with a items per page of 3", func() {
 			values := url.Values(map[string][]string{
 				common.DashboardPaginationFrom: []string{"1"},
-				common.DashboardPaginationTo: []string{"3"},
+				common.DashboardPaginationTo:   []string{"3"},
 			})
 			list := pagInterface([]string{"a", "b", "c", "d", "e"})
 
@@ -113,7 +114,6 @@ var _ = Describe("pagination", func() {
 			))
 		})
 	})
-
 
 })
 

--- a/pkg/tm-bot/ui/pages/pagination/pagination_test.go
+++ b/pkg/tm-bot/ui/pages/pagination/pagination_test.go
@@ -1,0 +1,132 @@
+// Copyright 2020 Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pagination_test
+
+import (
+	"net/url"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/gardener/test-infra/pkg/common"
+	"github.com/gardener/test-infra/pkg/tm-bot/ui/pages/pagination"
+)
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "UI Pagination Suite")
+}
+
+var _ = Describe("pagination", func() {
+
+	Context("current page", func() {
+		It("should return items 1-3", func() {
+			values := url.Values(map[string][]string{
+				common.DashboardPaginationFrom: []string{"1"},
+				common.DashboardPaginationTo: []string{"3"},
+			})
+
+			list := pagInterface([]string{"a", "b", "c", "d", "e"})
+
+			res, p := pagination.SliceFromValues(list, values)
+			Expect(res).To(ConsistOf("a", "b", "c"))
+			Expect(p.Current).To(Equal(0))
+		})
+
+		It("should return default items per page if no pagination is given", func() {
+			values := url.Values(map[string][]string{})
+			list := pagInterface([]string{"a", "b", "c", "d", "e"})
+
+			res, p := pagination.SliceFromValues(list, values)
+			Expect(res).To(ConsistOf("a", "b", "c", "d", "e"))
+			Expect(p.Current).To(Equal(0))
+		})
+
+		It("should return items 2-3", func() {
+			values := url.Values(map[string][]string{
+				common.DashboardPaginationFrom: []string{"2"},
+				common.DashboardPaginationTo: []string{"3"},
+			})
+			list := pagInterface([]string{"a", "b", "c", "d", "e"})
+
+			res, p := pagination.SliceFromValues(list, values)
+			Expect(res).To(ConsistOf("b", "c"))
+			Expect(p.Current).To(Equal(1))
+		})
+
+		It("should return items 3-4", func() {
+			values := url.Values(map[string][]string{
+				common.DashboardPaginationFrom: []string{"3"},
+				common.DashboardPaginationTo: []string{"4"},
+			})
+			list := pagInterface([]string{"a", "b", "c", "d", "e"})
+
+			res, p := pagination.SliceFromValues(list, values)
+			Expect(res).To(ConsistOf("c", "d"))
+			Expect(p.Current).To(Equal(1))
+		})
+	})
+
+	Context("pages", func() {
+		It("should return 5 pages with a items per page of 1", func() {
+			values := url.Values(map[string][]string{
+				common.DashboardPaginationFrom: []string{"1"},
+				common.DashboardPaginationTo: []string{"1"},
+			})
+			list := pagInterface([]string{"a", "b", "c", "d", "e"})
+
+			_, res := pagination.SliceFromValues(list, values)
+			Expect(res.Pages).To(HaveLen(5))
+			Expect(res.Pages).To(ConsistOf(
+				pagination.Page{From: 1, To: 1},
+				pagination.Page{From: 2, To: 2},
+				pagination.Page{From: 3, To: 3},
+				pagination.Page{From: 4, To: 4},
+				pagination.Page{From: 5, To: 5},
+			))
+		})
+
+		It("should return 2 pages with a items per page of 3", func() {
+			values := url.Values(map[string][]string{
+				common.DashboardPaginationFrom: []string{"1"},
+				common.DashboardPaginationTo: []string{"3"},
+			})
+			list := pagInterface([]string{"a", "b", "c", "d", "e"})
+
+			_, res := pagination.SliceFromValues(list, values)
+			Expect(res.Pages).To(HaveLen(2))
+			Expect(res.Pages).To(ConsistOf(
+				pagination.Page{From: 1, To: 3},
+				pagination.Page{From: 4, To: 5},
+			))
+		})
+	})
+
+
+})
+
+type pagInterface []string
+
+func (p pagInterface) Len() int           { return len(p) }
+func (p pagInterface) Less(i, j int) bool { return p[i] < p[j] }
+func (p pagInterface) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+
+func (p pagInterface) GetPaginatedList(from, to int) pagination.Interface {
+	to++
+	if to > len(p) {
+		return p
+	}
+	return p[from:to]
+}

--- a/pkg/tm-bot/ui/pages/runs.go
+++ b/pkg/tm-bot/ui/pages/runs.go
@@ -41,7 +41,9 @@ type testrunItem struct {
 	Duration  string
 	Progress  string
 
-	Dimension string
+	Dimension       string
+	Retries         string
+	PreviousAttempt string
 
 	ArgoURL    string
 	GrafanaURL string
@@ -108,12 +110,20 @@ func NewTestrunsPage(p *Page) http.HandlerFunc {
 				testrun:   &testrun,
 				ID:        tr.GetName(),
 				Namespace: tr.GetNamespace(),
-				RunID:     tr.GetLabels()[common.LabelTestrunExecutionGroup],
 				Phase:     PhaseIcon(tr.Status.Phase),
 				StartTime: startTime,
 				Duration:  d.String(),
 				Progress:  util.TestrunProgress(&tr),
 				Dimension: metadata.GetDimensionFromMetadata("/"),
+			}
+			if retries, ok := tr.Annotations[common.AnnotationRetries]; ok {
+				testrunsList[i].Retries = retries
+			}
+			if prevAttempt, ok := tr.Annotations[common.AnnotationPreviousAttempt]; ok {
+				testrunsList[i].PreviousAttempt = prevAttempt
+			}
+			if runID, ok := tr.Labels[common.LabelTestrunExecutionGroup]; ok {
+				testrunsList[i].RunID = runID
 			}
 			if argoHostURL != "" {
 				testrunsList[i].ArgoURL = testrunner.GetArgoURLFromHost(argoHostURL, &tr)

--- a/pkg/tm-bot/ui/pages/runs.go
+++ b/pkg/tm-bot/ui/pages/runs.go
@@ -124,7 +124,6 @@ func NewTestrunsPage(p *Page) http.HandlerFunc {
 		}
 
 		paginatedTestruns, pages := pagination.SliceFromValues(testrunsList, r.URL.Query())
-		sort.Sort(testrunsList)
 		sort.Sort(runsList)
 		params := map[string]interface{}{
 			"rungroup":   rgName,

--- a/pkg/tm-bot/ui/pages/testrun.go
+++ b/pkg/tm-bot/ui/pages/testrun.go
@@ -142,6 +142,13 @@ func NewTestrunPage(p *Page) http.HandlerFunc {
 type testrunItemList []testrunItem
 
 func (l testrunItemList) GetPaginatedList(from, to int) pagination.Interface {
+	to++
+	if from > len(l) {
+		return make(testrunItemList, 0)
+	}
+	if to >= len(l) {
+		return l[from:]
+	}
 	return l[from:to]
 }
 

--- a/pkg/tm-bot/ui/pages/testrun.go
+++ b/pkg/tm-bot/ui/pages/testrun.go
@@ -91,7 +91,6 @@ func NewTestrunPage(p *Page) http.HandlerFunc {
 				testrun:   tr,
 				ID:        tr.GetName(),
 				Namespace: tr.GetNamespace(),
-				RunID:     tr.GetLabels()[common.LabelTestrunExecutionGroup],
 				Phase:     PhaseIcon(tr.Status.Phase),
 				StartTime: startTime,
 				Duration:  d.String(),
@@ -100,6 +99,15 @@ func NewTestrunPage(p *Page) http.HandlerFunc {
 			},
 			Steps:     make(testrunStepStatusItemList, len(tr.Status.Steps)),
 			RawStatus: statusTable.String(),
+		}
+		if retries, ok := tr.Annotations[common.AnnotationRetries]; ok {
+			item.Retries = retries
+		}
+		if prevAttempt, ok := tr.Annotations[common.AnnotationPreviousAttempt]; ok {
+			item.PreviousAttempt = prevAttempt
+		}
+		if runID, ok := tr.Labels[common.LabelTestrunExecutionGroup]; ok {
+			item.RunID = runID
 		}
 		if argoHostURL != "" {
 			item.ArgoURL = testrunner.GetArgoURLFromHost(argoHostURL, tr)

--- a/pkg/tm-bot/ui/templates/testrun.html
+++ b/pkg/tm-bot/ui/templates/testrun.html
@@ -24,6 +24,14 @@
                         <label class="mdl-textfield__label" for="dimension">Dimension</label>
                     </div>
                 </div>
+                {{ if .page.PreviousAttempt }}
+                <div class="mdl-cell  mdl-list__item-primary-content">
+                    <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+                        <input class="mdl-textfield__input" id="attempt" value="{{ .page.PreviousAttempt }}" readonly>
+                        <label class="mdl-textfield__label" for="attempt">Attempt {{ .page.Retries }}</label>
+                    </div>
+                </div>
+                {{ end }}
             </div>
             <div class="mdl-grid">
                 <div class="mdl-cell mdl-list__item-primary-content">
@@ -77,6 +85,12 @@
 
         </div></div>
         <div class="mdl-card__menu">
+            {{ if .page.PreviousAttempt }}
+                <a class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect" href="/testrun/{{ .page.Namespace }}/{{ .page.PreviousAttempt }}">
+                    <i class="material-icons mdl-list__item-icon">replay</i>
+                    Previous Attempt
+                </a>
+            {{ end }}
             {{ if .page.ArgoURL }}
                 <a id="argo-url-{{.page.ID}}" href="{{ .page.ArgoURL }}" target="_blank" class="mdl-button mdl-js-button mdl-button--fab mdl-button--mini-fab"><img alt="argo logo" src="/static/img/argo.svg" /></a>
                 <div class="mdl-tooltip" for="argo-url-{{.page.ID}}">Show Argo Workflow</div>

--- a/pkg/tm-bot/ui/templates/testruns.html
+++ b/pkg/tm-bot/ui/templates/testruns.html
@@ -50,6 +50,7 @@
                 <th class="mdl-data-table__cell--non-numeric">Progress</th>
                 <th class="mdl-data-table__cell--non-numeric">Start</th>
                 <th class="mdl-data-table__cell--non-numeric">Duration</th>
+                <th class="mdl-data-table__cell--non-numeric">Attempt</th>
                 <th class="mdl-data-table__cell--non-numeric">Details</th>
                 <th></th>
                 <th></th>
@@ -67,6 +68,7 @@
                     <td id="usage-col" class="mdl-data-table__cell--non-numeric">{{ $test.Progress }}</td>
                     <td id="usage-col" class="mdl-data-table__cell--non-numeric">{{ $test.StartTime }}</td>
                     <td id="usage-col" class="mdl-data-table__cell--non-numeric">{{ $test.Duration }}</td>
+                    <td id="usage-col" class="mdl-data-table__cell--non-numeric">{{ $test.Retries }}</td>
                     <td id="usage-col" class="mdl-data-table__cell--non-numeric">{{ $test.Dimension }}</td>
                     <td class="mdl-data-table__cell--numeric actions">
                         <a href="/testrun/{{ $test.Namespace }}/{{ $test.ID }}" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect">Details</a>


### PR DESCRIPTION
**What this PR does / why we need it**:

![image](https://user-images.githubusercontent.com/7979201/86483513-82f1ab00-bd54-11ea-86b6-939cc5c4836d.png)


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
It is now possible in the TM Dashboard to cutomize the testrun range. Also with that the correct page range is now displayed and the testruns start counting at 1 instead of 0.
```
```improvement user
Retry attempts are now correctly propagated to the annotations.
```
```improvement user
A new annotation has been introduced with a backlink to the previous attempt. Also the backlink and the attempts are now shown in the dashboard.
```
