### PR TITLE
Split slack messages send by notify into chunks of slacks message limit

### DIFF
--- a/pkg/util/slack-table-post.go
+++ b/pkg/util/slack-table-post.go
@@ -180,3 +180,53 @@ func (l resultRows) Less(a, b int) bool {
 
 	return vA.GreaterThan(vB)
 }
+
+// SplitString splits a string into byte slices of the given length.
+// Tt will try to split only on newlines.
+func SplitString(text string, size int) []string {
+	if len(text) < size {
+		return []string{text}
+	}
+
+	textByNL := strings.SplitAfter(text, "\n")
+	if len(textByNL) == 1 {
+		return splitStringWithSize(text, size)
+	}
+	var (
+		chunk string
+	)
+	chunks := make([]string, 0)
+	for _, text := range textByNL {
+		if (len(chunk) + len(text)) >= size {
+			chunks = append(chunks, chunk)
+			chunk = ""
+		}
+		if len(text) > size {
+			chunks = append(chunks, splitStringWithSize(text, size)...)
+			continue
+		}
+		chunk = chunk + text
+	}
+	if len(chunk) > 0 {
+		chunks = append(chunks, chunk)
+	}
+
+	return chunks
+}
+
+func splitStringWithSize(data string, size int) []string {
+	if len(data) < size {
+		return []string{data}
+	}
+
+	var chunk string
+	chunks := make([]string, 0, len(data)/size+1)
+	for len(data) >= size {
+		chunk, data = data[:size], data[size:]
+		chunks = append(chunks, chunk)
+	}
+	if len(data) > 0 {
+		chunks = append(chunks, data)
+	}
+	return chunks
+}

--- a/pkg/util/slack-table-post_test.go
+++ b/pkg/util/slack-table-post_test.go
@@ -1,0 +1,44 @@
+// Copyright 2020 Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/gardener/test-infra/pkg/util"
+)
+
+var _ = Describe("Slack Table Post", func() {
+
+	Context("SplitStrings", func() {
+		It("Should return the text if the text is lower than the given max size", func() {
+			data := "Lorem ipsum"
+			res := util.SplitString(data, 20)
+			Expect(res).To(HaveLen(1))
+			Expect(res[0]).To(Equal(data))
+		})
+
+		It("Should split by newline", func() {
+			data := "Lor\nem\nipsum\ndolor"
+			res := util.SplitString(data, 9)
+			Expect(res).To(HaveLen(3))
+			Expect(res[0]).To(Equal("Lor\nem\n"))
+			Expect(res[1]).To(Equal("ipsum\n"))
+			Expect(res[2]).To(Equal("dolor"))
+		})
+	})
+
+})


### PR DESCRIPTION
**What this PR does / why we need it**:
An issue has been fixed that destroyed the slack formatting for messages that are longer than slacks max message size limit.
This PR splits the slack menssage in chunks sop that our preffered formatting is applied.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Slack Notifications are now correctly formatted even if the message is bigger than slacks max message limit.
```
