### PR TITLE
Add additional dimension info to slack table renderer to include NoPrivCtrs

### DIFF
--- a/pkg/testrunner/result/summary-poster.go
+++ b/pkg/testrunner/result/summary-poster.go
@@ -83,8 +83,12 @@ func parseTestrunsToTableItems(runs testrunner.RunList) (tableItems util.TableIt
 				}
 			}
 
+			var additionalDimensionInfo string
+			if !*meta.AllowPrivilegedContainers {
+				additionalDimensionInfo = "NoPrivCtrs"
+			}
 			item := &util.TableItem{
-				Meta:         util.ItemMeta{CloudProvider: meta.CloudProvider, TestrunID: meta.Testrun.ID, OperatingSystem: meta.OperatingSystem, KubernetesVersion: meta.KubernetesVersion, FlavorDescription: meta.FlavorDescription},
+				Meta:         util.ItemMeta{CloudProvider: meta.CloudProvider, TestrunID: meta.Testrun.ID, OperatingSystem: meta.OperatingSystem, KubernetesVersion: meta.KubernetesVersion, FlavorDescription: meta.FlavorDescription, AdditionalDimensionInfo: additionalDimensionInfo},
 				StatusSymbol: status,
 			}
 			tableItems = append(tableItems, item)

--- a/pkg/util/slack-table-post.go
+++ b/pkg/util/slack-table-post.go
@@ -45,11 +45,12 @@ type TableItem struct {
 }
 
 type ItemMeta struct {
-	CloudProvider     string
-	TestrunID         string
-	OperatingSystem   string
-	KubernetesVersion string
-	FlavorDescription string
+	CloudProvider           string
+	TestrunID               string
+	OperatingSystem         string
+	KubernetesVersion       string
+	FlavorDescription       string
+	AdditionalDimensionInfo string
 }
 
 type resultRow struct {
@@ -89,6 +90,9 @@ func RenderTableForSlack(log logr.Logger, items TableItems) (string, error) {
 		}
 
 		dimensionKey := fmt.Sprintf("%s %s", meta.KubernetesVersion, meta.OperatingSystem)
+		if meta.AdditionalDimensionInfo != "" {
+			dimensionKey = fmt.Sprintf("%s [%s]", dimensionKey, meta.AdditionalDimensionInfo)
+		}
 		if meta.FlavorDescription != "" {
 			dimensionKey = fmt.Sprintf("%s (%s)", dimensionKey, meta.FlavorDescription)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a generic "additional dimension info" field to the slack output table to include additional dimension/metadata information like the recently introduced `allowPrivilegeContainers`.
