### PR TITLE
revert testrunner watches to intelligent polling

### DIFF
--- a/cmd/testrunner/cmd/run_template/options.go
+++ b/cmd/testrunner/cmd/run_template/options.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gardener/test-infra/pkg/common"
 	"github.com/gardener/test-infra/pkg/logger"
 	"github.com/gardener/test-infra/pkg/shootflavors"
+	"github.com/gardener/test-infra/pkg/testmachinery/controller/watch"
 	"github.com/gardener/test-infra/pkg/testrunner"
 	"github.com/gardener/test-infra/pkg/testrunner/result"
 	testrunnerTemplate "github.com/gardener/test-infra/pkg/testrunner/template"
@@ -36,6 +37,7 @@ import (
 
 type options struct {
 	testrunnerConfig testrunner.Config
+	watchOptions     watch.Options
 	collectConfig    result.Config
 	shootParameters  testrunnerTemplate.Parameters
 
@@ -135,6 +137,7 @@ func (o *options) AddFlags(fs *pflag.FlagSet) error {
 	fs.BoolVar(&o.testrunnerConfig.Serial, "serial", false, "executes all testruns of a bucket only after the previous bucket has finished")
 	fs.IntVar(&o.testrunnerConfig.BackoffBucket, "backoff-bucket", 0, "Number of parallel created testruns per backoff period")
 	fs.DurationVar(&o.testrunnerConfig.BackoffPeriod, "backoff-period", 0, "Time to wait between the creation of testrun buckets")
+	fs.DurationVar(o.watchOptions.PollInterval, "poll-interval", time.Minute, "poll interval of the underlaying watch")
 
 	fs.StringVar(&o.collectConfig.ConcourseOnErrorDir, "concourse-onError-dir", os.Getenv("ON_ERROR_DIR"), "On error dir which is used by Concourse.")
 

--- a/cmd/testrunner/cmd/run_template/run_template.go
+++ b/cmd/testrunner/cmd/run_template/run_template.go
@@ -88,7 +88,7 @@ func (o *options) run(ctx context.Context) error {
 
 	logger.Log.V(3).Info("starting watcher")
 
-	watcher, err := watch.NewFromFile(logger.Log.WithName("watch"), o.tmKubeconfigPath, nil)
+	watcher, err := watch.NewFromFile(logger.Log.WithName("watch"), o.tmKubeconfigPath, &o.watchOptions)
 	if err != nil {
 		return errors.Wrap(err, "unable to start testrun watch controller")
 	}

--- a/cmd/testrunner/cmd/run_testrun/options.go
+++ b/cmd/testrunner/cmd/run_testrun/options.go
@@ -21,11 +21,13 @@ import (
 
 	"github.com/spf13/pflag"
 
+	"github.com/gardener/test-infra/pkg/testmachinery/controller/watch"
 	"github.com/gardener/test-infra/pkg/testrunner"
 )
 
 type options struct {
 	testrunnerConfig testrunner.Config
+	watchOptions     watch.Options
 
 	fs                   *pflag.FlagSet
 	dryRun               bool
@@ -73,6 +75,7 @@ func (o *options) AddFlags(fs *pflag.FlagSet) error {
 	fs.BoolVar(&o.testrunnerConfig.ExecutorConfig.Serial, "serial", false, "executes all testruns of a bucket only after the previous bucket has finished")
 	fs.IntVar(&o.testrunnerConfig.ExecutorConfig.BackoffBucket, "backoff-bucket", 0, "Number of parallel created testruns per backoff period")
 	fs.DurationVar(&o.testrunnerConfig.ExecutorConfig.BackoffPeriod, "backoff-period", 0, "Time to wait between the creation of testrun buckets")
+	fs.DurationVar(o.watchOptions.PollInterval, "poll-interval", time.Minute, "poll interval of the underlaying watch")
 
 	// DEPRECATED FLAGS
 	// is now handled by the testmachinery

--- a/cmd/testrunner/cmd/run_testrun/run_testrun.go
+++ b/cmd/testrunner/cmd/run_testrun/run_testrun.go
@@ -64,7 +64,7 @@ func NewRunTestrunCommand() (*cobra.Command, error) {
 func (o *options) run(ctx context.Context) error {
 	logger.Log.Info("start testmachinery testrunner")
 
-	watcher, err := watch.NewFromFile(logger.Log, o.tmKubeconfigPath, nil)
+	watcher, err := watch.NewFromFile(logger.Log, o.tmKubeconfigPath, &o.watchOptions)
 	if err != nil {
 		logger.Log.Error(err, "unable to start testrun watch controller")
 		os.Exit(1)

--- a/pkg/testmachinery/controller/watch/cache.go
+++ b/pkg/testmachinery/controller/watch/cache.go
@@ -1,0 +1,111 @@
+// Copyright 2020 Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package watch
+
+import (
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/rest"
+	toolscache "k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+
+	tmv1beta1 "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
+)
+
+// CachedInformerType specifies the cached informer type.
+const CachedInformerType InformerType = "cached"
+
+type cachedInformer struct {
+	log      logr.Logger
+	client   client.Client
+	cache    cache.Cache
+	eventbus EventBus
+}
+
+func newCachedInformer(log logr.Logger, config *rest.Config, options *Options) (Informer, error) {
+	mapper, err := apiutil.NewDynamicRESTMapper(config)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create the informer for the cached read client and registering informers
+	cache, err := cache.New(config, cache.Options{Scheme: options.Scheme, Mapper: mapper, Resync: options.SyncPeriod, Namespace: options.Namespace})
+	if err != nil {
+		return nil, err
+	}
+
+	writer, err := client.New(config, client.Options{
+		Scheme: options.Scheme,
+		Mapper: mapper,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	c := &client.DelegatingClient{
+		Reader: &client.DelegatingReader{
+			CacheReader:  cache,
+			ClientReader: writer,
+		},
+		Writer:       writer,
+		StatusClient: writer,
+	}
+	return &cachedInformer{
+		log:    log,
+		client: c,
+		cache:  cache,
+	}, nil
+}
+
+func (c *cachedInformer) Start(stop <-chan struct{}) error {
+	i, err := c.cache.GetInformer(&tmv1beta1.Testrun{})
+	if err != nil {
+		if kindMatchErr, ok := err.(*meta.NoKindMatchError); ok {
+			c.log.Error(err, "if kind is a CRD, it should be installed before calling Start",
+				"kind", kindMatchErr.GroupKind)
+		}
+		return err
+	}
+	i.AddEventHandler(toolscache.ResourceEventHandlerFuncs{
+		AddFunc:    c.addItemToQueue,
+		UpdateFunc: func(old, new interface{}) { c.addItemToQueue(new) },
+		DeleteFunc: c.addItemToQueue,
+	})
+
+	return c.cache.Start(stop)
+}
+
+func (c *cachedInformer) WaitForCacheSync(stop <-chan struct{}) bool {
+	return c.cache.WaitForCacheSync(stop)
+}
+
+func (c *cachedInformer) InjectEventBus(eb EventBus) {
+	c.eventbus = eb
+}
+
+func (c *cachedInformer) Client() client.Client {
+	return c.client
+}
+
+func (c *cachedInformer) addItemToQueue(obj interface{}) {
+	// try to cast to testrun ignore the event if this is not possible
+	tr, ok := obj.(*tmv1beta1.Testrun)
+	if !ok {
+		return
+	}
+	c.eventbus.Publish(keyOfTestrun(tr), tr)
+}

--- a/pkg/testmachinery/controller/watch/defaults.go
+++ b/pkg/testmachinery/controller/watch/defaults.go
@@ -25,6 +25,10 @@ func applyDefaultOptions(opts *Options) *Options {
 		opts = &Options{}
 	}
 
+	if len(opts.InformerType) == 0 {
+		opts.InformerType = CachedInformerType
+	}
+
 	if opts.Scheme == nil {
 		opts.Scheme = testmachinery.TestMachineryScheme
 	}
@@ -32,6 +36,10 @@ func applyDefaultOptions(opts *Options) *Options {
 	if opts.SyncPeriod == nil {
 		d := 10 * time.Minute
 		opts.SyncPeriod = &d
+	}
+	if opts.PollInterval == nil {
+		d := 1 * time.Minute
+		opts.PollInterval = &d
 	}
 	return opts
 }

--- a/pkg/testmachinery/controller/watch/eventbus.go
+++ b/pkg/testmachinery/controller/watch/eventbus.go
@@ -15,9 +15,16 @@
 package watch
 
 import (
+	"errors"
+	"fmt"
+	"strings"
 	"sync"
+	"time"
 
+	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/workqueue"
 
 	tmv1beta1 "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
 )
@@ -27,25 +34,61 @@ type TestrunChannel chan *tmv1beta1.Testrun
 type EventBusHandle *int
 
 type EventBus interface {
+	// Start starts watcher and its informer
+	Start(<-chan struct{}) error
+	// Subscribe registers a subscription to receive vents published for a specific key.
 	Subscribe(key string, ch TestrunChannel) EventBusHandle
+	// Unsubscribe removes the subscription from a key with the unique handle.
 	Unsubscribe(key string, h EventBusHandle)
+	// Publish sends a update to all registered subscription for the specific key.
 	Publish(key string, tr *tmv1beta1.Testrun)
+	// Has checks if the given is subscribed by anyone.
 	Has(key string) bool
+	// Subscriptions returns a list of all watched keys.
+	Subscriptions() []string
 }
 
 type eventbus struct {
+	log     logr.Logger
+	queue   workqueue.RateLimitingInterface
 	watches map[string]map[EventBusHandle]TestrunChannel
 	mux     sync.RWMutex
 }
 
-func NewEventBus() EventBus {
+func NewEventBus(log logr.Logger) EventBus {
 	return &eventbus{
+		log:     log,
 		watches: make(map[string]map[EventBusHandle]TestrunChannel),
 		mux:     sync.RWMutex{},
 	}
 }
 
+func (e *eventbus) Start(stop <-chan struct{}) error {
+	e.queue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "watch")
+	defer e.queue.ShutDown()
+
+	const jitterPeriod = 1 * time.Second
+
+	// we only need one worker here
+	go wait.Until(e.worker, jitterPeriod, stop)
+
+	<-stop
+	return nil
+}
+
 func (e *eventbus) Publish(key string, tr *tmv1beta1.Testrun) {
+	e.mux.RLock()
+	_, ok := e.watches[key]
+	defer e.mux.RUnlock()
+	if !ok {
+		return
+	}
+
+	e.queue.Add(tr)
+}
+
+// publish should be only called from the rate limited workqueue and does the actual publish of events
+func (e *eventbus) publish(key string, tr *tmv1beta1.Testrun) {
 	e.mux.RLock()
 	defer e.mux.RUnlock()
 	bus, ok := e.watches[key]
@@ -98,7 +141,7 @@ func (e *eventbus) Unsubscribe(key string, h EventBusHandle) {
 	delete(bus, h)
 }
 
-// has returns whether a the requested is watched
+// Has returns whether a the requested is watched
 func (e *eventbus) Has(key string) bool {
 	e.mux.RLock()
 	defer e.mux.RUnlock()
@@ -109,6 +152,58 @@ func (e *eventbus) Has(key string) bool {
 	return len(bus) != 0
 }
 
+// Subscriptions returns all subscribed testruns
+func (e *eventbus) Subscriptions() []string {
+	e.mux.RLock()
+	defer e.mux.RUnlock()
+	watches := make([]string, len(e.watches))
+	i := 0
+	for key := range e.watches {
+		watches[i] = key
+		i++
+	}
+	return watches
+}
+
+func (e *eventbus) worker() {
+	for e.processQueue() {
+	}
+}
+
+// processQueue takes the next item from the queue
+func (e *eventbus) processQueue() bool {
+	obj, shutdown := e.queue.Get()
+	if shutdown {
+		return false
+	}
+	defer e.queue.Done(obj)
+
+	tr, ok := obj.(*tmv1beta1.Testrun)
+	if !ok {
+		// As the item in the workqueue is actually invalid, so remove it directly form the queue
+		e.queue.Forget(obj)
+		e.log.V(5).Info("watch queue item was not a testrun", "type", fmt.Sprintf("%T", obj), "value", obj)
+		// Return true, don't take a break
+		return true
+	}
+
+	e.publish(keyOfTestrun(tr), tr)
+
+	e.queue.Forget(obj)
+	return true
+}
+
 func keyOfTestrun(tr *tmv1beta1.Testrun) string {
 	return types.NamespacedName{Name: tr.Name, Namespace: tr.Namespace}.String()
+}
+
+func namespacedNameFromKey(key string) (types.NamespacedName, error) {
+	splitKey := strings.Split(key, string(types.Separator))
+	if len(splitKey) != 2 {
+		return types.NamespacedName{}, errors.New("invalid namespaced name")
+	}
+	return types.NamespacedName{
+		Name:      splitKey[1],
+		Namespace: splitKey[0],
+	}, nil
 }

--- a/pkg/testmachinery/controller/watch/polling.go
+++ b/pkg/testmachinery/controller/watch/polling.go
@@ -1,0 +1,106 @@
+// Copyright 2020 Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package watch
+
+import (
+	"context"
+	"reflect"
+	"time"
+
+	"github.com/go-logr/logr"
+	log "github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	tmv1beta1 "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
+)
+
+// PollingInformerType specifies the polling informer type.
+const PollingInformerType InformerType = "polling"
+
+type pollingInformer struct {
+	log          logr.Logger
+	client       client.Client
+	eventbus     EventBus
+	pollInterval time.Duration
+
+	old map[string]*tmv1beta1.Testrun
+}
+
+func newPollingInformer(log logr.Logger, config *rest.Config, options *Options) (Informer, error) {
+	c, err := client.New(config, client.Options{
+		Scheme: options.Scheme,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &pollingInformer{
+		log:          log,
+		client:       c,
+		pollInterval: *options.PollInterval,
+		old:          make(map[string]*tmv1beta1.Testrun),
+	}, nil
+}
+
+// Start starts the polling
+func (p *pollingInformer) Start(stop <-chan struct{}) error {
+	return wait.PollImmediateUntil(p.pollInterval, p.process, stop)
+}
+
+func (p *pollingInformer) process() (done bool, err error) {
+	ctx := context.Background()
+	defer ctx.Done()
+
+	newOldCache := make(map[string]*tmv1beta1.Testrun)
+	for _, key := range p.eventbus.Subscriptions() {
+		nn, err := namespacedNameFromKey(key)
+		if err != nil {
+			p.log.Error(err, "invalid key identifier", "key", key)
+			continue
+		}
+
+		tr := &tmv1beta1.Testrun{}
+		if err := p.client.Get(ctx, nn, tr); err != nil {
+			if !apierrors.IsNotFound(err) {
+				log.Error(err, "unable to get tr", "key", key)
+			}
+			continue
+		}
+
+		if old, ok := p.old[key]; ok && reflect.DeepEqual(old, tr) {
+			continue
+		}
+
+		p.eventbus.Publish(key, tr)
+	}
+
+	p.old = newOldCache
+	return false, nil
+}
+
+// WaitForCacheSync implements a noop operation for th polling informer as there are no caches to start
+func (p *pollingInformer) WaitForCacheSync(stop <-chan struct{}) bool {
+	return true
+}
+
+func (p *pollingInformer) InjectEventBus(eb EventBus) {
+	p.eventbus = eb
+}
+
+func (p *pollingInformer) Client() client.Client {
+	return p.client
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
A new polling informer for the testrun watch has been added.
```
```improvement operator
Testrunner watches do now use the new polling informer.
```
