### PR TITLE
Add "additionalLocations" to flavors

### DIFF
--- a/pkg/apis/testmachinery/v1beta1/types.go
+++ b/pkg/apis/testmachinery/v1beta1/types.go
@@ -15,6 +15,7 @@
 package v1beta1
 
 import (
+	"fmt"
 	argov1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
 	"github.com/gardener/test-infra/pkg/util/strconf"
 	corev1 "k8s.io/api/core/v1"
@@ -30,9 +31,22 @@ type LocationType string
 
 // Testdefinition location types
 const (
-	LocationTypeGit   LocationType = "git"
-	LocationTypeLocal LocationType = "local"
+	LocationTypeGit     LocationType = "git"
+	LocationTypeLocal   LocationType = "local"
+	LocationTypeUnknown LocationType = "unknown"
 )
+
+// GetLocationType returns the LocationType constant for the given string. Returns LocationTypeUnknown and an error if the given string did not match any known location type.
+func GetLocationType(locationType string) (LocationType, error) {
+	switch locationType {
+	case "git":
+		return LocationTypeGit, nil
+	case "local":
+		return LocationTypeLocal, nil
+	default:
+		return LocationTypeUnknown, fmt.Errorf("unknown location type '%s'", locationType)
+	}
+}
 
 // ConditionType is the type of a testflow step indicating when it should be executed.
 type ConditionType string

--- a/pkg/common/types_shootflavor.go
+++ b/pkg/common/types_shootflavor.go
@@ -53,6 +53,9 @@ type Shoot struct {
 	// AdditionalAnnotations holds annotations to be added to created shoots
 	AdditionalAnnotations map[string]string
 
+	// AdditionalLocations defines additional locations or overwrites locations from where to get tests from
+	AdditionalLocations []AdditionalLocation
+
 	// Worker pools to test
 	Workers []gardencorev1beta1.Worker
 }
@@ -77,8 +80,19 @@ type ShootFlavor struct {
 	// +optional
 	AdditionalAnnotations map[string]string `json:"annotations"`
 
+	// AdditionalLocations defines additional locations or overwrites locations from where to get tests from
+	// +optional
+	AdditionalLocations []AdditionalLocation `json:"additionalLocations"`
+
 	// Worker pools to test
 	Workers []ShootWorkerFlavor `json:"workers"`
+}
+
+// AdditionalLocation describes a location where to look for tests (beyond the ones added automatically from the component descriptor).
+type AdditionalLocation struct {
+	Type     string `json:"type"`
+	Repo     string `json:"repo"`
+	Revision string `json:"revision"`
 }
 
 type ShootKubernetesVersionFlavor struct {

--- a/pkg/shootflavors/extendedflavors.go
+++ b/pkg/shootflavors/extendedflavors.go
@@ -93,6 +93,7 @@ func NewExtended(k8sClient client.Client, rawFlavors []*common.ExtendedShootFlav
 						Shoot: common.Shoot{
 							Description:               rawFlavor.Description,
 							AdditionalAnnotations:     rawFlavor.AdditionalAnnotations,
+							AdditionalLocations:       rawFlavor.AdditionalLocations,
 							Provider:                  rawFlavor.Provider,
 							KubernetesVersion:         k8sVersion,
 							AllowPrivilegedContainers: rawFlavor.AllowPrivilegedContainers,

--- a/pkg/shootflavors/extendedflavors_test.go
+++ b/pkg/shootflavors/extendedflavors_test.go
@@ -87,6 +87,7 @@ var _ = Describe("extended flavor test", func() {
 			ShootFlavor: common.ShootFlavor{
 				AllowPrivilegedContainers: pointer.BoolPtr(true),
 				AdditionalAnnotations:     map[string]string{"a": "b"},
+				AdditionalLocations:       []common.AdditionalLocation{{Type: "git", Repo: "https:// github.com/gardener/gardener", Revision: "master"}},
 				Provider:                  common.CloudProviderGCP,
 				KubernetesVersions: common.ShootKubernetesVersionFlavor{
 					Versions: &[]gardencorev1beta1.ExpirableVersion{
@@ -113,6 +114,7 @@ var _ = Describe("extended flavor test", func() {
 			Provider:                  common.CloudProviderGCP,
 			AllowPrivilegedContainers: pointer.BoolPtr(true),
 			AdditionalAnnotations:     map[string]string{"a": "b"},
+			AdditionalLocations:       []common.AdditionalLocation{{Type: "git", Repo: "https:// github.com/gardener/gardener", Revision: "master"}},
 			KubernetesVersion:         gardencorev1beta1.ExpirableVersion{Version: "1.15"},
 			Workers:                   []gardencorev1beta1.Worker{{Name: "wp1"}},
 		}))

--- a/pkg/shootflavors/flavors.go
+++ b/pkg/shootflavors/flavors.go
@@ -83,6 +83,7 @@ func New(rawFlavors []*common.ShootFlavor) (*Flavors, error) {
 
 					shoots = append(shoots, &common.Shoot{
 						AdditionalAnnotations:     rawFlavor.AdditionalAnnotations,
+						AdditionalLocations:       rawFlavor.AdditionalLocations,
 						Provider:                  rawFlavor.Provider,
 						KubernetesVersion:         k8sVersion,
 						AllowPrivilegedContainers: rawFlavor.AllowPrivilegedContainers,
@@ -93,6 +94,7 @@ func New(rawFlavors []*common.ShootFlavor) (*Flavors, error) {
 			}
 			shoots = append(shoots, &common.Shoot{
 				AdditionalAnnotations:     rawFlavor.AdditionalAnnotations,
+				AdditionalLocations:       rawFlavor.AdditionalLocations,
 				Provider:                  rawFlavor.Provider,
 				KubernetesVersion:         k8sVersion,
 				AllowPrivilegedContainers: rawFlavor.AllowPrivilegedContainers,

--- a/pkg/shootflavors/flavors_test.go
+++ b/pkg/shootflavors/flavors_test.go
@@ -102,6 +102,32 @@ var _ = Describe("flavor test", func() {
 		))
 	})
 
+	It("should return one shoot with additional locations", func() {
+		rawFlavors := []*common.ShootFlavor{
+			{
+				Provider:            common.CloudProviderGCP,
+				AdditionalLocations: []common.AdditionalLocation{{Type: "git", Repo: "github.com/org/name", Revision: "1.2.3"}},
+				KubernetesVersions: common.ShootKubernetesVersionFlavor{
+					Versions: &[]gardencorev1beta1.ExpirableVersion{
+						{
+							Version: "1.15",
+						},
+					},
+				},
+			},
+		}
+		flavors, err := New(rawFlavors)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(flavors.GetShoots()).To(HaveLen(1))
+		Expect(flavors.GetShoots()).To(ConsistOf(
+			&common.Shoot{
+				Provider:            common.CloudProviderGCP,
+				AdditionalLocations: []common.AdditionalLocation{{Type: "git", Repo: "github.com/org/name", Revision: "1.2.3"}},
+				KubernetesVersion:   gardencorev1beta1.ExpirableVersion{Version: "1.15"},
+			},
+		))
+	})
+
 	It("should return one shoot with disabled allowPrivilegeContainers", func() {
 		rawFlavors := []*common.ShootFlavor{
 			{

--- a/pkg/testrun_renderer/default/default.go
+++ b/pkg/testrun_renderer/default/default.go
@@ -97,8 +97,9 @@ func Render(cfg *Config) (*v1beta1.Testrun, error) {
 	}
 
 	shoots := make([]*shoot, 0)
-
+	additionalLocs := make([]common.AdditionalLocation, 0)
 	for _, flavor := range cfg.Shoots.Flavors.GetShoots() {
+		additionalLocs = append(additionalLocs, flavor.AdditionalLocations...)
 		shoots = append(shoots, &shoot{
 			Type:      flavor.Provider,
 			Suffix:    fmt.Sprintf("%s-%s", flavor.Provider, util.RandomString(3)),
@@ -132,7 +133,7 @@ func Render(cfg *Config) (*v1beta1.Testrun, error) {
 		return nil, err
 	}
 
-	if err := testrun_renderer.AddBOMLocationsToTestrun(tr, "default", cfg.Components, true); err != nil {
+	if err := testrun_renderer.AddLocationsToTestrun(tr, "default", cfg.Components, true, additionalLocs); err != nil {
 		return nil, err
 	}
 	return tr, nil

--- a/pkg/testrunner/template/renderer.go
+++ b/pkg/testrunner/template/renderer.go
@@ -90,7 +90,7 @@ func (r *templateRenderer) Render(parameters *internalParameters, chartPath stri
 			meta := metadata.DeepCopy()
 			// Add all repositories defined in the component descriptor to the testrun locations.
 			// This gives us all dependent repositories as well as there deployed version.
-			if err := testrun_renderer.AddBOMLocationsToTestrun(tr, "default", parameters.ComponentDescriptor, true); err != nil {
+			if err := testrun_renderer.AddLocationsToTestrun(tr, "default", parameters.ComponentDescriptor, true, parameters.AdditionalLocations); err != nil {
 				r.log.Info(fmt.Sprintf("cannot add bom locations: %s", err.Error()))
 				continue
 			}

--- a/pkg/testrunner/template/shoot_template_test.go
+++ b/pkg/testrunner/template/shoot_template_test.go
@@ -16,6 +16,7 @@ package template
 
 import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
 	"github.com/gardener/test-infra/pkg/shootflavors"
 	"k8s.io/utils/pointer"
 	"path/filepath"
@@ -41,6 +42,7 @@ var _ = Describe("shoot templates", func() {
 					Workers:                   []gardencorev1beta1.Worker{{Name: "wp1", Machine: gardencorev1beta1.Machine{Image: &gardencorev1beta1.ShootMachineImage{Name: "core-os"}}}},
 					AllowPrivilegedContainers: pointer.BoolPtr(false),
 					AdditionalAnnotations:     map[string]string{"a": "b"},
+					AdditionalLocations:       []common.AdditionalLocation{{Type: "git", Repo: "https://github.com/gardener/gardener", Revision: "1.2.3"}},
 				},
 				ExtendedShootConfiguration: common.ExtendedShootConfiguration{
 					Name:         "test-name",
@@ -82,6 +84,12 @@ var _ = Describe("shoot templates", func() {
 			Expect(tr.Annotations).To(HaveKeyWithValue("shoot.k8sVersion", "1.15.2"))
 			Expect(tr.Annotations).To(HaveKeyWithValue("shoot.k8sPrevPrePatchVersion", "1.15.2"))
 			Expect(tr.Annotations).To(HaveKeyWithValue("shoot.k8sPrevPatchVersion", "1.15.2"))
+
+			Expect(tr.Spec.LocationSets[0].Locations).To(ContainElement(v1beta1.TestLocation{
+				Type:     "git",
+				Repo:     "https://github.com/gardener/gardener",
+				Revision: "1.2.3",
+			}))
 		})
 
 		It("should render the basic shoot chart and write correct metadata", func() {

--- a/pkg/testrunner/template/template.go
+++ b/pkg/testrunner/template/template.go
@@ -98,6 +98,8 @@ func renderChartWithShoot(log logr.Logger, renderer *templateRenderer, parameter
 	}
 
 	for _, flavor := range shootFlavors {
+		parameters := parameters.DeepCopy()
+		parameters.AdditionalLocations = flavor.Get().AdditionalLocations
 		chartPath, err := determineAbsoluteShootChartPath(parameters, flavor.Get().ChartPath)
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to determine chart to render")

--- a/pkg/testrunner/template/types.go
+++ b/pkg/testrunner/template/types.go
@@ -15,6 +15,7 @@
 package template
 
 import (
+	"github.com/gardener/test-infra/pkg/common"
 	"github.com/gardener/test-infra/pkg/testmachinery/metadata"
 	"github.com/gardener/test-infra/pkg/testrunner/componentdescriptor"
 )
@@ -45,9 +46,23 @@ type internalParameters struct {
 	GardenerKubeconfig []byte
 	GardenerVersion    string
 	Landscape          string
+
+	AdditionalLocations []common.AdditionalLocation
 }
 
-// ValueRenderer renders the helm values, run metdata and info for a specific chart rendering
+func (i *internalParameters) DeepCopy() *internalParameters {
+	return &internalParameters{
+		FlavorConfigPath:    i.FlavorConfigPath,
+		ComponentDescriptor: i.ComponentDescriptor,
+		ChartPath:           i.ChartPath,
+		Namespace:           i.Namespace,
+		GardenerKubeconfig:  i.GardenerKubeconfig,
+		GardenerVersion:     i.GardenerVersion,
+		Landscape:           i.Landscape,
+	}
+}
+
+// ValueRenderer renders the helm values, run metadata and info for a specific chart rendering
 type ValueRenderer interface {
 	Render(defaultValues map[string]interface{}) (values map[string]interface{}, metadata *metadata.Metadata, info interface{}, err error)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds field `additionalLocations` to flavors. It allows to add or overwrite locations from where the actual tests are fetched.
Usage example:
```
flavors:
- provider: aws
  additionalLocations:
  - type: git
    repo:  https://github.com/gardener/gardener
    revision: master
```
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
Flavors can customize created TestRuns with additional or overwritten testlocations with field `additionalLocations` containing an array of testlocation objects.
```
