### PR TITLE
Fix gardensetup test

### DIFF
--- a/pkg/testmachinery/config/validation.go
+++ b/pkg/testmachinery/config/validation.go
@@ -30,11 +30,6 @@ func Validate(identifier string, config tmv1beta1.ConfigElement) error {
 		return fmt.Errorf("%s.name: Required value", identifier)
 	}
 
-	// configmaps should either have a value or a value from defined
-	if config.Value == "" && config.ValueFrom == nil {
-		return fmt.Errorf("%s.(value or valueFrom): Required value or valueFrom: A config must consist of a value or a reference to a value", identifier)
-	}
-
 	// if a valuefrom is defined then a configmap or a secret reference should be defined
 	if config.ValueFrom != nil {
 		if err := strconf.Validate(fmt.Sprintf("%s.valueFrom", identifier), config.ValueFrom); err != nil {

--- a/pkg/testrun_renderer/templates/shoots_v1beta1.go
+++ b/pkg/testrun_renderer/templates/shoots_v1beta1.go
@@ -99,11 +99,14 @@ func defaultShootConfig(cfg *CreateShootConfig) []v1beta1.ConfigElement {
 			Name:  ConfigSeedName,
 			Value: ConfigSeedValue,
 		},
-		{
+	}
+
+	if cfg.ShootAnnotations != nil {
+		defaultShootConfig = append(defaultShootConfig, v1beta1.ConfigElement{
 			Type:  v1beta1.ConfigTypeEnv,
 			Name:  ConfigShootAnnotations,
 			Value: util.MarshalMap(cfg.ShootAnnotations),
-		},
+		})
 	}
 
 	if cfg.AllowPrivilegedContainers != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
- Only add shoot annotations if they are defined
- allow empty config elements

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
It is now allowed to specify empty config elements.
```
