### PR TITLE
New elasticsearch command to update/rewrite data

### DIFF
--- a/cmd/elasticsearch/README.md
+++ b/cmd/elasticsearch/README.md
@@ -29,4 +29,14 @@ subcommand is requiredexit status 1
 # Commands
 ## `precompute`
 This command reads all existing teststep metadata from elasticsearch, then re-computes all the precomputed values like phaseNum and clusterDomain and if changes to the existing `.pre` field are detected, updates them in elasticsearch.
-This is useful if you want to modify or amend the precomputed values and fields in the testmachinery code and then want to update all existing data.  
+This is useful if you want to modify or amend the precomputed values and fields in the testmachinery code and then want to update all existing data.
+
+#### Note: read-only indexes
+If you use curator to roll-over indexes, they will be made read-only-allow-delete, hence before attempting to change data, make them read-write again:
+```shell
+# check which indexes are read-only-allow-delete
+curl -s 'localhost:9200/testmachinery-*' | jq '.[].settings.index | {index: .provided_name, readOnly: .blocks.read_only_allow_delete}' -c
+
+# remove read-only-allow-delete for one index
+curl -X PUT "localhost/testmachinery-000017/_settings" -H 'Content-Type: application/json' -d'{ "index.blocks.read_only_allow_delete" : null } }'
+```

--- a/cmd/elasticsearch/README.md
+++ b/cmd/elasticsearch/README.md
@@ -1,0 +1,32 @@
+# Elasticsearch data manipulation tool
+
+```
+Elasticsearch tool for TestMachinery
+
+Usage:
+  elasticsearch [command]
+
+Available Commands:
+  help        Help about any command
+  precompute  Reads existing teststep metadata, re-computes the current precomputed values and optionally updates the respective elasticsearch document.
+
+Flags:
+      --cli                  logger runs as cli logger. enables cli logging
+      --dev                  enable development logging which result in console encoding, enabled stacktrace and enabled caller
+      --disable-caller       disable the caller of logs (default true)
+      --disable-stacktrace   disable the stacktrace of error logs (default true)
+      --disable-timestamp    disable timestamp output (default true)
+      --endpoint string      Elasticsearch endpoint, e.g. https://example.com:9200
+  -h, --help                 help for elasticsearch
+      --password string      Elasticsearch basic auth password
+      --user string          Elasticsearch basic auth username
+  -v, --verbosity int        number for the log level verbosity (default 1)
+
+Use "elasticsearch [command] --help" for more information about a command.
+subcommand is requiredexit status 1
+```
+
+# Commands
+## `precompute`
+This command reads all existing teststep metadata from elasticsearch, then re-computes all the precomputed values like phaseNum and clusterDomain and if changes to the existing `.pre` field are detected, updates them in elasticsearch.
+This is useful if you want to modify or amend the precomputed values and fields in the testmachinery code and then want to update all existing data.  

--- a/cmd/elasticsearch/cmd/cmd.go
+++ b/cmd/elasticsearch/cmd/cmd.go
@@ -1,0 +1,67 @@
+// Copyright 2020 Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/gardener/test-infra/cmd/elasticsearch/cmd/precompute"
+	"github.com/gardener/test-infra/pkg/logger"
+
+	"github.com/spf13/cobra"
+)
+
+var RootFlags struct {
+	Endpoint string
+	User     string
+	Password string
+}
+
+var rootCmd = &cobra.Command{
+	Use:   "elasticsearch",
+	Short: "Elasticsearch tool for TestMachinery",
+	PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+		log, err := logger.NewCliLogger()
+		if err != nil {
+			return err
+		}
+		logger.SetLogger(log)
+
+		_ = cmd.MarkFlagRequired("endpoint")
+		_ = cmd.MarkFlagRequired("user")
+		_ = cmd.MarkFlagRequired("password")
+
+		return nil
+	},
+}
+
+// Execute executes the testrunner cli commands
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Printf("%v", err)
+		os.Exit(1)
+	}
+}
+
+func init() {
+	logger.InitFlags(rootCmd.PersistentFlags())
+
+	rootCmd.PersistentFlags().String("endpoint", "", "Elasticsearch endpoint, e.g. https://example.com:9200")
+	rootCmd.PersistentFlags().StringVar(&RootFlags.User, "user", "", "Elasticsearch basic auth username")
+	rootCmd.PersistentFlags().StringVar(&RootFlags.Password, "password", "", "Elasticsearch basic auth password")
+
+	precompute.AddCommand(rootCmd)
+}

--- a/cmd/elasticsearch/cmd/precompute/precompute.go
+++ b/cmd/elasticsearch/cmd/precompute/precompute.go
@@ -1,0 +1,171 @@
+// Copyright 2020 Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package precompute
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/gardener/test-infra/pkg/apis/config"
+	"github.com/gardener/test-infra/pkg/logger"
+	"github.com/gardener/test-infra/pkg/testmachinery/collector"
+	"github.com/gardener/test-infra/pkg/util/elasticsearch"
+	"github.com/spf13/cobra"
+	"io"
+	"net/http"
+	"reflect"
+)
+
+var (
+	// only touch ES when true, dry-run otherwise
+	updateES bool
+)
+
+// AddCommand adds the precompute subcommand to another command.
+func AddCommand(cmd *cobra.Command) {
+	cmd.AddCommand(precomputeCmd)
+}
+
+var precomputeCmd = &cobra.Command{
+	Use:   "precompute",
+	Short: "Reads existing teststep metadata, re-computes the current precomputed values and optionally updates the respective elasticsearch document.",
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if updateES {
+			logger.Log.Info("Starting 'elasticsearch precompute' in update mode", "elasticsearch endpoint", cmd.Flag("endpoint").Value, "elasticsearch user", cmd.Flag("user").Value)
+		} else {
+			logger.Log.Info("Starting 'elasticsearch precompute' in dry-run mode")
+		}
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := run(cmd); err != nil {
+			logger.Log.Error(err, "error during execution")
+			return err
+		}
+		return nil
+	},
+	PostRun: func(cmd *cobra.Command, args []string) {
+		logger.Log.Info("Finished 'elasticsearch precompute'")
+	},
+}
+
+// package init defines the flags for the precompute command
+func init() {
+	precomputeCmd.Flags().BoolVar(&updateES, "update", false, "when false, only prints potential updates to stdout instead of touching documents in elasticsearch")
+}
+
+func run(cmd *cobra.Command) error {
+	esClient, err := elasticsearch.NewClient(config.ElasticSearch{
+		Endpoint: cmd.Flag("endpoint").Value.String(),
+		Username: cmd.Flag("user").Value.String(),
+		Password: cmd.Flag("password").Value.String(),
+	})
+	if err != nil {
+		return err
+	}
+
+	pageSize := 10
+	path, payload := BuildScrollQueryInitial("testmachinery-*", pageSize)
+
+	var processedItems int
+	for i := 0;; i++ {
+		esResponse, err := queryAndRecomputeAndStore(esClient, path, payload)
+		if err != nil {
+			return err
+		}
+		processedItems += len(esResponse.Hits.Results)
+		logger.Log.Info(fmt.Sprintf("%d%% processed (%d/%d)", processedItems * 100 / esResponse.Hits.Total.Value, processedItems, esResponse.Hits.Total.Value))
+
+		// once we hit the first page with less than pageSize results, there will be no further page -> done
+		if len(esResponse.Hits.Results) < pageSize {
+			break
+		}
+
+		// on to the next page
+		scrollID := esResponse.ScrollID
+		path, payload = BuildScrollQueryNextPage(scrollID)
+	}
+
+	return nil
+}
+
+// queryAndRecomputeAndStore queries the testmachinery index for tm data, recomputes the pre-calculated fields and if changed, updates the respective data
+func queryAndRecomputeAndStore(esClient elasticsearch.Client, path string, payload io.Reader) (QueryResponse, error) {
+	ctx := context.Background()
+	defer ctx.Done()
+
+	bytes, err := esClient.RequestWithCtx(ctx, http.MethodGet, path, payload)
+	if err != nil {
+		return QueryResponse{}, err
+	}
+
+	var esResponse QueryResponse
+	if err := json.Unmarshal(bytes, &esResponse); err != nil {
+		return QueryResponse{}, err
+	}
+	logger.Log.V(6).Info("Got response from ES", "esResponse", esResponse)
+
+	var modifiedItems []Result
+	for _, result := range esResponse.Hits.Results {
+		var k8sVersion, clusterDomain string
+		if result.StepSummary.Metadata != nil {
+			k8sVersion = result.StepSummary.Metadata.Metadata.KubernetesVersion
+			if k8sVersion == "" && result.StepSummary.Metadata.Annotations != nil {
+				k8sVersion = result.StepSummary.Metadata.Annotations["metadata.testmachinery.gardener.cloud/k8sVersion"]
+			}
+			if k8sVersion == "" && result.StepSummary.Metadata.Annotations != nil {
+				k8sVersion = result.StepSummary.Metadata.Annotations["testrunner.testmachinery.sapcloud.io/k8sVersion"]
+			}
+		}
+		oldPreComputed := result.StepSummary.PreComputed
+		if oldPreComputed != nil {
+			clusterDomain = oldPreComputed.ClusterDomain
+		}
+		newPreComputed := collector.PreComputeTeststepFields(result.StepSummary.Phase, k8sVersion, clusterDomain)
+
+		if reflect.DeepEqual(oldPreComputed, newPreComputed) {
+			logger.Log.V(6).Info("old and new precomputed are equal -> nothing to do")
+		} else {
+			logger.Log.Info("preComputed field changed", "oldPreComputed", oldPreComputed, "newPreComputed", newPreComputed)
+			result.StepSummary.PreComputed = newPreComputed
+			modifiedItems = append(modifiedItems, result)
+		}
+	}
+
+	if len(modifiedItems) == 0 {
+		logger.Log.V(6).Info("no modified data for any result (in this page) -> nothing to update")
+		return esResponse, nil
+	}
+
+	path, payload, err = BuildBulkUpdateQuery(modifiedItems)
+	if err != nil {
+		return QueryResponse{}, err
+	}
+	logger.Log.V(6).Info("going to bulk update", "path", path)
+
+
+	if !updateES {
+		logger.Log.Info("Not modifying elasticsearch data as update flag was not set")
+		return esResponse, nil
+	}
+
+	// do the real update
+	bytes, err = esClient.RequestWithCtx(ctx, http.MethodPost, path, payload)
+	if err != nil {
+		logger.Log.Error(err, "Error during bulk update", "response", string(bytes))
+		return QueryResponse{}, err
+	}
+
+	return esResponse, nil
+}

--- a/cmd/elasticsearch/cmd/precompute/query.go
+++ b/cmd/elasticsearch/cmd/precompute/query.go
@@ -1,0 +1,115 @@
+// Copyright 2020 Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package precompute
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/gardener/test-infra/pkg/testmachinery/metadata"
+	"io"
+	"strings"
+)
+
+type QueryResponse struct {
+	ScrollID string `json:"_scroll_id,omitempty"`
+	Hits     Hits   `json:"hits,omitempty"`
+}
+
+type Hits struct {
+	Total Total      `json:"total,omitempty"`
+	Results []Result `json:"hits,omitempty"`
+}
+
+type Total struct {
+	Value int `json:"value"`
+}
+
+type Result struct {
+	Index string `json:"_index"`
+	DocID string `json:"_id"`
+	StepSummary metadata.StepSummary `json:"_source,omitempty"`
+}
+
+func BuildBulkUpdateQuery(items []Result) (path string, payload io.Reader, err error) {
+	path = fmt.Sprintf("/_bulk")
+	var buffer strings.Builder
+	for _, item := range items {
+		buffer.WriteString(fmt.Sprintf("{\"index\":{\"_index\":\"%s\",\"_id\":\"%s\"}}\n", item.Index, item.DocID))
+		bytes, err := json.Marshal(item.StepSummary)
+		if err != nil {
+			return "", nil, err
+		}
+		buffer.Write(bytes)
+		buffer.WriteString("\n")
+	}
+
+	payload = strings.NewReader(buffer.String())
+	return
+}
+
+func BuildScrollQueryInitial(index string, pageSize int) (path string, payload io.Reader) {
+	path = fmt.Sprintf("/%s/_search?scroll=1m", index)
+
+	// default paging size
+	if pageSize == 0 {
+		pageSize = 100
+	}
+
+	// add a filter if you want to restrict the dataset for experimenting/debugging
+	// "range": {
+	//    "tm.tr.startTime": {
+	//        "gte": "2020-09-30T16:45:24.249Z",
+	//        "lte": "2020-10-01T16:45:24.249Z",
+	//        "format": "strict_date_optional_time"
+	//    }
+	// }
+	query := `
+		{
+			"size": %d,
+			"query": {
+				"bool": {
+					"must": [],
+					"filter": [
+						{
+							"match_all": {}
+						},
+						{
+							"match_phrase": {
+								"type.keyword": "teststep"
+							}
+						}
+					],
+					"should": [],
+					"must_not": []
+				}
+			}
+		}`
+	query = fmt.Sprintf(query, pageSize)
+
+	payload = strings.NewReader(query)
+	return
+}
+
+func BuildScrollQueryNextPage(scrollID string) (path string, payload io.Reader) {
+	path = "/_search/scroll"
+	query := `
+		{
+			"scroll": "1m",
+			"scroll_id": "%s"
+		}`
+	query = fmt.Sprintf(query, scrollID)
+	payload = strings.NewReader(query)
+	return
+}

--- a/cmd/elasticsearch/cmd/precompute/query.go
+++ b/cmd/elasticsearch/cmd/precompute/query.go
@@ -22,6 +22,29 @@ import (
 	"strings"
 )
 
+
+type BulkResponse struct {
+	ErrorsOccurred bool `json:"errors"`
+	Items []BulkItem `json:"items,omitempty"`
+}
+
+type BulkItem struct {
+	Index BulkItemIndex `json:"index"`
+}
+
+type BulkItemIndex struct {
+	Index string `json:"_index"`
+	Type string `json:"_type"`
+	ID string `json:"_id"`
+	HTTPStatus int `json:"status"`
+	Error BulkItemIndexError `json:"error"`
+}
+
+type BulkItemIndexError struct {
+	Type string `json:"type"`
+	Reason string `json:"reason,omitempty"`
+}
+
 type QueryResponse struct {
 	ScrollID string `json:"_scroll_id,omitempty"`
 	Hits     Hits   `json:"hits,omitempty"`

--- a/cmd/elasticsearch/main.go
+++ b/cmd/elasticsearch/main.go
@@ -1,0 +1,23 @@
+// Copyright 2020 Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/gardener/test-infra/cmd/elasticsearch/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/pkg/testmachinery/collector/precompute.go
+++ b/pkg/testmachinery/collector/precompute.go
@@ -1,0 +1,68 @@
+// Copyright 2020 Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Copyright 2020 Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"fmt"
+	"github.com/Masterminds/semver"
+	argov1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
+	tmv1beta1 "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
+	"github.com/gardener/test-infra/pkg/testmachinery/metadata"
+)
+
+// PreComputeTeststepFields precomputes fields for elasticsearch that are otherwise hard to add at runtime (i.e. as grafana does not support scripted fields)
+func PreComputeTeststepFields(phase argov1.NodePhase, k8sVersion string, clusterDomain string) *metadata.StepPreComputed {
+	var preComputed metadata.StepPreComputed
+
+	switch phase {
+	case tmv1beta1.PhaseStatusFailed, tmv1beta1.PhaseStatusTimeout:
+		zero := 0
+		preComputed.PhaseNum = &zero
+	case tmv1beta1.PhaseStatusSuccess:
+		hundred := 100
+		preComputed.PhaseNum = &hundred
+	}
+
+	if k8sVersion != "" {
+		semVer, err := semver.NewVersion(k8sVersion)
+		if err != nil {
+			fmt.Printf("cannot parse k8s Version, will not precompute derived data: %s", err)
+		} else {
+			preComputed.K8SMajorMinorVersion = fmt.Sprintf("%d.%d", semVer.Major(), semVer.Minor())
+		}
+	}
+
+	if clusterDomain != "" {
+		preComputed.ArgoDisplayName = "argo"
+		preComputed.LogsDisplayName = "logs"
+		preComputed.ClusterDomain = clusterDomain
+	}
+
+	return &preComputed
+}

--- a/pkg/testmachinery/collector/summary.go
+++ b/pkg/testmachinery/collector/summary.go
@@ -132,11 +132,10 @@ func (c *collector) generateSummary(tr *tmv1beta1.Testrun, meta *metadata.Metada
 
 // preComputeTeststepFields precomputes fields for elasticsearch that are otherwise hard to add at runtime (i.e. as grafana does not support scripted fields)
 func (c *collector) preComputeTeststepFields(stepStatus *tmv1beta1.StepStatus, meta metadata.Metadata) *metadata.StepPreComputed {
-	k8sVersion := meta.KubernetesVersion
 	clusterDomain, err := util.GetClusterDomainURL(c.client)
 	if err != nil {
 		c.log.Error(err, "Could not obtain cluster domain URL, will not pre compute dependent fields (argo-, grafana-url)")
 	}
 
-	return PreComputeTeststepFields(stepStatus.Phase, k8sVersion, clusterDomain)
+	return PreComputeTeststepFields(stepStatus.Phase, meta, clusterDomain)
 }

--- a/pkg/testmachinery/metadata/types.go
+++ b/pkg/testmachinery/metadata/types.go
@@ -85,7 +85,7 @@ type TestrunSummary struct {
 	TelemetryData *TelemetryData     `json:"telemetry,omitempty"`
 }
 
-// StepSummaryMetadata is the metadta for a specific step result.
+// StepSummaryMetadata is the metadata for a specific step result.
 type StepSummaryMetadata struct {
 	Metadata
 	StepName    string `json:"stepName,omitempty"`
@@ -117,6 +117,8 @@ type StepPreComputed struct {
 	ArgoDisplayName string `json:"argoText,omitempty"`
 	// the cluster domain of the testmachinery (useful to build other URLs in dashboards)
 	ClusterDomain string `json:"clusterDomain,omitempty"`
+	// a provider field enriched with some dimension aspects (i.e. azure_multizone(NoPrivCtrs)
+	ProviderEnhanced string `json:"providerEnhanced,omitempty"`
 }
 
 // Dimension describes the basic dimension of a test

--- a/pkg/util/elasticsearch/elasticsearch.go
+++ b/pkg/util/elasticsearch/elasticsearch.go
@@ -70,7 +70,9 @@ func NewClient(cfg config.ElasticSearch) (Client, error) {
 }
 
 func (c *client) Request(httpMethod, rawPath string, payload io.Reader) ([]byte, error) {
-	return c.RequestWithCtx(context.Background(), httpMethod, rawPath, payload)
+	ctx := context.Background()
+	defer ctx.Done()
+	return c.RequestWithCtx(ctx, httpMethod, rawPath, payload)
 }
 
 func (c *client) RequestWithCtx(ctx context.Context, httpMethod, rawPath string, payload io.Reader) ([]byte, error) {

--- a/pkg/util/elasticsearch/mocks/client.go
+++ b/pkg/util/elasticsearch/mocks/client.go
@@ -5,6 +5,7 @@
 package mock_elasticsearch
 
 import (
+	context "context"
 	gomock "github.com/golang/mock/gomock"
 	io "io"
 	reflect "reflect"
@@ -74,4 +75,19 @@ func (m *MockClient) Request(arg0, arg1 string, arg2 io.Reader) ([]byte, error) 
 func (mr *MockClientMockRecorder) Request(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Request", reflect.TypeOf((*MockClient)(nil).Request), arg0, arg1, arg2)
+}
+
+// RequestWithCtx mocks base method
+func (m *MockClient) RequestWithCtx(arg0 context.Context, arg1, arg2 string, arg3 io.Reader) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RequestWithCtx", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RequestWithCtx indicates an expected call of RequestWithCtx
+func (mr *MockClientMockRecorder) RequestWithCtx(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestWithCtx", reflect.TypeOf((*MockClient)(nil).RequestWithCtx), arg0, arg1, arg2, arg3)
 }

--- a/pkg/util/s3/mocks/client.go
+++ b/pkg/util/s3/mocks/client.go
@@ -7,7 +7,7 @@ package mock_s3
 import (
 	s3 "github.com/gardener/test-infra/pkg/util/s3"
 	gomock "github.com/golang/mock/gomock"
-	minio "github.com/minio/minio-go"
+	minio_go "github.com/minio/minio-go"
 	reflect "reflect"
 )
 
@@ -35,7 +35,7 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // GetObject mocks base method
-func (m *MockClient) GetObject(arg0, arg1 string, arg2 minio.GetObjectOptions) (s3.Object, error) {
+func (m *MockClient) GetObject(arg0, arg1 string, arg2 minio_go.GetObjectOptions) (s3.Object, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetObject", arg0, arg1, arg2)
 	ret0, _ := ret[0].(s3.Object)
@@ -116,10 +116,10 @@ func (mr *MockObjectMockRecorder) Read(arg0 interface{}) *gomock.Call {
 }
 
 // Stat mocks base method
-func (m *MockObject) Stat() (minio.ObjectInfo, error) {
+func (m *MockObject) Stat() (minio_go.ObjectInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Stat")
-	ret0, _ := ret[0].(minio.ObjectInfo)
+	ret0, _ := ret[0].(minio_go.ObjectInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a new command `elasticsearch` to update es data.
For now has only one subcommand `precompute`, which allows to rerun the computation of the precompute fields (stored in the teststep es documents in `.pre`) and update the data in elasticsearch.
Useful for modifying or introducing new pre fields and updating all existing data.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
A new command `elasticsearch precompute` was introduced to allow to update all teststep `.pre` fields in elasticsearch to the current/most up-to-date precompute values.
```
