### PR TITLE
Feature/git env

### DIFF
--- a/.ci/integrationtest-config.yaml
+++ b/.ci/integrationtest-config.yaml
@@ -46,8 +46,8 @@ testmachinery:
           host: minio.ingress.tm-it.core.shoot.canary.k8s-hana.ondemand.com
       ssl: false
     bucketName: testmachinery
-    accessKey: kjdpasnvpornv
-    secretKey: askldmackmdpacm
+    accessKey: foo
+    secretKey: bar
 
 #  esConfiguration:
 #    endpoint: https:...:9200

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ generate:
 
 .PHONY: format
 format:
-	@$(REPO_ROOT)/vendor/github.com/gardener/gardener-extensions/hack/format.sh ./cmd ./pkg
+	@$(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/format.sh ./cmd ./pkg
 
 .PHONY: install
 install:

--- a/cmd/elasticsearch/cmd/precompute/precompute.go
+++ b/cmd/elasticsearch/cmd/precompute/precompute.go
@@ -87,7 +87,7 @@ func run(cmd *cobra.Command) error {
 			return err
 		}
 		processedItems += len(esResponse.Hits.Results)
-		logger.Log.Info(fmt.Sprintf("%d%% processed (%d/%d)", processedItems * 100 / esResponse.Hits.Total.Value, processedItems, esResponse.Hits.Total.Value))
+		logger.Log.Info(fmt.Sprintf("%d%% processed (%d/%d)", processedItems*100/esResponse.Hits.Total.Value, processedItems, esResponse.Hits.Total.Value))
 
 		// once we hit the first page with less than pageSize results, there will be no further page -> done
 		if len(esResponse.Hits.Results) < pageSize {

--- a/cmd/elasticsearch/cmd/precompute/query.go
+++ b/cmd/elasticsearch/cmd/precompute/query.go
@@ -22,10 +22,9 @@ import (
 	"strings"
 )
 
-
 type BulkResponse struct {
-	ErrorsOccurred bool `json:"errors"`
-	Items []BulkItem `json:"items,omitempty"`
+	ErrorsOccurred bool       `json:"errors"`
+	Items          []BulkItem `json:"items,omitempty"`
 }
 
 type BulkItem struct {
@@ -33,15 +32,15 @@ type BulkItem struct {
 }
 
 type BulkItemIndex struct {
-	Index string `json:"_index"`
-	Type string `json:"_type"`
-	ID string `json:"_id"`
-	HTTPStatus int `json:"status"`
-	Error BulkItemIndexError `json:"error"`
+	Index      string             `json:"_index"`
+	Type       string             `json:"_type"`
+	ID         string             `json:"_id"`
+	HTTPStatus int                `json:"status"`
+	Error      BulkItemIndexError `json:"error"`
 }
 
 type BulkItemIndexError struct {
-	Type string `json:"type"`
+	Type   string `json:"type"`
 	Reason string `json:"reason,omitempty"`
 }
 
@@ -51,7 +50,7 @@ type QueryResponse struct {
 }
 
 type Hits struct {
-	Total Total      `json:"total,omitempty"`
+	Total   Total    `json:"total,omitempty"`
 	Results []Result `json:"hits,omitempty"`
 }
 
@@ -60,8 +59,8 @@ type Total struct {
 }
 
 type Result struct {
-	Index string `json:"_index"`
-	DocID string `json:"_id"`
+	Index       string               `json:"_index"`
+	DocID       string               `json:"_id"`
 	StepSummary metadata.StepSummary `json:"_source,omitempty"`
 }
 

--- a/docs/testmachinery/GetStarted.md
+++ b/docs/testmachinery/GetStarted.md
@@ -88,6 +88,8 @@ spec:
 | TM_KUBECONFIG_PATH      | points to a directory containing all kubeconfig files (defaults to `/tmp/env/kubeconfig`). </br> The files contained in this dir depend on the concrete TestRun and can contain up to 5 files: <ul><li>_testmachinery.config_: the kubeconfig pointing to the testmachinery cluster</li><li>_host.config_: the kubeconfig pointing to the cluster hosting the gardener (not available for untrusted steps)</li><li>_gardener.config_: the kubeconfig pointing to the gardener cluster created by TM (or predefined/given by a TestRun, not available for untrusted steps)</li><li>_seed.config_: the kubeconfig pointing to the seed cluster configured by TM (or predefined/given by a TestRun, not available for untrusted steps)</li><li>_shoot.config_: the kubeconfig pointing to the shoot cluster created by TM (or predefined/given by a TestRun)</li></ul>|
 | TM_EXPORT_PATH | points to a directory where the test can place arbitrary test-run data which will be archived at the end. Useful if some postprocessing needs to be done on that data. Further information can be found [here](#export-contract) |
 | TM_TESTRUN_ID | Name of the testrun |
+| TM_GIT_SHA | The commit SHA of the used git location |
+| TM_GIT_REF | The ref of the used git location (branch or tag name). Will be empty if only a commit sha is provided (e.g. when testing a Pull Request via the TM bot) |
 
 #### Shoot tests
 When your test is running as part of the gardener test suite to test a shoot, there are some more available context variables.

--- a/pkg/testmachinery/config.go
+++ b/pkg/testmachinery/config.go
@@ -71,6 +71,12 @@ const (
 	// TM_TESTRUN_ID_NAME is the name of the environment variable that holds the current testrun id
 	TM_TESTRUN_ID_NAME = "TM_TESTRUN_ID"
 
+	// TM_GIT_SHA_NAME is the name of the environment variable that holds the current git commit sha of the specified location.
+	TM_GIT_SHA_NAME = "TM_GIT_SHA"
+
+	// TM_GIT_REF_NAME is the name of the environment variable that holds the current git ref of the specified location.
+	TM_GIT_REF_NAME = "TM_GIT_REF"
+
 	// ConfigMapName is the name of the testmachinery configmap in the cluster
 	ConfigMapName = "tm-config"
 

--- a/pkg/testmachinery/locations/location/locallocation.go
+++ b/pkg/testmachinery/locations/location/locallocation.go
@@ -53,6 +53,14 @@ func NewLocalLocation(log logr.Logger, testDefLocation *tmv1beta1.TestLocation) 
 	}
 }
 
+// GitInfo implements the dummy func for the local git info.
+func (l *LocalLocation) GitInfo() testdefinition.GitInfo {
+	return testdefinition.GitInfo{
+		SHA: "local",
+		Ref: "local",
+	}
+}
+
 // SetTestDefs adds its TestDefinitions to the TestDefinition Map.
 func (l *LocalLocation) SetTestDefs(testDefMap map[string]*testdefinition.TestDefinition) error {
 	testDefs, err := l.readTestDefs()

--- a/pkg/testmachinery/testdefinition/testdefinition.go
+++ b/pkg/testmachinery/testdefinition/testdefinition.go
@@ -89,6 +89,14 @@ func New(def *tmv1beta1.TestDefinition, loc Location, fileName string) (*TestDef
 					Name:  testmachinery.TM_PHASE_NAME,
 					Value: "{{inputs.parameters.phase}}",
 				},
+				{
+					Name:  testmachinery.TM_GIT_SHA_NAME,
+					Value: loc.GitInfo().SHA,
+				},
+				{
+					Name:  testmachinery.TM_GIT_REF_NAME,
+					Value: loc.GitInfo().Ref,
+				},
 			},
 		},
 		Inputs: argov1.Inputs{

--- a/pkg/testmachinery/testdefinition/types.go
+++ b/pkg/testmachinery/testdefinition/types.go
@@ -35,6 +35,14 @@ type Location interface {
 	Name() string
 	// GetLocation returns the original TestLocation object
 	GetLocation() *tmv1beta1.TestLocation
+	// GitInfo returns the current git information
+	GitInfo() GitInfo
+}
+
+// GitInfo describes additional information about the used sources.
+type GitInfo struct {
+	SHA string
+	Ref string
 }
 
 // GetStdInputArtifacts returns the default input artifacts of testdefionitions.

--- a/pkg/testmachinery/testflow/validation_test.go
+++ b/pkg/testmachinery/testflow/validation_test.go
@@ -304,6 +304,10 @@ func (l *locationMock) Type() tmv1beta1.LocationType {
 	return "mock"
 }
 
+func (l *locationMock) GitInfo() testdefinition.GitInfo {
+	return testdefinition.GitInfo{}
+}
+
 func (l *locationMock) SetTestDefs(_ map[string]*testdefinition.TestDefinition) error {
 	return nil
 }

--- a/pkg/testmachinery/testrun/kubeconfigs.go
+++ b/pkg/testmachinery/testrun/kubeconfigs.go
@@ -108,5 +108,5 @@ func addKubeconfig(configs *[]*config.Element, secrets *[]runtime.Object, tr *tm
 		}, config.LevelTestDefinition))
 		return nil
 	}
-	return fmt.Errorf("undefined StringSecType %s", string(kubeconfig.Type))
+	return fmt.Errorf("undefined StringSecType %s", strconf.TypeToString(kubeconfig.Type))
 }

--- a/pkg/testmachinery/testrun/validation.go
+++ b/pkg/testmachinery/testrun/validation.go
@@ -92,5 +92,5 @@ func validateKubeconfig(identifier string, kubeconfig *strconf.StringOrConfig) e
 		return strconf.Validate(identifier, kubeconfig.Config())
 	}
 
-	return fmt.Errorf("%s: Undefined StringSecType %s", identifier, string(kubeconfig.Type))
+	return fmt.Errorf("%s: Undefined StringSecType %s", identifier, strconf.TypeToString(kubeconfig.Type))
 }

--- a/pkg/util/strconf/strconf.go
+++ b/pkg/util/strconf/strconf.go
@@ -35,6 +35,18 @@ const (
 	Config             // The IntOrString holds a string.
 )
 
+// TypeToString returns the human readable type of a stringOrConfig type.
+func TypeToString(t Type) string {
+	switch t {
+	case String:
+		return "string"
+	case Config:
+		return "config"
+	default:
+		return ""
+	}
+}
+
 // FromString creates a StringOrConfig from a string.
 func FromString(s string) *StringOrConfig {
 	return &StringOrConfig{


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds additional env vars for git location.
`GIT_SHA`: the commit sha of the specified location. This env var is always set.
`GIT_REF`: the specified `testLocation.Revision`. Is only set if the revision is not a commit sha

**Special notes for your reviewer**:
cc @timebertt 

@dguendisch also fixed the formatting of some files

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Additional environment variables for `TM_GIT_SHA` and `TM_GIT_REF` have been added.
```
