### PR TITLE
Add TM Dashboard URL to slack summary

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -87,6 +87,9 @@ const (
 	// AnnotationGroupPurpose is the annotation to describe a run group with an arbitrary string
 	AnnotationGroupPurpose = "metadata.testmachinery.gardener.cloud/group-purpose"
 
+	// AnnotationTMDashboardURL is the annotation to describe the URL of the TM Dashboard if present
+	AnnotationTMDashboardURL = "metadata.testmachinery.gardener.cloud/tm-dashboard-url"
+
 	// LabelTestrunExecutionGroup is the label to specify the unique name of the run (multiple testruns) this test belongs to.
 	// A run represents all tests that are running from one testrunner.
 	LabelTestrunExecutionGroup = "testrunner.testmachinery.gardener.cloud/execution-group"

--- a/pkg/testrunner/list.go
+++ b/pkg/testrunner/list.go
@@ -69,6 +69,7 @@ func (rl RunList) Errors() error {
 func (rl RunList) Run(log logr.Logger, config *Config, testrunNamePrefix string, notify ...chan *Run) error {
 
 	var executiongroupID string
+	var tmDashboardURL string
 	if !config.NoExecutionGroup {
 		executiongroupID = uuid.New().String()
 		// Print dashboard url if possible and if a execution group is defined
@@ -77,7 +78,8 @@ func (rl RunList) Run(log logr.Logger, config *Config, testrunNamePrefix string,
 		if err != nil {
 			log.V(3).Info("unable to get TestMachinery Dashboard URL", "error", err.Error())
 		} else {
-			log.Info(fmt.Sprintf("TestMachinery Dashboard: %s", GetTmDashboardURLFromHostForExecutionGroup(TMDashboardHost, executiongroupID)))
+			tmDashboardURL = GetTmDashboardURLFromHostForExecutionGroup(TMDashboardHost, executiongroupID)
+			log.Info(fmt.Sprintf("TestMachinery Dashboard: %s", tmDashboardURL))
 		}
 	}
 
@@ -98,6 +100,7 @@ func (rl RunList) Run(log logr.Logger, config *Config, testrunNamePrefix string,
 		)
 		f = func() {
 			rl[trI].SetRunID(executiongroupID)
+			rl[trI].SetTMDashboardURL(tmDashboardURL)
 			triggerRunEvent(notify, rl[trI])
 			rl[trI].Exec(log, config, testrunNamePrefix)
 			if rl[trI].Metadata != nil {

--- a/pkg/testrunner/run.go
+++ b/pkg/testrunner/run.go
@@ -26,7 +26,7 @@ import (
 	"time"
 )
 
-// SetRunID sets the provided run id as annotation and adds it to the metadata
+// SetRunID sets the provided run id as label and adds it to the metadata
 func (r *Run) SetRunID(id string) {
 	if len(id) == 0 {
 		return
@@ -38,6 +38,17 @@ func (r *Run) SetRunID(id string) {
 	if r.Metadata != nil {
 		r.Metadata.Testrun.ExecutionGroup = id
 	}
+}
+
+// SetTMDashboardURL sets the provided dashboard URL as annotation
+func (r *Run) SetTMDashboardURL(url string) {
+	if url == "" {
+		return
+	}
+	if r.Testrun.Annotations == nil {
+		r.Testrun.Annotations = make(map[string]string, 1)
+	}
+	r.Testrun.Annotations[common.AnnotationTMDashboardURL] = url
 }
 
 func (r *Run) Exec(log logr.Logger, config *Config, prefix string) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a URL pointing to the TM Dashboard UI to the slack summary.

![image](https://user-images.githubusercontent.com/30311254/100653997-7bf1b780-3349-11eb-899b-824c68b254f2.png)
