### PR TITLE
Add more info to slack notification footer incl grafana dashboard url

### DIFF
--- a/cmd/testrunner/cmd/run_template/options.go
+++ b/cmd/testrunner/cmd/run_template/options.go
@@ -158,6 +158,7 @@ func (o *options) AddFlags(fs *pflag.FlagSet) error {
 	fs.StringVar(&o.collectConfig.SlackToken, "slack-token", "", "Client token to authenticate")
 	fs.StringVar(&o.collectConfig.SlackChannel, "slack-channel", "", "Client channel id to send the message to.")
 	fs.StringVar(&o.collectConfig.ConcourseURL, "concourse-url", "", "Concourse job URL.")
+	fs.StringVar(&o.collectConfig.GrafanaURL, "grafana-url", "", "Grafana Dashboard URL.")
 	fs.BoolVar(&o.collectConfig.PostSummaryInSlack, "post-summary-in-slack", false, "Post testruns summary in slack.")
 
 	// parameter flags

--- a/pkg/testrunner/result/types.go
+++ b/pkg/testrunner/result/types.go
@@ -52,6 +52,9 @@ type Config struct {
 	// ConcourseURL provides the concourse URL as reference for testruns summary results
 	ConcourseURL string
 
+	// GrafanaURL provides the grafana dashboard URL for test results
+	GrafanaURL string
+
 	// SlackToken is the slack token for slack API operations
 	SlackToken string
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Compacts & beautifies the slack notification footer and adds a grafana dashboard url to it:
![image](https://user-images.githubusercontent.com/30311254/100871088-f7657d00-349f-11eb-8928-2cd0a37a9b27.png)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
```
