### PR TITLE
Increase caching of github 404 from 10min to 1h

### DIFF
--- a/pkg/testmachinery/ghcache/ghcache.go
+++ b/pkg/testmachinery/ghcache/ghcache.go
@@ -94,7 +94,7 @@ func AddFlags(flagset *flag.FlagSet) *config.GitHubCache {
 		"Path directory that should be used to cache github requests")
 	flagset.IntVar(&internalConfig.CacheDiskSizeGB, "github-cache-size", 1,
 		"Size of the github cache in GB")
-	flagset.IntVar(&internalConfig.MaxAgeSeconds, "github-cache-max-age", 600,
+	flagset.IntVar(&internalConfig.MaxAgeSeconds, "github-cache-max-age", 3600,
 		"Maximum age of a failed github response in seconds")
 	return internalConfig
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Increase caching of github 404 from 10min to 1h as we still run into GH rate limits and we don't have GH user pooling yet.
