### PR TITLE
Update loki and promtail v1.3.0 -> 2.0.0

### DIFF
--- a/charts/internal/logging/charts/promtail/values.yaml
+++ b/charts/internal/logging/charts/promtail/values.yaml
@@ -114,14 +114,6 @@ config:
     # Maximum time to wait for server to respond to a request
     timeout: 10s
 
-    backoff_config:
-      # Initial backoff time between retries
-      minbackoff: 100ms
-      # Maximum backoff time between retries
-      maxbackoff: 5s
-      # Maximum number of retries when sending batches, 0 means infinite retries
-      maxretries: 20
-
     # The labels to add to any time series or alerts when communicating with loki
     external_labels: {}
 

--- a/charts/internal/logging/values.yaml
+++ b/charts/internal/logging/values.yaml
@@ -1,13 +1,15 @@
 loki:
   image:
     repository: grafana/loki
-    tag: v1.3.0
+    tag: 2.0.0
   podAnnotations:
       cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
   persistence:
     enabled: true
     storageClassName: default
   config:
+    limits_config:
+      max_entries_limit_per_query: 10000
     table_manager:
       retention_deletes_enabled: true
       retention_period: 336h # two weeks (but probably when table gets deleted we have max 7 days of history, see https://github.com/grafana/loki/issues/916)
@@ -23,7 +25,7 @@ loki:
 promtail:
   image:
     repository: grafana/promtail
-    tag: v1.3.0
+    tag: 2.0.0
   resources:
     limits:
       cpu: 500m
@@ -37,8 +39,9 @@ promtail:
     value: testload
     effect: NoSchedule
   scrapeConfigs:
-  - entry_parser: docker
-    job_name: pods
+  - job_name: pods
+    pipeline_stages:
+    - docker: {}
     kubernetes_sd_configs:
     - role: pod
     relabel_configs:


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates loki and promtail from `v1.3.0` to `2.0.0` and adapts to changed configuration.

