### PR TITLE
Fix reorder of nodes with multiple dependsOn nodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,10 @@ format:
 check:
 	@$(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/check.sh ./cmd/... ./pkg/...
 
+.PHONY: test
+test:
+	@go test -mod=vendor $(REPO_ROOT)/cmd/... $(REPO_ROOT)/pkg/...
+
 .PHONY: install
 install:
 	@./hack/install

--- a/pkg/testmachinery/testdefinition/types.go
+++ b/pkg/testmachinery/testdefinition/types.go
@@ -13,7 +13,6 @@ import (
 // TestDefinition represents a TestDefinition which was fetched from locations.
 type TestDefinition struct {
 	Info     *tmv1beta1.TestDefinition
-	TaskName string
 	Location Location
 	FileName string
 	Template *argov1.Template

--- a/pkg/testmachinery/testflow/flow_operations_test.go
+++ b/pkg/testmachinery/testflow/flow_operations_test.go
@@ -703,6 +703,7 @@ var serialTestDef = func() testdefinition.TestDefinition {
 		Template: &argov1.Template{},
 	}
 }()
+
 var defaultTestDef = testdefinition.NewEmpty()
 
 func createStepsFromNodes(nodes ...*node.Node) map[string]*testflow.Step {

--- a/pkg/testmachinery/testflow/flow_test.go
+++ b/pkg/testmachinery/testflow/flow_test.go
@@ -1,0 +1,97 @@
+package testflow_test
+
+import (
+	"fmt"
+
+	tmv1beta1 "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
+	"github.com/gardener/test-infra/pkg/testmachinery"
+	"github.com/gardener/test-infra/pkg/testmachinery/testdefinition"
+	"github.com/gardener/test-infra/pkg/testmachinery/testflow"
+	testutils "github.com/gardener/test-infra/test/utils"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("flow", func() {
+	Context("init", func() {
+		It("should set the root node as parent of all steps with no dependencies", func() {
+			rootNode := testNode("root", nil, defaultTestDef, nil)
+			locs := &testutils.LocationsMock{
+				StepToTestDefinitions: map[string][]*testdefinition.TestDefinition{
+					"create":        {testutils.TestDef("create")},
+					"delete":        {testutils.TestDef("delete")},
+					"tests-beta":    {testutils.TestDef("default"), testutils.SerialTestDef("serial"), testutils.DisruptiveTestDef("disruptive")},
+					"tests-release": {testutils.TestDef("default"), testutils.SerialTestDef("serial"), testutils.DisruptiveTestDef("disruptive")},
+				},
+			}
+			tf := tmv1beta1.TestFlow{}
+			Expect(testutils.ReadYAMLFile("./testdata/testflow-00.yaml", &tf)).To(Succeed())
+
+			_, err := testflow.NewFlow("testid", rootNode, tf, locs, nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(rootNode.Children.Len()).To(Equal(1), "the root node should have one create child")
+			createNode := rootNode.Children.List()[0]
+			Expect(createNode.TestDefinition.Info.Name).To(Equal("create"))
+
+			// beta step
+			Expect(createNode.Children.Len()).To(Equal(1), "the create node should have 1 test child")
+			defaultBetaNode := createNode.Children.List()[0]
+			Expect(defaultBetaNode.TestDefinition.Info.Name).To(Equal("default"))
+			Expect(defaultBetaNode.Parents.Len()).To(Equal(1), "the default beta node should have one parent")
+			Expect(defaultBetaNode.Parents.List()[0].TestDefinition.Info.Name).To(Equal("create"))
+
+			Expect(defaultBetaNode.Children.Len()).To(Equal(1), "the disruptive beta node should have 1 test child")
+			serialBetaNode := defaultBetaNode.Children.List()[0]
+			Expect(serialBetaNode.TestDefinition.Info.Name).To(Equal("serial"))
+
+			Expect(serialBetaNode.Children.Len()).To(Equal(1), "the default beta node should have 1 test child")
+			disruptiveBetaNode := serialBetaNode.Children.List()[0]
+			Expect(disruptiveBetaNode.TestDefinition.Info.Name).To(Equal("disruptive"))
+
+			// release step
+			Expect(disruptiveBetaNode.Children.Len()).To(Equal(1), "the disruptive beta node should have 1 test child")
+			defaultReleaseNode := disruptiveBetaNode.Children.List()[0]
+			Expect(defaultReleaseNode.TestDefinition.Info.Name).To(Equal("default"))
+
+			Expect(defaultReleaseNode.Children.Len()).To(Equal(1), "the default release node should have 1 test child")
+			serialReleaseNode := defaultReleaseNode.Children.List()[0]
+			Expect(serialReleaseNode.TestDefinition.Info.Name).To(Equal("serial"))
+
+			Expect(serialReleaseNode.Children.Len()).To(Equal(1), "the serial release node should have 1 test child")
+			disruptiveReleaseNode := serialReleaseNode.Children.List()[0]
+			Expect(disruptiveReleaseNode.TestDefinition.Info.Name).To(Equal("disruptive"))
+
+			// delete
+			Expect(disruptiveReleaseNode.Children.Len()).To(Equal(1), "the disruptive release node should have 1 test child")
+			deleteNode := disruptiveReleaseNode.Children.List()[0]
+			Expect(deleteNode.TestDefinition.Info.Name).To(Equal("delete"))
+		})
+
+		It("should set the root node as parent of all steps with no dependencies", func() {
+			rootNode := testNode("root", nil, defaultTestDef, &tmv1beta1.DAGStep{})
+			locs := &testutils.LocationsMock{
+				StepToTestDefinitions: map[string][]*testdefinition.TestDefinition{
+					"create":        {testutils.TestDef("create")},
+					"delete":        {testutils.TestDef("delete")},
+					"tests-beta":    {testutils.TestDef("default"), testutils.SerialTestDef("serial"), testutils.DisruptiveTestDef("disruptive")},
+					"tests-release": {testutils.TestDef("default"), testutils.SerialTestDef("serial"), testutils.DisruptiveTestDef("disruptive")},
+				},
+			}
+			tf := tmv1beta1.TestFlow{}
+			Expect(testutils.ReadYAMLFile("./testdata/testflow-00.yaml", &tf)).To(Succeed())
+
+			flow, err := testflow.NewFlow("testid", rootNode, tf, locs, nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			tmpl := flow.GetDAGTemplate(testmachinery.PhaseRunning)
+
+			for _, task := range tmpl.Tasks {
+				if task.Name != "root" {
+					Expect(len(task.Dependencies) > 0).To(BeTrue(), fmt.Sprintf("task %q should have at least one dependency", task.Name))
+				}
+			}
+		})
+	})
+})

--- a/pkg/testmachinery/testflow/node/node.go
+++ b/pkg/testmachinery/testflow/node/node.go
@@ -75,18 +75,33 @@ func NewEmpty(name string) *Node {
 }
 
 // AddChildren adds Nodes as children
-func (n *Node) AddChildren(children ...*Node) {
+func (n *Node) AddChildren(children ...*Node) *Node {
 	n.Children.Add(children...)
+	return n
 }
 
-// ClearParent removes a node from the current node's children
-func (n *Node) RemoveChild(child *Node) {
+// RemoveChild removes a node from the current node's children
+func (n *Node) RemoveChild(child *Node) *Node {
+	child.RemoveParent(n)
 	n.Children.Remove(child)
+	return n
+}
+
+// RemoveChildren removes all nodes from the current node's children
+func (n *Node) RemoveChildren(children ...*Node) *Node {
+	for _, child := range children {
+		n.RemoveChild(child)
+	}
+	return n
 }
 
 // ClearChildren removes all children from the current node
-func (n *Node) ClearChildren() {
+func (n *Node) ClearChildren() *Node {
+	for child := range n.Children.Iterate() {
+		child.RemoveParent(n)
+	}
 	n.Children = NewSet()
+	return n
 }
 
 // AddParents adds nodes as parents.
@@ -95,13 +110,15 @@ func (n *Node) AddParents(parents ...*Node) {
 }
 
 // ClearParent removes a node from the current node's parents
-func (n *Node) RemoveParent(parent *Node) {
+func (n *Node) RemoveParent(parent *Node) *Node {
 	n.Parents.Remove(parent)
+	return n
 }
 
 // ClearParents removes all parents from the current node
-func (n *Node) ClearParents() {
+func (n *Node) ClearParents() *Node {
 	n.Parents = NewSet()
+	return n
 }
 
 // ParentNames returns the names of all parent nodes

--- a/pkg/testmachinery/testflow/node/node_suite_test.go
+++ b/pkg/testmachinery/testflow/node/node_suite_test.go
@@ -3,8 +3,6 @@ package node
 import (
 	"testing"
 
-	argov1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
-
 	tmv1beta1 "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
 	"github.com/gardener/test-infra/pkg/testmachinery/testdefinition"
 	testutils "github.com/gardener/test-infra/test/utils"
@@ -25,9 +23,9 @@ var _ = Describe("node operations", func() {
 			step.Definition.ContinueOnError = true
 			locs := &testutils.LocationsMock{
 				TestDefinitions: []*testdefinition.TestDefinition{
-					defaultTestDef,
-					serialTestDef(),
-					disruptiveTestDef(),
+					testutils.TestDef("default"),
+					testutils.SerialTestDef("serial"),
+					testutils.DisruptiveTestDef("disruptive"),
 				},
 			}
 			nodes, err := CreateNodesFromStep(step, locs, nil, "")
@@ -46,27 +44,3 @@ var _ = Describe("node operations", func() {
 
 	})
 })
-
-func serialTestDef() *testdefinition.TestDefinition {
-	return &testdefinition.TestDefinition{
-		Info: &tmv1beta1.TestDefinition{
-			Spec: tmv1beta1.TestDefSpec{
-				Behavior: []string{tmv1beta1.SerialBehavior},
-			},
-		},
-		Template: &argov1.Template{},
-	}
-}
-
-func disruptiveTestDef() *testdefinition.TestDefinition {
-	return &testdefinition.TestDefinition{
-		Info: &tmv1beta1.TestDefinition{
-			Spec: tmv1beta1.TestDefSpec{
-				Behavior: []string{tmv1beta1.DisruptiveBehavior},
-			},
-		},
-		Template: &argov1.Template{},
-	}
-}
-
-var defaultTestDef = testdefinition.NewEmpty()

--- a/pkg/testmachinery/testflow/node/types.go
+++ b/pkg/testmachinery/testflow/node/types.go
@@ -2,13 +2,25 @@ package node
 
 import (
 	argov1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	tmv1beta1 "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
 	"github.com/gardener/test-infra/pkg/testmachinery/testdefinition"
 )
 
 type Set struct {
-	list []*Node
-	set  map[*Node]int
+	set map[*Node]sets.Empty
+	// first item of the linked list
+	listStart *listItem
+	// last item of the linked list
+	listEnd *listItem
+}
+
+// listItem is a internal structure for a linked list of nodes
+type listItem struct {
+	node     *Node
+	previous *listItem
+	next     *listItem
 }
 
 // Node is an object that represents a node of the internal DAG representation

--- a/pkg/testmachinery/testflow/testdata/testflow-00.yaml
+++ b/pkg/testmachinery/testflow/testdata/testflow-00.yaml
@@ -1,0 +1,20 @@
+- name: create
+  definition:
+    name: create
+
+- name: tests-beta
+  dependsOn: [ create ]
+  definition:
+    name: tests-beta
+    continueOnError: true
+
+- name: tests-release
+  dependsOn: [ tests-beta ]
+  definition:
+    name: tests-release
+    continueOnError: true
+
+- name: delete
+  dependsOn: [ tests-release, tests-beta ]
+  definition:
+    name: delete

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -16,6 +16,7 @@ package utils
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1"
 	mrhealth "github.com/gardener/gardener-resource-manager/pkg/health"
@@ -25,6 +26,9 @@ import (
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/yaml"
+
+	"io/ioutil"
 	"net/http"
 	"reflect"
 	"strings"
@@ -261,4 +265,22 @@ func HTTPGet(url string) (*http.Response, error) {
 	}
 
 	return response, nil
+}
+
+// ReadJSONFile reads a file and deserializes the json into the given object
+func ReadJSONFile(path string, obj interface{}) error {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, obj)
+}
+
+// ReadYAMLFile reads a file and deserializes the yaml into the given object
+func ReadYAMLFile(path string, obj interface{}) error {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	return yaml.Unmarshal(data, obj)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Fixes a bug in the reorder function for a testflow where a step defines multiple dependencies on other steps.
```
