### PR TITLE
use new ttl strategy instead of outdated TTLSecondsAfterFinished for argo workflows

### DIFF
--- a/pkg/testmachinery/argo/argo.go
+++ b/pkg/testmachinery/argo/argo.go
@@ -40,14 +40,19 @@ func CreateWorkflow(name, namespace, entrypoint, onExitName string, templates []
 
 	wf := &argov1.Workflow{
 		Spec: argov1.WorkflowSpec{
-			Affinity:                getWorkflowAffinity(),
-			Tolerations:             getWorkflowTolerations(),
-			Entrypoint:              entrypoint,
-			ImagePullSecrets:        getImagePullSecrets(pullImageSecretNames),
-			Volumes:                 volumes,
-			Templates:               append(templates, SuspendTemplate()),
-			TTLSecondsAfterFinished: ttl,
+			Affinity:         getWorkflowAffinity(),
+			Tolerations:      getWorkflowTolerations(),
+			Entrypoint:       entrypoint,
+			ImagePullSecrets: getImagePullSecrets(pullImageSecretNames),
+			Volumes:          volumes,
+			Templates:        append(templates, SuspendTemplate()),
 		},
+	}
+
+	if ttl != nil {
+		wf.Spec.TTLStrategy = &argov1.TTLStrategy{
+			SecondsAfterCompletion: ttl,
+		}
 	}
 
 	if onExitName != "" {


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Updated the generated argo workflow to use new ttl strategy instead of the outdated TTLSecondsAfterFinished
```
