### PR TITLE
add own ttl controller that deletes testruns after the ttl exceeds

### DIFF
--- a/pkg/apis/config/config.go
+++ b/pkg/apis/config/config.go
@@ -37,20 +37,31 @@ type Configuration struct {
 
 // Controller holds information about the testmachinery controller
 type Controller struct {
-	// HealthAddr is the address of the healtcheck endpoint
+	// HealthAddr is the address of the healtcheck endpoint.
 	HealthAddr string `json:"healthAddr,omitempty"`
 
-	// MetricsAddr is the address of the metrics endpoint
+	// MetricsAddr is the address of the metrics endpoint.
 	MetricsAddr string `json:"metricsAddr,omitempty"`
 
-	// EnableLeaderElection enables leader election for the controller
+	// EnableLeaderElection enables leader election for the controller.
 	EnableLeaderElection bool `json:"enableLeaderElection,omitempty"`
 
 	// MaxConcurrentSyncs is the max concurrent reconciles the controller does.
 	MaxConcurrentSyncs int `json:"maxConcurrentSyncs,omitempty"`
 
-	// WebhookConfig holds the validating webhook configuration
+	// TTLController contains the ttl controller configuration.
+	TTLController TTLController `json:"ttlController,omitempty"`
+
+	// WebhookConfig holds the validating webhook configuration.
 	WebhookConfig WebhookConfig `json:"webhook,omitempty"`
+}
+
+// TTLController contains the ttl controller configuration.
+type TTLController struct {
+	// Disable disables the ttl controller.
+	Disable bool `json:"disable,omitempty"`
+	// MaxConcurrentSyncs is the max concurrent reconciles the controller does.
+	MaxConcurrentSyncs int `json:"maxConcurrentSyncs,omitempty"`
 }
 
 // WebhookConfig holds the validating webhook configuration

--- a/pkg/testmachinery/controller/testmachinery_controller.go
+++ b/pkg/testmachinery/controller/testmachinery_controller.go
@@ -23,6 +23,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
+	"github.com/gardener/test-infra/pkg/testmachinery/controller/ttl"
+
 	"github.com/gardener/test-infra/pkg/apis/config"
 	tmv1beta1 "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
 	"github.com/gardener/test-infra/pkg/testmachinery"
@@ -70,5 +72,12 @@ func RegisterTestMachineryController(mgr manager.Manager, log logr.Logger, confi
 			MaxConcurrentReconciles: config.Controller.MaxConcurrentSyncs,
 		})
 	}
-	return bldr.Complete(tmReconciler)
+	if err := bldr.Complete(tmReconciler); err != nil {
+		return err
+	}
+
+	if !config.Controller.TTLController.Disable {
+		return ttl.AddControllerToManager(log, mgr, config.Controller.TTLController)
+	}
+	return nil
 }

--- a/pkg/testmachinery/controller/ttl/add.go
+++ b/pkg/testmachinery/controller/ttl/add.go
@@ -1,0 +1,38 @@
+// Copyright 2021 Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ttl
+
+import (
+	"github.com/go-logr/logr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/gardener/test-infra/pkg/apis/config"
+	tmv1beta1 "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
+)
+
+// AddControllerToManager adds a new ttl controller to the manager.
+func AddControllerToManager(log logr.Logger, mgr manager.Manager, config config.TTLController) error {
+	c := New(log.WithName("TTL"), mgr.GetClient(), mgr.GetScheme())
+
+	bldr := ctrl.NewControllerManagedBy(mgr).For(&tmv1beta1.Testrun{})
+	if config.MaxConcurrentSyncs != 0 {
+		bldr.WithOptions(controller.Options{
+			MaxConcurrentReconciles: config.MaxConcurrentSyncs,
+		})
+	}
+	return bldr.Complete(c)
+}

--- a/pkg/testmachinery/controller/ttl/controller.go
+++ b/pkg/testmachinery/controller/ttl/controller.go
@@ -1,0 +1,90 @@
+// Copyright 2021 Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ttl
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	tmv1beta1 "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
+)
+
+// Controller defines the ttl controller.
+type Controller struct {
+	log    logr.Logger
+	scheme *runtime.Scheme
+	client client.Client
+}
+
+// New creates a new ttl controller
+func New(log logr.Logger, kubeClient client.Client, scheme *runtime.Scheme) *Controller {
+	return &Controller{
+		log:    log,
+		scheme: scheme,
+		client: kubeClient,
+	}
+}
+
+func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	tr := &tmv1beta1.Testrun{}
+	if err := c.client.Get(ctx, req.NamespacedName, tr); err != nil {
+		return reconcile.Result{}, err
+	}
+	logger := c.log.WithValues("testrun", req.String())
+
+	if !tr.DeletionTimestamp.IsZero() {
+		// skip reconcile if testrun is already deleted.
+		return reconcile.Result{}, nil
+	}
+
+	if tr.Spec.TTLSecondsAfterFinished == nil {
+		logger.V(10).Info("testrun has not ttl set")
+		return reconcile.Result{}, nil
+	}
+
+	if !tr.Status.Phase.Completed() {
+		logger.V(7).Info("testrun still progressing")
+		return reconcile.Result{}, nil
+	}
+
+	trTime := tr.Status.CompletionTime
+	// the completion time should be set when the testrun is completed.
+	// but if not we default to the creation time
+	if trTime == nil {
+		trTime = &tr.CreationTimestamp
+	}
+
+	// time when the ttl is expired
+	ttlDuration := time.Duration(*tr.Spec.TTLSecondsAfterFinished) * time.Second
+	ttlExpiredTime := trTime.Add(ttlDuration)
+
+	if t := time.Since(ttlExpiredTime); t < 0 {
+		logger.V(5).Info("testrun ttl not yet expired requeuing")
+		return reconcile.Result{
+			RequeueAfter: t * -1,
+		}, nil
+	}
+
+	if err := c.client.Delete(ctx, tr); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	return reconcile.Result{}, nil
+}

--- a/pkg/testmachinery/controller/ttl/controller_suite_test.go
+++ b/pkg/testmachinery/controller/ttl/controller_suite_test.go
@@ -1,0 +1,77 @@
+// Copyright 2021 Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ttl_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	"github.com/gardener/test-infra/pkg/apis/testmachinery"
+	testmachineryapi "github.com/gardener/test-infra/pkg/testmachinery"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "TTL Controller Test Suite")
+}
+
+var (
+	testenv    *envtest.Environment
+	restConfig *rest.Config
+	fakeClient client.Client
+)
+
+var _ = BeforeSuite(func() {
+	ctx := context.Background()
+	defer ctx.Done()
+	var err error
+	crd := &v1beta1.CustomResourceDefinition{}
+	crd.Name = "testruns.testmachinery.sapcloud.io"
+	crd.Spec.Group = testmachinery.GroupName
+	crd.Spec.Scope = v1beta1.NamespaceScoped
+	crd.Spec.Names = v1beta1.CustomResourceDefinitionNames{
+		Kind:     "Testrun",
+		Plural:   "testruns",
+		Singular: "testrun",
+	}
+	crd.Spec.Versions = []v1beta1.CustomResourceDefinitionVersion{{
+		Name:    "v1beta1",
+		Served:  true,
+		Storage: true,
+	}}
+	crd.Spec.Subresources = &v1beta1.CustomResourceSubresources{
+		Status: &v1beta1.CustomResourceSubresourceStatus{},
+	}
+	testenv = &envtest.Environment{
+		CRDs: []client.Object{crd},
+	}
+
+	restConfig, err = testenv.Start()
+	Expect(err).ToNot(HaveOccurred())
+
+	fakeClient, err = client.New(restConfig, client.Options{Scheme: testmachineryapi.TestMachineryScheme})
+	Expect(err).ToNot(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+	Expect(testenv.Stop()).ToNot(HaveOccurred())
+})

--- a/pkg/testmachinery/controller/ttl/controller_test.go
+++ b/pkg/testmachinery/controller/ttl/controller_test.go
@@ -1,0 +1,148 @@
+// Copyright 2021 Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ttl_test
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	tmv1beta1 "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
+	"github.com/gardener/test-infra/pkg/testmachinery"
+	"github.com/gardener/test-infra/pkg/testmachinery/controller/ttl"
+)
+
+var _ = Describe("Reconcile", func() {
+
+	var (
+		ctx        context.Context
+		namespace  string
+		controller reconcile.Reconciler
+	)
+	BeforeEach(func() {
+		ctx = context.Background()
+		ns := &corev1.Namespace{}
+		ns.Name = fmt.Sprintf("test-%d", rand.Intn(1000))
+		if err := fakeClient.Create(ctx, ns); err != nil {
+			if !apierrors.IsAlreadyExists(err) {
+				Expect(err).ToNot(HaveOccurred())
+			}
+		}
+		namespace = ns.Name
+
+		controller = ttl.New(logr.Discard(), fakeClient, testmachinery.TestMachineryScheme)
+	})
+
+	AfterEach(func() {
+		defer ctx.Done()
+		ns := &corev1.Namespace{}
+		ns.Name = namespace
+		Expect(fakeClient.Delete(ctx, ns)).To(Succeed())
+		Eventually(func() error {
+			if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(ns), &corev1.Namespace{}); err != nil {
+				if apierrors.IsNotFound(err) {
+					return nil
+				}
+				return err
+			}
+			return nil
+		}, 1*time.Minute, 10*time.Second).Should(Succeed())
+	})
+
+	It("should not delete a testrun when no ttl is set", func() {
+		tr := &tmv1beta1.Testrun{}
+		tr.Name = "no-ttl"
+		tr.Namespace = namespace
+		Expect(fakeClient.Create(ctx, tr)).To(Succeed())
+
+		res, err := controller.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(tr)})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res.RequeueAfter.Seconds()).To(Equal(0.0))
+
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(tr), tr)).To(Succeed())
+		Expect(tr.DeletionTimestamp.IsZero()).To(BeTrue())
+	})
+
+	It("should not delete a testrun and requeue when its ttl is no yet exceeded", func() {
+		tr := &tmv1beta1.Testrun{}
+		tr.Name = "not-exceeded"
+		tr.Namespace = namespace
+		tr.Spec.TTLSecondsAfterFinished = pointer.Int32Ptr(10)
+		Expect(fakeClient.Create(ctx, tr)).To(Succeed())
+		tr.Status.Phase = tmv1beta1.PhaseStatusSuccess
+		t := metav1.Now()
+		tr.Status.CompletionTime = &t
+		Expect(fakeClient.Status().Update(ctx, tr)).To(Succeed())
+
+		res, err := controller.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(tr)})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res.RequeueAfter.Seconds()).To(BeNumerically("~", 10.0, 1))
+
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(tr), tr)).To(Succeed())
+		Expect(tr.DeletionTimestamp.IsZero()).To(BeTrue())
+	})
+
+	It("should delete a testrun when its ttl is exceeded", func() {
+		tr := &tmv1beta1.Testrun{}
+		tr.Name = "exceeded"
+		tr.Namespace = namespace
+		tr.Spec.TTLSecondsAfterFinished = pointer.Int32Ptr(10)
+		Expect(fakeClient.Create(ctx, tr)).To(Succeed())
+		tr.Status.Phase = tmv1beta1.PhaseStatusSuccess
+		tr.Status.CompletionTime = &metav1.Time{Time: metav1.Now().Add(-20 * time.Second)}
+		Expect(fakeClient.Status().Update(ctx, tr)).To(Succeed())
+
+		res, err := controller.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(tr)})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res.RequeueAfter.Seconds()).To(Equal(0.0))
+
+		err = fakeClient.Get(ctx, client.ObjectKeyFromObject(tr), tr)
+		if !apierrors.IsNotFound(err) {
+			Expect(err).ToNot(HaveOccurred())
+		}
+		if err == nil {
+			Expect(tr.DeletionTimestamp.IsZero()).To(BeFalse())
+		}
+	})
+
+	It("should use the creation timestamp if no completion timestamp exists", func() {
+		tr := &tmv1beta1.Testrun{}
+		tr.Name = "no-ts"
+		tr.Namespace = namespace
+		tr.Spec.TTLSecondsAfterFinished = pointer.Int32Ptr(10)
+		Expect(fakeClient.Create(ctx, tr)).To(Succeed())
+		tr.Status.Phase = tmv1beta1.PhaseStatusError
+		Expect(fakeClient.Status().Update(ctx, tr)).To(Succeed())
+
+		res, err := controller.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(tr)})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res.RequeueAfter.Seconds()).To(BeNumerically("~", 10.0, 1))
+
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(tr), tr)).To(Succeed())
+		Expect(tr.DeletionTimestamp.IsZero()).To(BeTrue())
+	})
+
+})


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds our own ttl controller that deletes testruns after their ttl has exceeded.
This was done to not rely on the argo ttl controller anymore.
The argo ttl controller and the testmachinery ttl controller do not interfere with each other so it is safe to run both controllers in parallel.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
A TTL controller has been added that deletes testruns after their configured ttl time has exceeded.
```
