### PR TITLE
add a dryRun flag to display all test cases

### DIFF
--- a/integration-tests/e2e/README.md
+++ b/integration-tests/e2e/README.md
@@ -48,7 +48,7 @@ go run -mod=vendor ./integration-tests/e2e --k8sVersion=1.16.2 --cloudprovider=a
 | - | debug | false | Runs application in debug mode |
 | - | testcase |  | List of explicit testcases to test. If used, `TESTCASE_GROUPS` and `TESTCASE_GROUPS` are ignored.  |
 | - | cleanUpAfterwards | false | Removes downloaded or existings kubernetes files to reduce memory footprint. |
-
+| - | dryRun | false | Dry Run mode, get all test cases and save them to a file, then print the filename path. |
 ### Description Files
 Example:
 ```json

--- a/integration-tests/e2e/config/config.go
+++ b/integration-tests/e2e/config/config.go
@@ -67,6 +67,7 @@ var (
 	DownloadsDir             string
 	RunCleanUpAfterTest      bool
 	RetryFailedTestcases     bool
+	DryRun                   bool
 )
 
 const (
@@ -93,6 +94,7 @@ func init() {
 	flag.StringVar(&TestcaseGroupString, "testcasegroup", "", "Testcase groups to run (conformance, fast, slow")
 	flag.Var(&ExplicitTestcases, "testcase", "List of testcases. If used description file and execution group are ingored.")
 	flag.BoolVar(&RetryFailedTestcases, "retryFailedTestcases", false, "runs an additional kubetest run for failed tests only")
+	flag.BoolVar(&DryRun, "dryRun", false, "specify dryRun = true to only display all testcases")
 	flag.Parse()
 	if Debug {
 		log.SetLevel(log.DebugLevel)

--- a/integration-tests/e2e/kubetest/desc_generator.go
+++ b/integration-tests/e2e/kubetest/desc_generator.go
@@ -175,6 +175,12 @@ func getAllE2eTestCases() sets.StringSet {
 	if log.GetLevel() == log.DebugLevel {
 		allTestcases.WriteToFile(AllTestcasesFilePath)
 	}
+	if config.DryRun {
+		fmt.Println("In Dry Run mode, only print file containing all test cases for specified k8s version")
+		allTestcases.WriteToFile(AllTestcasesFilePath)
+		fmt.Printf("All test cases have been saved in %s \n", AllTestcasesFilePath)
+		os.Exit(0)
+	}
 	return allTestcases
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
add a dryRun flag to display all test cases
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @dguendisch @schrodit 

the test command looks like this:
```
go run -mod=vendor ./integration-tests/e2e --k8sVersion=1.20.4 --dryRun=true --cloudprovider=aws --testcasegroup="*"
```
and the result looks like this:
```
INFO[0005] kubetest test run successful
In Dry Run mode, only print file containing all test cases for specified k8s version
All test cases have been saved in /tmp/e2e/all_testcases.txt
```
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator

```
