### PR TITLE
Fix invalid JSON in integration-tests/e2e/kubetest/description/1.20/working.json

### DIFF
--- a/integration-tests/e2e/kubetest/description/1.20/working.json
+++ b/integration-tests/e2e/kubetest/description/1.20/working.json
@@ -459,7 +459,7 @@
   { "testcase": "[sig-storage] Pod Disks schedule a pod w/ RW PD(s) mounted to 1 or more containers, write to PD, verify content, delete pod, and repeat in rapid succession [Slow] using 1 containers and 2 PDs", "groups": ["fast"]},
   { "testcase": "[sig-storage] PersistentVolumes-local  [Volume type: block] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted", "groups": ["fast"]},
   { "testcase": "[sig-storage] PersistentVolumes-local  StatefulSet with pod affinity [Slow] should use volumes spread across nodes when pod management is parallel and pod has anti-affinity", "groups": ["fast"]},
-  { "testcase": "[sig-storage] PersistentVolumes-local  StatefulSet with pod affinity [Slow] should use volumes spread across nodes when pod has anti-affinity", "groups": ["fast"]}
+  { "testcase": "[sig-storage] PersistentVolumes-local  StatefulSet with pod affinity [Slow] should use volumes spread across nodes when pod has anti-affinity", "groups": ["fast"]},
   { "testcase": "[sig-storage] In-tree Volumes [Driver: hostPathSymlink] [Testpattern: Pre-provisioned PV (default fs)] subPath should support restarting containers using directory as subpath [Slow]", "groups": ["fast"]},
   { "testcase": "[sig-storage] In-tree Volumes [Driver: hostPathSymlink] [Testpattern: Pre-provisioned PV (default fs)] volumes should allow exec of files on the volume", "groups": ["fast"]},
   { "testcase": "[sig-storage] In-tree Volumes [Driver: hostPathSymlink] [Testpattern: Pre-provisioned PV (ext3)] volumes should allow exec of files on the volume", "groups": ["fast"]},


### PR DESCRIPTION
Introduced with https://github.com/gardener/test-infra/pull/346

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
