### PR TITLE
Add unittest for patch filtering on old minor version, e.g. 1.14.*

### DIFF
--- a/pkg/util/kubernetes_version_test.go
+++ b/pkg/util/kubernetes_version_test.go
@@ -68,6 +68,21 @@ var _ = Describe("kubernetes version util", func() {
 			))
 		})
 
+		It("should return latest patch of old minor version", func() {
+			pattern := "1.14.*"
+			filter := true
+			versionFlavor := common.ShootKubernetesVersionFlavor{
+				Pattern:             &pattern,
+				FilterPatchVersions: &filter,
+			}
+
+			versions, err := util.GetK8sVersions(cloudprofile, versionFlavor, false)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(versions).To(ConsistOf(
+				newExpirableVersion("1.14.6"),
+			))
+		})
+
 		It("should return all versions", func() {
 			pattern := "*"
 			versionFlavor := common.ShootKubernetesVersionFlavor{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing

**What this PR does / why we need it**:
Adds a unittest for filtering the latest patch version of a previous minor version.

/invite @schrodit 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
