### PR TITLE
Use two PRs for the different "products" for cncf certification

### DIFF
--- a/cmd/cncf-conformance-pr-creator/create_pr_k8s_conformance.py
+++ b/cmd/cncf-conformance-pr-creator/create_pr_k8s_conformance.py
@@ -134,7 +134,7 @@ def inplace_change(filename, old_string, new_string):
         f.write(s)
 
 
-def modifyFiles():
+def modifyFiles(product_name):
     gardener_version = get_gardener_version()
     subprocess.run(["git", "clean", "-f", "-d"])
 
@@ -145,15 +145,9 @@ def modifyFiles():
         provider = provider_version_tuple[0]
         k8s_version = provider_version_tuple[1]
         modify_files_for_product(gardener_version=gardener_version,
-                                 product_name='gardener',
+                                 product_name=product_name,
                                  provider=provider,
                                  k8s_version=k8s_version)
-        modify_files_for_product(
-            gardener_version=gardener_version,
-            product_name='sap-cp',
-            provider=provider,
-            k8s_version=k8s_version)
-
 
 def activate_google_application_credentials():
     cfg_factory = ccc.cfg.cfg_factory()
@@ -308,5 +302,10 @@ except subprocess.CalledProcessError as e:
 gitHelper = cloneForkedRepo()
 syncForkAndUpstream(gitHelper)
 branch_name = createNewBranch()
-modifyFiles()
+modifyFiles('sap-cp')
+commitAndPushChanges(gitHelper, branch_name)
+
+subprocess.run(["git", "checkout", "master"])
+branch_name = createNewBranch()
+modifyFiles('gardener')
 commitAndPushChanges(gitHelper, branch_name)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
CNCF colleagues asked us to file two different PRs in the future, one for the product `gardener` and one for `sap-cp`, see https://github.com/cncf/k8s-conformance/pull/1291#issuecomment-765743659
This PR just modifies the resp. automation to create two distinct branches with the distinct files for these two products, so that it's easier to file the resp. PRs on CNCF side.

/invite @schrodit 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
