### PR TITLE
Ignore NodeFeature:RuntimeHandler tests

### DIFF
--- a/integration-tests/e2e/kubetest/description/1.15/skip.json
+++ b/integration-tests/e2e/kubetest/description/1.15/skip.json
@@ -5,6 +5,7 @@
   { "testcase": "[Driver: vSphere]"},
   { "testcase": "[Driver: cinder]"},
   { "testcase": "[Driver: gluster]"},
+  { "testcase": "[sig-node] RuntimeClass should run a Pod requesting a RuntimeClass with a configured handler [NodeFeature:RuntimeHandler]"},
   { "testcase": "[k8s.io] Cluster size autoscaler scalability [Slow] CA ignores unschedulable pods while scheduling schedulable pods [Feature:ClusterAutoscalerScalability6]"},
   { "testcase": "[k8s.io] Cluster size autoscaler scalability [Slow] should scale down empty nodes [Feature:ClusterAutoscalerScalability3]"},
   { "testcase": "[k8s.io] Cluster size autoscaler scalability [Slow] should scale down underutilized nodes [Feature:ClusterAutoscalerScalability4]"},

--- a/integration-tests/e2e/kubetest/description/1.15/working.json
+++ b/integration-tests/e2e/kubetest/description/1.15/working.json
@@ -433,7 +433,6 @@
   { "testcase": "[k8s.io] Security Context When creating a container with runAsNonRoot should run with an explicit non-root user ID", "groups": ["fast"]},
   { "testcase": "[k8s.io] [sig-node] Security Context should support pod.Spec.SecurityContext.RunAsUser [LinuxOnly]", "groups": ["fast"]},
   { "testcase": "[k8s.io] Security Context When creating a pod with readOnlyRootFilesystem should run the container with readonly rootfs when readOnlyRootFilesystem=true [LinuxOnly] [NodeConformance]", "groups": ["fast"]},
-  { "testcase": "[sig-node] RuntimeClass should run a Pod requesting a RuntimeClass with a configured handler [NodeFeature:RuntimeHandler]", "groups": ["fast"]},
   { "testcase": "[k8s.io] Security Context When creating a container with runAsUser should run the container with uid 0 [LinuxOnly] [NodeConformance]", "groups": ["fast"]},
   { "testcase": "[k8s.io] [sig-node] Security Context should support pod.Spec.SecurityContext.SupplementalGroups [LinuxOnly]", "groups": ["fast"]},
   { "testcase": "[k8s.io] [sig-node] Security Context should support pod.Spec.SecurityContext.RunAsUser And pod.Spec.SecurityContext.RunAsGroup [LinuxOnly]", "groups": ["fast"]},

--- a/integration-tests/e2e/kubetest/description/1.16/skip.json
+++ b/integration-tests/e2e/kubetest/description/1.16/skip.json
@@ -4,6 +4,7 @@
   { "testcase": "[Driver: vSphere]"},
   { "testcase": "[Driver: cinder]"},
   { "testcase": "[Driver: gluster]"},
+  { "testcase": "[sig-node] RuntimeClass should run a Pod requesting a RuntimeClass with a configured handler [NodeFeature:RuntimeHandler]"},
   { "testcase": "[k8s.io] Cluster size autoscaler scalability [Slow] CA ignores unschedulable pods while scheduling schedulable pods [Feature:ClusterAutoscalerScalability6]"},
   { "testcase": "[k8s.io] Cluster size autoscaler scalability [Slow] should scale down empty nodes [Feature:ClusterAutoscalerScalability3]"},
   { "testcase": "[k8s.io] Cluster size autoscaler scalability [Slow] should scale down underutilized nodes [Feature:ClusterAutoscalerScalability4]"},

--- a/integration-tests/e2e/kubetest/description/1.16/working.json
+++ b/integration-tests/e2e/kubetest/description/1.16/working.json
@@ -320,7 +320,6 @@
   { "testcase": "[k8s.io] Security Context When creating a container with runAsNonRoot should run with an explicit non-root user ID [LinuxOnly]", "groups": ["fast"]},
   { "testcase": "[k8s.io] [sig-node] Security Context should support pod.Spec.SecurityContext.RunAsUser [LinuxOnly]", "groups": ["fast"]},
   { "testcase": "[k8s.io] Security Context When creating a pod with readOnlyRootFilesystem should run the container with readonly rootfs when readOnlyRootFilesystem=true [LinuxOnly] [NodeConformance]", "groups": ["fast"]},
-  { "testcase": "[sig-node] RuntimeClass should run a Pod requesting a RuntimeClass with a configured handler [NodeFeature:RuntimeHandler]", "groups": ["fast"]},
   { "testcase": "[k8s.io] Security Context When creating a container with runAsUser should run the container with uid 0 [LinuxOnly] [NodeConformance]", "groups": ["fast"]},
   { "testcase": "[k8s.io] [sig-node] Security Context should support pod.Spec.SecurityContext.SupplementalGroups [LinuxOnly]", "groups": ["fast"]},
   { "testcase": "[k8s.io] [sig-node] Security Context should support pod.Spec.SecurityContext.RunAsUser And pod.Spec.SecurityContext.RunAsGroup [LinuxOnly]", "groups": ["fast"]},

--- a/integration-tests/e2e/kubetest/description/1.17/skip.json
+++ b/integration-tests/e2e/kubetest/description/1.17/skip.json
@@ -4,6 +4,7 @@
   { "testcase": "[Driver: vSphere]"},
   { "testcase": "[Driver: cinder]"},
   { "testcase": "[Driver: gluster]"},
+  { "testcase": "[sig-node] RuntimeClass should run a Pod requesting a RuntimeClass with a configured handler [NodeFeature:RuntimeHandler]"},
   { "testcase": "[k8s.io] Cluster size autoscaler scalability [Slow] CA ignores unschedulable pods while scheduling schedulable pods [Feature:ClusterAutoscalerScalability6]"},
   { "testcase": "[k8s.io] Cluster size autoscaler scalability [Slow] should scale down empty nodes [Feature:ClusterAutoscalerScalability3]"},
   { "testcase": "[k8s.io] Cluster size autoscaler scalability [Slow] should scale down underutilized nodes [Feature:ClusterAutoscalerScalability4]"},

--- a/integration-tests/e2e/kubetest/description/1.17/working.json
+++ b/integration-tests/e2e/kubetest/description/1.17/working.json
@@ -292,7 +292,6 @@
   { "testcase": "[k8s.io] Security Context When creating a container with runAsNonRoot should run with an explicit non-root user ID [LinuxOnly]", "groups": ["fast"]},
   { "testcase": "[k8s.io] [sig-node] Security Context should support pod.Spec.SecurityContext.RunAsUser [LinuxOnly]", "groups": ["fast"]},
   { "testcase": "[k8s.io] Security Context When creating a pod with readOnlyRootFilesystem should run the container with readonly rootfs when readOnlyRootFilesystem=true [LinuxOnly] [NodeConformance]", "groups": ["fast"]},
-  { "testcase": "[sig-node] RuntimeClass should run a Pod requesting a RuntimeClass with a configured handler [NodeFeature:RuntimeHandler]", "groups": ["fast"]},
   { "testcase": "[k8s.io] Security Context When creating a container with runAsUser should run the container with uid 0 [LinuxOnly] [NodeConformance]", "groups": ["fast"]},
   { "testcase": "[k8s.io] [sig-node] Security Context should support pod.Spec.SecurityContext.SupplementalGroups [LinuxOnly]", "groups": ["fast"]},
   { "testcase": "[k8s.io] [sig-node] Security Context should support pod.Spec.SecurityContext.RunAsUser And pod.Spec.SecurityContext.RunAsGroup [LinuxOnly]", "groups": ["fast"]},

--- a/integration-tests/e2e/kubetest/description/1.18/skip.json
+++ b/integration-tests/e2e/kubetest/description/1.18/skip.json
@@ -4,6 +4,7 @@
   { "testcase": "[Driver: vSphere]"},
   { "testcase": "[Driver: cinder]"},
   { "testcase": "[Driver: gluster]"},
+  { "testcase": "[sig-node] RuntimeClass should run a Pod requesting a RuntimeClass with a configured handler [NodeFeature:RuntimeHandler]"},
   { "testcase": "[k8s.io] Cluster size autoscaler scalability [Slow] CA ignores unschedulable pods while scheduling schedulable pods [Feature:ClusterAutoscalerScalability6]"},
   { "testcase": "[k8s.io] Cluster size autoscaler scalability [Slow] should scale down empty nodes [Feature:ClusterAutoscalerScalability3]"},
   { "testcase": "[k8s.io] Cluster size autoscaler scalability [Slow] should scale down underutilized nodes [Feature:ClusterAutoscalerScalability4]"},

--- a/integration-tests/e2e/kubetest/description/1.18/working.json
+++ b/integration-tests/e2e/kubetest/description/1.18/working.json
@@ -292,7 +292,6 @@
   { "testcase": "[k8s.io] Security Context When creating a container with runAsNonRoot should run with an explicit non-root user ID [LinuxOnly]", "groups": ["fast"]},
   { "testcase": "[k8s.io] [sig-node] Security Context should support pod.Spec.SecurityContext.RunAsUser [LinuxOnly]", "groups": ["fast"]},
   { "testcase": "[k8s.io] Security Context When creating a pod with readOnlyRootFilesystem should run the container with readonly rootfs when readOnlyRootFilesystem=true [LinuxOnly] [NodeConformance]", "groups": ["fast"]},
-  { "testcase": "[sig-node] RuntimeClass should run a Pod requesting a RuntimeClass with a configured handler [NodeFeature:RuntimeHandler]", "groups": ["fast"]},
   { "testcase": "[k8s.io] Security Context When creating a container with runAsUser should run the container with uid 0 [LinuxOnly] [NodeConformance]", "groups": ["fast"]},
   { "testcase": "[k8s.io] [sig-node] Security Context should support pod.Spec.SecurityContext.SupplementalGroups [LinuxOnly]", "groups": ["fast"]},
   { "testcase": "[k8s.io] [sig-node] Security Context should support pod.Spec.SecurityContext.RunAsUser And pod.Spec.SecurityContext.RunAsGroup [LinuxOnly]", "groups": ["fast"]},

--- a/integration-tests/e2e/kubetest/description/1.19/skip.json
+++ b/integration-tests/e2e/kubetest/description/1.19/skip.json
@@ -4,6 +4,7 @@
   { "testcase": "[Driver: vSphere]"},
   { "testcase": "[Driver: cinder]"},
   { "testcase": "[Driver: gluster]"},
+  { "testcase": "[sig-node] RuntimeClass should run a Pod requesting a RuntimeClass with a configured handler [NodeFeature:RuntimeHandler]"},
   { "testcase": "[k8s.io] Cluster size autoscaler scalability [Slow] CA ignores unschedulable pods while scheduling schedulable pods [Feature:ClusterAutoscalerScalability6]"},
   { "testcase": "[k8s.io] Cluster size autoscaler scalability [Slow] should scale down empty nodes [Feature:ClusterAutoscalerScalability3]"},
   { "testcase": "[k8s.io] Cluster size autoscaler scalability [Slow] should scale down underutilized nodes [Feature:ClusterAutoscalerScalability4]"},

--- a/integration-tests/e2e/kubetest/description/1.19/working.json
+++ b/integration-tests/e2e/kubetest/description/1.19/working.json
@@ -292,7 +292,6 @@
   { "testcase": "[k8s.io] Security Context When creating a container with runAsNonRoot should run with an explicit non-root user ID [LinuxOnly]", "groups": ["fast"]},
   { "testcase": "[k8s.io] [sig-node] Security Context should support pod.Spec.SecurityContext.RunAsUser [LinuxOnly]", "groups": ["fast"]},
   { "testcase": "[k8s.io] Security Context When creating a pod with readOnlyRootFilesystem should run the container with readonly rootfs when readOnlyRootFilesystem=true [LinuxOnly] [NodeConformance]", "groups": ["fast"]},
-  { "testcase": "[sig-node] RuntimeClass should run a Pod requesting a RuntimeClass with a configured handler [NodeFeature:RuntimeHandler]", "groups": ["fast"]},
   { "testcase": "[k8s.io] Security Context When creating a container with runAsUser should run the container with uid 0 [LinuxOnly] [NodeConformance]", "groups": ["fast"]},
   { "testcase": "[k8s.io] [sig-node] Security Context should support pod.Spec.SecurityContext.SupplementalGroups [LinuxOnly]", "groups": ["fast"]},
   { "testcase": "[k8s.io] [sig-node] Security Context should support pod.Spec.SecurityContext.RunAsUser And pod.Spec.SecurityContext.RunAsGroup [LinuxOnly]", "groups": ["fast"]},

--- a/integration-tests/e2e/kubetest/description/1.20/skip.json
+++ b/integration-tests/e2e/kubetest/description/1.20/skip.json
@@ -3,6 +3,7 @@
   { "testcase": "Alpha"},
   { "testcase": "[Experimental]"},
   { "testcase": "[Driver: gluster]"},
+  { "testcase": "[sig-node] RuntimeClass should run a Pod requesting a RuntimeClass with a configured handler [NodeFeature:RuntimeHandler]"},
   { "testcase": "[k8s.io] [sig-node] AppArmor load AppArmor profiles can disable an AppArmor profile, using unconfined"},
   { "testcase": "[k8s.io] [sig-node] AppArmor load AppArmor profiles should enforce an AppArmor profile"},
   { "testcase": "[k8s.io] [sig-node] SSH should SSH to all nodes and run commands"},

--- a/integration-tests/e2e/kubetest/description/1.20/working.json
+++ b/integration-tests/e2e/kubetest/description/1.20/working.json
@@ -292,7 +292,6 @@
   { "testcase": "[k8s.io] Security Context When creating a container with runAsNonRoot should run with an explicit non-root user ID [LinuxOnly]", "groups": ["fast"]},
   { "testcase": "[k8s.io] [sig-node] Security Context should support pod.Spec.SecurityContext.RunAsUser [LinuxOnly]", "groups": ["fast"]},
   { "testcase": "[k8s.io] Security Context When creating a pod with readOnlyRootFilesystem should run the container with readonly rootfs when readOnlyRootFilesystem=true [LinuxOnly] [NodeConformance]", "groups": ["fast"]},
-  { "testcase": "[sig-node] RuntimeClass should run a Pod requesting a RuntimeClass with a configured handler [NodeFeature:RuntimeHandler]", "groups": ["fast"]},
   { "testcase": "[k8s.io] Security Context When creating a container with runAsUser should run the container with uid 0 [LinuxOnly] [NodeConformance]", "groups": ["fast"]},
   { "testcase": "[k8s.io] [sig-node] Security Context should support pod.Spec.SecurityContext.SupplementalGroups [LinuxOnly]", "groups": ["fast"]},
   { "testcase": "[k8s.io] [sig-node] Security Context should support pod.Spec.SecurityContext.RunAsUser And pod.Spec.SecurityContext.RunAsGroup [LinuxOnly]", "groups": ["fast"]},

--- a/integration-tests/e2e/kubetest/description/1.21/skip.json
+++ b/integration-tests/e2e/kubetest/description/1.21/skip.json
@@ -4,6 +4,7 @@
   { "testcase": "[Driver: vSphere]"},
   { "testcase": "[Driver: cinder]"},
   { "testcase": "[Driver: gluster]"},
+  { "testcase": "[sig-node] RuntimeClass should run a Pod requesting a RuntimeClass with a configured handler [NodeFeature:RuntimeHandler]"},
   { "testcase": "[k8s.io] Cluster size autoscaler scalability [Slow] CA ignores unschedulable pods while scheduling schedulable pods [Feature:ClusterAutoscalerScalability6]"},
   { "testcase": "[k8s.io] Cluster size autoscaler scalability [Slow] should scale down empty nodes [Feature:ClusterAutoscalerScalability3]"},
   { "testcase": "[k8s.io] Cluster size autoscaler scalability [Slow] should scale down underutilized nodes [Feature:ClusterAutoscalerScalability4]"},

--- a/integration-tests/e2e/kubetest/description/1.21/working.json
+++ b/integration-tests/e2e/kubetest/description/1.21/working.json
@@ -288,7 +288,6 @@
   { "testcase": "[k8s.io] Security Context When creating a container with runAsNonRoot should run with an explicit non-root user ID [LinuxOnly]", "groups": ["fast"]},
   { "testcase": "[k8s.io] [sig-node] Security Context should support pod.Spec.SecurityContext.RunAsUser [LinuxOnly]", "groups": ["fast"]},
   { "testcase": "[k8s.io] Security Context When creating a pod with readOnlyRootFilesystem should run the container with readonly rootfs when readOnlyRootFilesystem=true [LinuxOnly] [NodeConformance]", "groups": ["fast"]},
-  { "testcase": "[sig-node] RuntimeClass should run a Pod requesting a RuntimeClass with a configured handler [NodeFeature:RuntimeHandler]", "groups": ["fast"]},
   { "testcase": "[k8s.io] Security Context When creating a container with runAsUser should run the container with uid 0 [LinuxOnly] [NodeConformance]", "groups": ["fast"]},
   { "testcase": "[k8s.io] [sig-node] Security Context should support pod.Spec.SecurityContext.SupplementalGroups [LinuxOnly]", "groups": ["fast"]},
   { "testcase": "[k8s.io] [sig-node] Security Context should support pod.Spec.SecurityContext.RunAsUser And pod.Spec.SecurityContext.RunAsGroup [LinuxOnly]", "groups": ["fast"]},

--- a/integration-tests/e2e/kubetest/description/1.22/skip.json
+++ b/integration-tests/e2e/kubetest/description/1.22/skip.json
@@ -4,6 +4,7 @@
   { "testcase": "[Driver: vSphere]"},
   { "testcase": "[Driver: cinder]"},
   { "testcase": "[Driver: gluster]"},
+  { "testcase": "[sig-node] RuntimeClass should run a Pod requesting a RuntimeClass with a configured handler [NodeFeature:RuntimeHandler]"},
   { "testcase": "[k8s.io] Cluster size autoscaler scalability [Slow] CA ignores unschedulable pods while scheduling schedulable pods [Feature:ClusterAutoscalerScalability6]"},
   { "testcase": "[k8s.io] Cluster size autoscaler scalability [Slow] should scale down empty nodes [Feature:ClusterAutoscalerScalability3]"},
   { "testcase": "[k8s.io] Cluster size autoscaler scalability [Slow] should scale down underutilized nodes [Feature:ClusterAutoscalerScalability4]"},

--- a/integration-tests/e2e/kubetest/description/1.22/working.json
+++ b/integration-tests/e2e/kubetest/description/1.22/working.json
@@ -288,7 +288,6 @@
   { "testcase": "[k8s.io] Security Context When creating a container with runAsNonRoot should run with an explicit non-root user ID [LinuxOnly]", "groups": ["fast"]},
   { "testcase": "[k8s.io] [sig-node] Security Context should support pod.Spec.SecurityContext.RunAsUser [LinuxOnly]", "groups": ["fast"]},
   { "testcase": "[k8s.io] Security Context When creating a pod with readOnlyRootFilesystem should run the container with readonly rootfs when readOnlyRootFilesystem=true [LinuxOnly] [NodeConformance]", "groups": ["fast"]},
-  { "testcase": "[sig-node] RuntimeClass should run a Pod requesting a RuntimeClass with a configured handler [NodeFeature:RuntimeHandler]", "groups": ["fast"]},
   { "testcase": "[k8s.io] Security Context When creating a container with runAsUser should run the container with uid 0 [LinuxOnly] [NodeConformance]", "groups": ["fast"]},
   { "testcase": "[k8s.io] [sig-node] Security Context should support pod.Spec.SecurityContext.SupplementalGroups [LinuxOnly]", "groups": ["fast"]},
   { "testcase": "[k8s.io] [sig-node] Security Context should support pod.Spec.SecurityContext.RunAsUser And pod.Spec.SecurityContext.RunAsGroup [LinuxOnly]", "groups": ["fast"]},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
When enabling `containerd` for the k8s e2e tests, we stumbled upon gardener/gardener#4458: this test would require a special `containerd` configuration to succeed. The feature itself is used e.g. for enabling gVisor and also tested there: https://github.com/gardener/gardener-extension-runtime-gvisor/blob/b7cb2d5a85de903def803f3db5500fea110b79a6/test/integration/container-runtime/container_runtime.go#L40

**Which issue(s) this PR fixes**:
Fixes gardener/gardener#4458

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other bugfix
Skip `[sig-node] RuntimeClass should run a Pod requesting a RuntimeClass with a configured handler [NodeFeature:RuntimeHandler]`, as it requires special test configuration for `containerd` to succeed.
```
