### PR TITLE
Update alpine 3.13 to 3.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY . .
 RUN make install
 
 ############# tm-controller #############
-FROM alpine:3.13 AS tm-controller
+FROM alpine:3.14 AS tm-controller
 
 COPY charts /charts
 COPY --from=builder /go/bin/testmachinery-controller /testmachinery-controller
@@ -31,7 +31,7 @@ WORKDIR /
 ENTRYPOINT ["/testmachinery-controller"]
 
 ############# telemetry-controller #############
-FROM alpine:3.13 AS telemetry-controller
+FROM alpine:3.14 AS telemetry-controller
 
 RUN apk add --update bash curl
 
@@ -43,7 +43,7 @@ WORKDIR /
 ENTRYPOINT ["/telemetry-controller"]
 
 ############# tm-base-step #############
-FROM golang:1.16-alpine3.13 AS base-step
+FROM golang:1.16-alpine3.14 AS base-step
 
 ENV HELM_TILLER_VERSION=v2.13.0
 ENV KUBECTL_VERSION=v1.19.7
@@ -127,7 +127,7 @@ WORKDIR /
 ENTRYPOINT ["/testrunner"]
 
 ############# tm-bot #############
-FROM alpine:3.13 AS tm-bot
+FROM alpine:3.14 AS tm-bot
 
 RUN apk add --update bash curl
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind cleanup

**What this PR does / why we need it**:
Updates base images from alpine 3.13 to 3.14 (which also updates python 3.8 to 3.9) so that newer versions of cicd libs can be installed.

/invite @schrodit
cc @vpnachev 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
