### PR TITLE
Switch base from alpine to debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,42 +43,29 @@ WORKDIR /
 ENTRYPOINT ["/telemetry-controller"]
 
 ############# tm-base-step #############
-FROM golang:1.16-alpine3.13 AS base-step
+FROM golang:1.16-bullseye AS base-step
 
 ENV HELM_TILLER_VERSION=v2.13.0
 ENV KUBECTL_VERSION=v1.19.7
 ENV HELM_V3_VERSION=v3.1.1
 
-RUN  \
-  apk update \
-  && apk add \
+RUN \
+  apt-get update \
+  && apt-get --assume-yes install \
     apache2-utils \
-    coreutils \
+    build-essential \
+    bc \
     cargo \
-    bash \
-    binutils \
-    bind-tools \
-    build-base \
-    curl \
+    dnsutils \
     file \
-    gcc \
-    git \
     jq \
-    libc-dev \
     libev-dev \
     libffi-dev \
-    openssh \
-    openssl \
-    openssl-dev \
-    python3 \
+    libssl-dev \
+    linux-headers-amd64 \
     python3-dev \
-    py3-pip \
-    wget \
-    grep \
-    findutils \
+    python3-pip \
     rsync \
-    bc \
-    linux-headers \
   && pip install --upgrade pip \
     gardener-cicd-cli \
     gardener-cicd-libs \


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind cleanup

**What this PR does / why we need it**:
Switches the base image from alpine to debian bullseye, allows to combine go 1.16 with python 3.9 => image size increased from (already huge?) 1.7GB to 2.0GB, image build time decreased from ~350secs to ~50secs because pip packages no longer need to build their deps from source (because of musl vs. glibc).
Not sure if it would be a good idea though, hence just a draft.

cc @schrodit @vpnachev 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
