### PR TITLE
Upgrade semver to v3.1.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	cloud.google.com/go v0.81.0
 	cloud.google.com/go/storage v1.10.0
-	github.com/Masterminds/semver v1.5.0
+	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/argoproj/argo/v2 v2.12.10
 	github.com/bradleyfalzon/ghinstallation v1.1.1

--- a/pkg/shootflavors/flavors.go
+++ b/pkg/shootflavors/flavors.go
@@ -17,7 +17,7 @@ package shootflavors
 import (
 	"fmt"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"

--- a/pkg/testmachinery/collector/precompute.go
+++ b/pkg/testmachinery/collector/precompute.go
@@ -32,7 +32,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	argov1 "github.com/argoproj/argo/v2/pkg/apis/workflow/v1alpha1"
 
 	tmv1beta1 "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"

--- a/pkg/testrunner/result/status-uploader.go
+++ b/pkg/testrunner/result/status-uploader.go
@@ -13,7 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/go-logr/logr"
 	"github.com/google/go-github/v27/github"
 	"github.com/pkg/errors"

--- a/pkg/tm-bot/github/client.go
+++ b/pkg/tm-bot/github/client.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/go-logr/logr"
 	"github.com/google/go-github/v27/github"
 	"github.com/pkg/errors"

--- a/pkg/tm-bot/github/mocks/client.go
+++ b/pkg/tm-bot/github/mocks/client.go
@@ -9,7 +9,7 @@ import (
 	json "encoding/json"
 	reflect "reflect"
 
-	semver "github.com/Masterminds/semver"
+	semver "github.com/Masterminds/semver/v3"
 	gomock "github.com/golang/mock/gomock"
 	github0 "github.com/google/go-github/v27/github"
 

--- a/pkg/tm-bot/github/types.go
+++ b/pkg/tm-bot/github/types.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/go-logr/logr"
 	"github.com/google/go-github/v27/github"
 

--- a/pkg/util/gardener.go
+++ b/pkg/util/gardener.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/util/gardener.go
+++ b/pkg/util/gardener.go
@@ -128,10 +128,11 @@ func FilterExpiredVersions(versions []gardencorev1beta1.ExpirableVersion) []gard
 
 // DecMinorVersion decreases the minor version of 1 and sets the patch version to 0.
 func DecMinorVersion(v *semver.Version) (*semver.Version, error) {
-	minor := v.Minor() - 1
-	if minor < 0 {
-		minor = 0
+	minor := uint64(0)
+	if v.Minor() > 0 {
+		minor = v.Minor() - 1
 	}
+
 	vPrev := fmt.Sprintf("%d.%d.%d", v.Major(), minor, 0)
 	return semver.NewVersion(vPrev)
 }

--- a/pkg/util/gardensetup/gs_extensions.go
+++ b/pkg/util/gardensetup/gs_extensions.go
@@ -19,7 +19,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"k8s.io/helm/pkg/strvals"
 
 	"github.com/gardener/test-infra/pkg/common"

--- a/pkg/util/kubernetes_version.go
+++ b/pkg/util/kubernetes_version.go
@@ -3,7 +3,7 @@ package util
 import (
 	"fmt"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/pkg/errors"
 

--- a/pkg/util/machine_image.go
+++ b/pkg/util/machine_image.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/pkg/errors"
 )

--- a/pkg/util/slack-table-post.go
+++ b/pkg/util/slack-table-post.go
@@ -19,7 +19,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/go-logr/logr"
 	"github.com/olekukonko/tablewriter"
 )

--- a/pkg/util/versions.go
+++ b/pkg/util/versions.go
@@ -1,7 +1,7 @@
 package util
 
 import (
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/pkg/errors"
 
 	"github.com/gardener/test-infra/pkg/common"

--- a/pkg/util/versions_test.go
+++ b/pkg/util/versions_test.go
@@ -15,7 +15,7 @@
 package util_test
 
 import (
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -16,9 +16,9 @@ github.com/BurntSushi/toml
 # github.com/Masterminds/goutils v1.1.1
 github.com/Masterminds/goutils
 # github.com/Masterminds/semver v1.5.0
-## explicit
 github.com/Masterminds/semver
 # github.com/Masterminds/semver/v3 v3.1.1
+## explicit
 github.com/Masterminds/semver/v3
 # github.com/Masterminds/sprig v2.22.0+incompatible
 ## explicit


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind cleanup

**What this PR does / why we need it**:
Updates "github.com/Masterminds/semver" from `1.5.0` to `3.1.1` for improved capabilities and fixes on constraints containing `AND` semantics like `>= 1.21 <= 1.22`.
This was broken in the old used version and works now.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @schrodit 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Updated "github.com/Masterminds/semver" from `1.5.0` to `3.1.1`
```
