### PR TITLE
update chart resources to latest api versions

### DIFF
--- a/charts/internal/argo/templates/ingress.yaml
+++ b/charts/internal/argo/templates/ingress.yaml
@@ -1,31 +1,45 @@
 
 ---
 {{ if .Values.argoui.ingress.enabled }}
-apiVersion: extensions/v1beta1
+{{- if semverCompare ">= 1.19-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: networking.k8s.io/v1
+  {{- else -}}
+apiVersion: networking.k8s.io/v1beta1
+  {{- end }}
 kind: Ingress
 metadata:
-    annotations:
-        {{- range $key, $value := .Values.argoui.ingress.annotations }}
-        {{ $key }}: {{ $value }}
-        {{- end }}
-    labels:
-        garden.sapcloud.io/purpose: managed-cert
-        {{- range $key, $value := .Values.argoui.ingress.labels }}
-        {{ $key }}: {{ $value }}
-        {{- end }}
-    name: {{ .Values.argoui.ingress.name }}
-    namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- range $key, $value := .Values.argoui.ingress.annotations }}
+    {{ $key }}: {{ $value }}
+  {{- end }}
+  labels:
+    garden.sapcloud.io/purpose: managed-cert
+    {{- range $key, $value := .Values.argoui.ingress.labels }}
+    {{ $key }}: {{ $value }}
+  {{- end }}
+  name: {{ .Values.argoui.ingress.name }}
+  namespace: {{ .Release.Namespace }}
 spec:
-    rules:
+  rules:
     - host: {{ .Values.argoui.ingress.host }}
       http:
-          paths:
+        paths:
+          {{- if semverCompare ">= 1.19-0" .Capabilities.KubeVersion.GitVersion }}
           - backend:
-                serviceName: argo-ui
-                servicePort: 80
+              service:
+                name: argo-ui
+                port:
+                  number: 80
             path: /
-    tls:
+            pathType: Prefix
+          {{- else }}
+          - backend:
+              serviceName: argo-ui
+              servicePort: 80
+            path: /
+  {{- end }}
+  tls:
     - hosts:
-      - {{ .Values.argoui.ingress.host }}
+        - {{ .Values.argoui.ingress.host }}
       secretName: argo-ui-tls
-{{ end }}
+  {{ end }}

--- a/charts/internal/logging/charts/loki/templates/ingress.yaml
+++ b/charts/internal/logging/charts/loki/templates/ingress.yaml
@@ -1,10 +1,10 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "loki.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
 {{- else -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
@@ -35,10 +35,20 @@ spec:
       http:
         paths:
         {{- range .paths }}
+        {{- if semverCompare ">= 1.19-0" .Capabilities.KubeVersion.GitVersion }}
+          - path: {{ . }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+        {{- else }}
           - path: {{ . }}
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
+        {{- end }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/testmachinery/templates/crd.yaml
+++ b/charts/testmachinery/templates/crd.yaml
@@ -13,7 +13,11 @@
 # limitations under the License.
 
 ---
+{{- if semverCompare ">= 1.16-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: apiextensions.k8s.io/v1
+{{- else }}
 apiVersion: apiextensions.k8s.io/v1beta1
+{{- end }}
 kind: CustomResourceDefinition
 metadata:
   labels:
@@ -21,6 +25,43 @@ metadata:
   name: testruns.testmachinery.sapcloud.io
 spec:
   group: testmachinery.sapcloud.io
+{{- if semverCompare ">= 1.16-0" .Capabilities.KubeVersion.GitVersion }}
+  names:
+    kind: Testrun
+    listKind: TestrunList
+    plural: testruns
+    shortNames:
+      - tr
+    singular: testrun
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: The corresponding Argo Workflow.
+          jsonPath: .status.workflow
+          name: Workflow
+          type: string
+        - description: The phase indicates the current status of the overall testrun.
+          jsonPath: .status.phase
+          name: Phase
+          type: string
+        - description: The StarTime indicates the time the testrun was triggered.
+          jsonPath: .status.startTime
+          name: StartTime
+          type: date
+        - description: The Duration indicates the complete duration of the workflow.
+          jsonPath: .status.duration
+          name: Duration
+          type: number
+      name: v1beta1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        status: {}
+{{- else }}
   versions:
   - name: v1beta1
     served: true
@@ -51,3 +92,4 @@ spec:
     type: number
     description: The Duration indicates the complete duration of the workflow.
     JSONPath: .status.duration
+{{- end }}

--- a/charts/testmachinery/templates/validating-webhook.yaml
+++ b/charts/testmachinery/templates/validating-webhook.yaml
@@ -13,7 +13,11 @@
 # limitations under the License.
 
 ---
+{{- if semverCompare ">= 1.16-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: admissionregistration.k8s.io/v1
+{{- else }}
 apiVersion: admissionregistration.k8s.io/v1beta1
+{{- end }}
 kind: ValidatingWebhookConfiguration
 metadata:
   name: testmachinery-controller
@@ -21,6 +25,12 @@ metadata:
     {{- include "defaultLabels" . | nindent 4 }}
 webhooks:
 - name: validate-testrun.tm.garden.cloud
+  {{- if semverCompare ">= 1.16-0" .Capabilities.KubeVersion.GitVersion }}
+  admissionReviewVersions: ["v1", "v1beta1"]
+  sideEffects: "None"
+  {{- else }}
+  admissionReviewVersions: ["v1beta1"]
+  {{- end }}
   rules:
   - apiGroups: ["testmachinery.sapcloud.io"]
     apiVersions: [v1beta1]

--- a/charts/tm-bot/templates/ingress.yaml
+++ b/charts/tm-bot/templates/ingress.yaml
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: extensions/v1beta1
+{{- if semverCompare ">= 1.19-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: networking.k8s.io/v1
+{{- else -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: tm-bot
@@ -31,7 +35,17 @@ spec:
   - host: {{ .Values.ingress.host }}
     http:
       paths:
+      {{- if semverCompare ">= 1.19-0" .Capabilities.KubeVersion.GitVersion }}
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: tm-bot
+            port:
+              number: 80
+      {{- else }}
       - path: /
         backend:
           serviceName: tm-bot
           servicePort: 80
+      {{- end }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind technical-debt

**What this PR does / why we need it**:
This PR updates resources used in the helm charts to their latest API version. It also adds a switch to ensure backward compatibility with older versions of K8s.  

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The `testrun` CRD continues to operate without a meaningful OpenAPI schema. It will preserve any fields. The validation webhook remains in place though.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Update API versions of resources deployed with helm.
```
