### PR TITLE
Update the go version of several TestDefinitions

### DIFF
--- a/.test-defs/allE2eTestgrid.yaml
+++ b/.test-defs/allE2eTestgrid.yaml
@@ -53,7 +53,7 @@ spec:
     export E2E_KUBECONFIG_PATH=$TM_KUBECONFIG_PATH/shoot.config &&
     export GARDEN_KUBECONFIG_PATH=$TM_KUBECONFIG_PATH/gardener.config &&
     go run --mod=vendor ./integration-tests/e2e --cleanUpAfterwards=true --flakeAttempts=5 --retryFailedTestcases=true
-  image: golang:1.13
+  image: golang:1.15
   resources:
     requests:
       memory: "500Mi"

--- a/.test-defs/cleanGardener.yaml
+++ b/.test-defs/cleanGardener.yaml
@@ -33,4 +33,4 @@ spec:
   args:
   - >-
     go run -mod=vendor ./cmd/cleanup/gardener --kubeconfig=$TM_KUBECONFIG_PATH/gardener.config
-  image: golang:1.13
+  image: golang:1.15

--- a/.test-defs/conformanceTestgrid.yaml
+++ b/.test-defs/conformanceTestgrid.yaml
@@ -56,7 +56,7 @@ spec:
     export E2E_KUBECONFIG_PATH=$TM_KUBECONFIG_PATH/shoot.config &&
     export GARDEN_KUBECONFIG_PATH=$TM_KUBECONFIG_PATH/gardener.config &&
     go run -mod=vendor ./integration-tests/e2e --cleanUpAfterwards=true --flakeAttempts=5
-  image: golang:1.13
+  image: golang:1.15
   resources:
     requests:
       memory: "500Mi"

--- a/.test-defs/conformanceTestgridParallel.yaml
+++ b/.test-defs/conformanceTestgridParallel.yaml
@@ -40,7 +40,7 @@ spec:
     export E2E_KUBECONFIG_PATH=$TM_KUBECONFIG_PATH/shoot.config &&
     export GARDEN_KUBECONFIG_PATH=$TM_KUBECONFIG_PATH/gardener.config &&
     go run -mod=vendor ./integration-tests/e2e --cleanUpAfterwards=true --flakeAttempts=5 --retryFailedTestcases=true
-  image: golang:1.13
+  image: golang:1.15
   resources:
     requests:
       memory: "500Mi"

--- a/.test-defs/e2eFast.yaml
+++ b/.test-defs/e2eFast.yaml
@@ -40,7 +40,7 @@ spec:
     export E2E_KUBECONFIG_PATH=$TM_KUBECONFIG_PATH/shoot.config &&
     export GARDEN_KUBECONFIG_PATH=$TM_KUBECONFIG_PATH/gardener.config &&
     go run -mod=vendor ./integration-tests/e2e --cleanUpAfterwards=true --flakeAttempts=5 --retryFailedTestcases=true
-  image: golang:1.13
+  image: golang:1.15
   resources:
     requests:
       memory: "500Mi"

--- a/.test-defs/e2eSlow.yaml
+++ b/.test-defs/e2eSlow.yaml
@@ -41,7 +41,7 @@ spec:
     export E2E_KUBECONFIG_PATH=$TM_KUBECONFIG_PATH/shoot.config &&
     export GARDEN_KUBECONFIG_PATH=$TM_KUBECONFIG_PATH/gardener.config &&
     go run -mod=vendor ./integration-tests/e2e --cleanUpAfterwards=true --flakeAttempts=5 --retryFailedTestcases=true
-  image: golang:1.13
+  image: golang:1.15
   resources:
     requests:
       memory: "500Mi"

--- a/.test-defs/e2eUntracked.yaml
+++ b/.test-defs/e2eUntracked.yaml
@@ -47,7 +47,7 @@ spec:
     export E2E_KUBECONFIG_PATH=$TM_KUBECONFIG_PATH/shoot.config &&
     export GARDEN_KUBECONFIG_PATH=$TM_KUBECONFIG_PATH/gardener.config &&
     go run -mod=vendor ./integration-tests/e2e --cleanUpAfterwards=true --flakeAttempts=5
-  image: golang:1.13
+  image: golang:1.15
   resources:
     requests:
       memory: "500Mi"

--- a/.test-defs/logGardener.yaml
+++ b/.test-defs/logGardener.yaml
@@ -33,4 +33,4 @@ spec:
   args:
   - >-
     go run -mod=vendor ./cmd/logging --kubeconfig=$TM_KUBECONFIG_PATH/host.config --output=$TM_EXPORT_PATH
-  image: golang:1.13
+  image: golang:1.15

--- a/.test-defs/scheduler-lock-gardener.yaml
+++ b/.test-defs/scheduler-lock-gardener.yaml
@@ -40,4 +40,4 @@ spec:
   args:
   - >-
     go run -mod=vendor ./cmd/hostscheduler gardener lock --id=$TM_TESTRUN_ID --kubeconfig=/tmp/secrets/gardener-service-account.kubeconfig --cloudprovider=$HOST_CLOUDPROVIDER
-  image: golang:1.13
+  image: golang:1.15

--- a/.test-defs/scheduler-lock.yaml
+++ b/.test-defs/scheduler-lock.yaml
@@ -52,4 +52,4 @@ spec:
   args:
   - >-
     go run -mod=vendor ./cmd/hostscheduler gke lock --id=$TM_TESTRUN_ID  --key=/tmp/secrets/gcloud.json --project=$GKE_PROJECT --zone=$GKE_ZONE
-  image: golang:1.13
+  image: golang:1.15

--- a/.test-defs/scheduler-release-gardener.yaml
+++ b/.test-defs/scheduler-release-gardener.yaml
@@ -40,4 +40,4 @@ spec:
   args:
   - >-
     go run -mod=vendor ./cmd/hostscheduler gardener release --kubeconfig=/tmp/secrets/gardener-service-account.kubeconfig --clean=$CLEAN
-  image: golang:1.13
+  image: golang:1.15

--- a/.test-defs/scheduler-release.yaml
+++ b/.test-defs/scheduler-release.yaml
@@ -52,4 +52,4 @@ spec:
   args:
   - >-
     go run -mod=vendor ./cmd/hostscheduler gke release --key=/tmp/secrets/gcloud.json --project=$PROJECT --zone=$ZONE --clean=$CLEAN
-  image: golang:1.13
+  image: golang:1.15

--- a/cmd/cncf-conformance-pr-creator/gardener_readme.txt
+++ b/cmd/cncf-conformance-pr-creator/gardener_readme.txt
@@ -72,7 +72,7 @@ Set the `KUBECONFIG` as path to the kubeconfig file of your newly created cluste
 
 ```bash
 #first set KUBECONFIG to your cluster
-docker run -ti -e --rm -v $KUBECONFIG:/mye2e/shoot.config golang:1.13 bash
+docker run -ti -e --rm -v $KUBECONFIG:/mye2e/shoot.config golang:1.15 bash
 # run all commands below within container
 go get github.com/gardener/test-infra; cd /go/src/github.com/gardener/test-infra
 export GO111MODULE=on; export E2E_EXPORT_PATH=/tmp/export; export KUBECONFIG=/mye2e/shoot.config; export GINKGO_PARALLEL=false


### PR DESCRIPTION
/area testing
/kind bug

The current HEAD of test-infra requires at least go1.15.
`make install` fails with the following error on go1.13 and go1.14:
```
$ docker run --rm -v ${GOPATH}/src:/go/src -it golang:1.14 bash
root@8f6f98ad9fa1:/go# cd src/github.com/gardener/test-infra/
root@8f6f98ad9fa1:/go/src/github.com/gardener/test-infra# make install
# golang.org/x/net/http2
vendor/golang.org/x/net/http2/transport.go:417:45: undefined: os.ErrDeadlineExceeded
^Cmake: *** [Makefile:72: install] Interrupt
```

Hence, TestDefinitions that are still on go1.13 fail with the same on test execution.

`os.ErrDeadlineExceeded` is introduced in go1.15 with https://cs.opensource.google/go/go/+/d422f54619b5b6e6301eaa3e9f22cfa7b65063c8.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The golang version of several TestDefinition is updated to match the required golang version by test-infra.
```
