### PR TITLE
minor improvements to testrunner

### DIFF
--- a/pkg/shootflavors/flavors.go
+++ b/pkg/shootflavors/flavors.go
@@ -53,6 +53,20 @@ func Validate(identifier string, flavor *common.ShootFlavor) error {
 		}
 	}
 
+	if len(flavor.AdditionalLocations) != 0 {
+		for i, location := range flavor.AdditionalLocations {
+			if location.Type == "" {
+				allErrs = multierror.Append(allErrs, fmt.Errorf("%s.additionalLocations[%d].type: value has to be defined", identifier, i))
+			}
+			if location.Repo == "" {
+				allErrs = multierror.Append(allErrs, fmt.Errorf("%s.additionalLocations[%d].repo: value has to be defined", identifier, i))
+			}
+			if location.Revision == "" {
+				allErrs = multierror.Append(allErrs, fmt.Errorf("%s.additionalLocations[%d].revision: value has to be defined", identifier, i))
+			}
+		}
+	}
+
 	return util.ReturnMultiError(allErrs)
 }
 

--- a/pkg/shootflavors/flavors_test.go
+++ b/pkg/shootflavors/flavors_test.go
@@ -129,6 +129,78 @@ var _ = Describe("flavor test", func() {
 		))
 	})
 
+	It("should fail with an incomplete additional location missing 'repo'", func() {
+		rawFlavors := []*common.ShootFlavor{
+			{
+				Provider:            common.CloudProviderGCP,
+				AdditionalLocations: []common.AdditionalLocation{{Type: "git", Revision: "1.2.3"}},
+				KubernetesVersions: common.ShootKubernetesVersionFlavor{
+					Versions: &[]gardencorev1beta1.ExpirableVersion{
+						{
+							Version: "1.15",
+						},
+					},
+				},
+			},
+		}
+		_, err := New(rawFlavors)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should fail with an incomplete additional location missing 'revision'", func() {
+		rawFlavors := []*common.ShootFlavor{
+			{
+				Provider:            common.CloudProviderGCP,
+				AdditionalLocations: []common.AdditionalLocation{{Type: "git", Repo: "github.com/org/name"}},
+				KubernetesVersions: common.ShootKubernetesVersionFlavor{
+					Versions: &[]gardencorev1beta1.ExpirableVersion{
+						{
+							Version: "1.15",
+						},
+					},
+				},
+			},
+		}
+		_, err := New(rawFlavors)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should fail with an incomplete additional location missing 'type'", func() {
+		rawFlavors := []*common.ShootFlavor{
+			{
+				Provider:            common.CloudProviderGCP,
+				AdditionalLocations: []common.AdditionalLocation{{Repo: "github.com/org/name", Revision: "1.2.3"}},
+				KubernetesVersions: common.ShootKubernetesVersionFlavor{
+					Versions: &[]gardencorev1beta1.ExpirableVersion{
+						{
+							Version: "1.15",
+						},
+					},
+				},
+			},
+		}
+		_, err := New(rawFlavors)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should fail with an incomplete additional location missing multiple fields", func() {
+		rawFlavors := []*common.ShootFlavor{
+			{
+				Provider:            common.CloudProviderGCP,
+				AdditionalLocations: []common.AdditionalLocation{{}},
+				KubernetesVersions: common.ShootKubernetesVersionFlavor{
+					Versions: &[]gardencorev1beta1.ExpirableVersion{
+						{
+							Version: "1.15",
+						},
+					},
+				},
+			},
+		}
+		_, err := New(rawFlavors)
+		Expect(err).To(HaveOccurred())
+	})
+
 	It("should return one shoot with disabled allowPrivilegeContainers", func() {
 		rawFlavors := []*common.ShootFlavor{
 			{

--- a/pkg/testrunner/template/renderer.go
+++ b/pkg/testrunner/template/renderer.go
@@ -209,7 +209,7 @@ func parseTestrunsFromChart(log logr.Logger, files map[string]string) []*v1beta1
 	for filename, file := range files {
 		tr, err := testmachinery.ParseTestrun([]byte(file))
 		if err != nil {
-			log.Info(fmt.Sprintf("cannot parse rendered file: %s", err.Error()))
+			log.Info(fmt.Sprintf("cannot parse rendered file %s: %s", filename, err.Error()))
 			continue
 		}
 		metav1.SetMetaDataAnnotation(&tr.ObjectMeta, common.AnnotationTemplateIDTestrun, filename)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind impediment

**What this PR does / why we need it**:
Some minor improvements of error handling by the testrunner.
- flavor validation will check `additionalLocations[]` for completeness
- testrunner will print the filename when it is not able to parse an already rendered file

**Which issue(s) this PR fixes**:
Fixes #378 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
validation of additionalLocations for flavors
```
