### PR TITLE
add a target to build test definition tools

### DIFF
--- a/.ci/test-definitions
+++ b/.ci/test-definitions
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+# Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.ci/test-definitions
+++ b/.ci/test-definitions
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -e
+export GO111MODULE=on
+
+printf "\nTest installation of test definition components\n"
+
+if [[ -z "${SOURCE_PATH}" ]]; then
+  export SOURCE_PATH="$(readlink -f "$(dirname ${0})/..")"
+else
+  export SOURCE_PATH="$(readlink -f "${SOURCE_PATH}")"
+fi
+
+cd "${SOURCE_PATH}"
+
+printf "\nNow installing: integration-tests/e2e ...\n"
+go install -mod=vendor ./integration-tests/e2e
+
+printf "\nNow installing: cmd/logging ...\n"
+go install -mod=vendor ./cmd/logging
+
+printf "\nNow installing: ./cmd/hostscheduler ...\n"
+go install -mod=vendor ./cmd/hostscheduler

--- a/.test-defs/allE2eTestgrid.yaml
+++ b/.test-defs/allE2eTestgrid.yaml
@@ -53,7 +53,7 @@ spec:
     export E2E_KUBECONFIG_PATH=$TM_KUBECONFIG_PATH/shoot.config &&
     export GARDEN_KUBECONFIG_PATH=$TM_KUBECONFIG_PATH/gardener.config &&
     go run --mod=vendor ./integration-tests/e2e --cleanUpAfterwards=true --flakeAttempts=5 --retryFailedTestcases=true
-  image: golang:1.15
+  image: golang:1.16
   resources:
     requests:
       memory: "500Mi"

--- a/.test-defs/cleanGardener.yaml
+++ b/.test-defs/cleanGardener.yaml
@@ -33,4 +33,4 @@ spec:
   args:
   - >-
     go run -mod=vendor ./cmd/cleanup/gardener --kubeconfig=$TM_KUBECONFIG_PATH/gardener.config
-  image: golang:1.15
+  image: golang:1.16

--- a/.test-defs/conformanceTestgrid.yaml
+++ b/.test-defs/conformanceTestgrid.yaml
@@ -56,7 +56,7 @@ spec:
     export E2E_KUBECONFIG_PATH=$TM_KUBECONFIG_PATH/shoot.config &&
     export GARDEN_KUBECONFIG_PATH=$TM_KUBECONFIG_PATH/gardener.config &&
     go run -mod=vendor ./integration-tests/e2e --cleanUpAfterwards=true --flakeAttempts=5
-  image: golang:1.15
+  image: golang:1.16
   resources:
     requests:
       memory: "500Mi"

--- a/.test-defs/conformanceTestgridParallel.yaml
+++ b/.test-defs/conformanceTestgridParallel.yaml
@@ -40,7 +40,7 @@ spec:
     export E2E_KUBECONFIG_PATH=$TM_KUBECONFIG_PATH/shoot.config &&
     export GARDEN_KUBECONFIG_PATH=$TM_KUBECONFIG_PATH/gardener.config &&
     go run -mod=vendor ./integration-tests/e2e --cleanUpAfterwards=true --flakeAttempts=5 --retryFailedTestcases=true
-  image: golang:1.15
+  image: golang:1.16
   resources:
     requests:
       memory: "500Mi"

--- a/.test-defs/e2eFast.yaml
+++ b/.test-defs/e2eFast.yaml
@@ -40,7 +40,7 @@ spec:
     export E2E_KUBECONFIG_PATH=$TM_KUBECONFIG_PATH/shoot.config &&
     export GARDEN_KUBECONFIG_PATH=$TM_KUBECONFIG_PATH/gardener.config &&
     go run -mod=vendor ./integration-tests/e2e --cleanUpAfterwards=true --flakeAttempts=5 --retryFailedTestcases=true
-  image: golang:1.15
+  image: golang:1.16
   resources:
     requests:
       memory: "500Mi"

--- a/.test-defs/e2eSlow.yaml
+++ b/.test-defs/e2eSlow.yaml
@@ -41,7 +41,7 @@ spec:
     export E2E_KUBECONFIG_PATH=$TM_KUBECONFIG_PATH/shoot.config &&
     export GARDEN_KUBECONFIG_PATH=$TM_KUBECONFIG_PATH/gardener.config &&
     go run -mod=vendor ./integration-tests/e2e --cleanUpAfterwards=true --flakeAttempts=5 --retryFailedTestcases=true
-  image: golang:1.15
+  image: golang:1.16
   resources:
     requests:
       memory: "500Mi"

--- a/.test-defs/e2eUntracked.yaml
+++ b/.test-defs/e2eUntracked.yaml
@@ -47,7 +47,7 @@ spec:
     export E2E_KUBECONFIG_PATH=$TM_KUBECONFIG_PATH/shoot.config &&
     export GARDEN_KUBECONFIG_PATH=$TM_KUBECONFIG_PATH/gardener.config &&
     go run -mod=vendor ./integration-tests/e2e --cleanUpAfterwards=true --flakeAttempts=5
-  image: golang:1.15
+  image: golang:1.16
   resources:
     requests:
       memory: "500Mi"

--- a/.test-defs/logGardener.yaml
+++ b/.test-defs/logGardener.yaml
@@ -33,4 +33,4 @@ spec:
   args:
   - >-
     go run -mod=vendor ./cmd/logging --kubeconfig=$TM_KUBECONFIG_PATH/host.config --output=$TM_EXPORT_PATH
-  image: golang:1.15
+  image: golang:1.16

--- a/.test-defs/scheduler-lock-gardener.yaml
+++ b/.test-defs/scheduler-lock-gardener.yaml
@@ -40,4 +40,4 @@ spec:
   args:
   - >-
     go run -mod=vendor ./cmd/hostscheduler gardener lock --id=$TM_TESTRUN_ID --kubeconfig=/tmp/secrets/gardener-service-account.kubeconfig --cloudprovider=$HOST_CLOUDPROVIDER
-  image: golang:1.15
+  image: golang:1.16

--- a/.test-defs/scheduler-lock.yaml
+++ b/.test-defs/scheduler-lock.yaml
@@ -52,4 +52,4 @@ spec:
   args:
   - >-
     go run -mod=vendor ./cmd/hostscheduler gke lock --id=$TM_TESTRUN_ID  --key=/tmp/secrets/gcloud.json --project=$GKE_PROJECT --zone=$GKE_ZONE
-  image: golang:1.15
+  image: golang:1.16

--- a/.test-defs/scheduler-release-gardener.yaml
+++ b/.test-defs/scheduler-release-gardener.yaml
@@ -40,4 +40,4 @@ spec:
   args:
   - >-
     go run -mod=vendor ./cmd/hostscheduler gardener release --kubeconfig=/tmp/secrets/gardener-service-account.kubeconfig --clean=$CLEAN
-  image: golang:1.15
+  image: golang:1.16

--- a/.test-defs/scheduler-release.yaml
+++ b/.test-defs/scheduler-release.yaml
@@ -52,4 +52,4 @@ spec:
   args:
   - >-
     go run -mod=vendor ./cmd/hostscheduler gke release --key=/tmp/secrets/gcloud.json --project=$PROJECT --zone=$ZONE --clean=$CLEAN
-  image: golang:1.15
+  image: golang:1.16

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,10 @@ install:
 .PHONY: verify
 verify: check
 
+.PHONY: build-test-defs
+build-test-defs:
+	@./hack/build-test-defs.sh
+
 .PHONY: all
 all: generate format verify install
 

--- a/hack/build-test-defs.sh
+++ b/hack/build-test-defs.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -e
+
+if [[ -z "${REPO_ROOT}" ]]; then
+  export REPO_ROOT="$(readlink -f "$(dirname ${0})/..")"
+else
+  export REPO_ROOT="$(readlink -f "${REPO_ROOT}")"
+fi
+
+DOCKERFILE_DIR="$REPO_ROOT/tmp/build-defs-dockerfiles"
+mkdir -p $DOCKERFILE_DIR
+BASE_IMAGE="golang:1.15"
+
+# build integration-tests/e2e
+cat << __EOF > $DOCKERFILE_DIR/e2e
+FROM $BASE_IMAGE
+WORKDIR /go/src/github.com/gardener/test-infra
+COPY . .
+
+RUN go install -mod=vendor ./integration-tests/e2e
+__EOF
+
+docker build -t tm-test-e2e-inst:latest -f $DOCKERFILE_DIR/e2e $REPO_ROOT
+
+# build cmd/logging
+cat << __EOF > $DOCKERFILE_DIR/logging
+FROM $BASE_IMAGE
+WORKDIR /go/src/github.com/gardener/test-infra
+COPY . .
+
+RUN go install -mod=vendor ./cmd/logging
+__EOF
+
+docker build -t tm-test-logging-inst:latest -f $DOCKERFILE_DIR/logging $REPO_ROOT
+
+# build cmd/hostscheduler
+cat << __EOF > $DOCKERFILE_DIR/hostscheduler
+FROM $BASE_IMAGE
+WORKDIR /go/src/github.com/gardener/test-infra
+COPY . .
+
+RUN go install -mod=vendor ./cmd/hostscheduler
+__EOF
+
+docker build -t tm-test-hostscheduler-inst:latest -f $DOCKERFILE_DIR/hostscheduler $REPO_ROOT

--- a/hack/build-test-defs.sh
+++ b/hack/build-test-defs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+# Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/build-test-defs.sh
+++ b/hack/build-test-defs.sh
@@ -23,7 +23,7 @@ fi
 
 DOCKERFILE_DIR="$REPO_ROOT/tmp/build-defs-dockerfiles"
 mkdir -p $DOCKERFILE_DIR
-BASE_IMAGE="golang:1.15"
+BASE_IMAGE="golang:1.16"
 
 # build integration-tests/e2e
 cat << __EOF > $DOCKERFILE_DIR/e2e


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind test

**What this PR does / why we need it**:
Add a `make` target + scripts to compile tools used in tests as defined in `.test-definitions`. A similar check is currently not available and thus basic installation issues are only detected when a test is executed.

As part of a recent dependency update, the go environment for these tests needs to be at least 1.16.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Once the PR is merged, we can add a step to the pipeline to run this regularly:  https://github.com/gardener/test-infra/blob/36f2a9c57f8c9f3c85ecbfa2583bf5babcbd2ce0/branch.cfg#L52-L56 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
make target to install test-definitions to detect issues early.
```
