### PR TITLE
Add more unit tests K8s version selection patterns

### DIFF
--- a/pkg/util/kubernetes_version_test.go
+++ b/pkg/util/kubernetes_version_test.go
@@ -68,7 +68,22 @@ var _ = Describe("kubernetes version util", func() {
 			))
 		})
 
-		It("should return latest patch of old minor version", func() {
+		It("should return latest patch of old minor version omitting patch and `filterPatchVersions: true`", func() {
+			pattern := "1.14"
+			filter := true
+			versionFlavor := common.ShootKubernetesVersionFlavor{
+				Pattern:             &pattern,
+				FilterPatchVersions: &filter,
+			}
+
+			versions, err := util.GetK8sVersions(cloudprofile, versionFlavor, false)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(versions).To(ConsistOf(
+				newExpirableVersion("1.14.6"),
+			))
+		})
+
+		It("should return latest patch of old minor version using '*' and `filterPatchVersions: true`", func() {
 			pattern := "1.14.*"
 			filter := true
 			versionFlavor := common.ShootKubernetesVersionFlavor{
@@ -79,6 +94,63 @@ var _ = Describe("kubernetes version util", func() {
 			versions, err := util.GetK8sVersions(cloudprofile, versionFlavor, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(versions).To(ConsistOf(
+				newExpirableVersion("1.14.6"),
+			))
+		})
+
+		It("should return latest patch of old minor version using 'X' and `filterPatchVersions: true`", func() {
+			pattern := "1.14.X"
+			filter := true
+			versionFlavor := common.ShootKubernetesVersionFlavor{
+				Pattern:             &pattern,
+				FilterPatchVersions: &filter,
+			}
+
+			versions, err := util.GetK8sVersions(cloudprofile, versionFlavor, false)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(versions).To(ConsistOf(
+				newExpirableVersion("1.14.6"),
+			))
+		})
+
+		It("should return all patch versions of an old minor version omitting patch and `filterPatchVersions`", func() {
+			pattern := "1.14"
+			versionFlavor := common.ShootKubernetesVersionFlavor{
+				Pattern: &pattern,
+			}
+
+			versions, err := util.GetK8sVersions(cloudprofile, versionFlavor, false)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(versions).To(ConsistOf(
+				newExpirableVersion("1.14.5"),
+				newExpirableVersion("1.14.6"),
+			))
+		})
+
+		It("should return all patch versions of an old minor version using `*` and omitting `filterPatchVersions`", func() {
+			pattern := "1.14.*"
+			versionFlavor := common.ShootKubernetesVersionFlavor{
+				Pattern: &pattern,
+			}
+
+			versions, err := util.GetK8sVersions(cloudprofile, versionFlavor, false)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(versions).To(ConsistOf(
+				newExpirableVersion("1.14.5"),
+				newExpirableVersion("1.14.6"),
+			))
+		})
+
+		It("should return all patch versions of an old minor version using `X` and omitting `filterPatchVersions`", func() {
+			pattern := "1.14.X"
+			versionFlavor := common.ShootKubernetesVersionFlavor{
+				Pattern: &pattern,
+			}
+
+			versions, err := util.GetK8sVersions(cloudprofile, versionFlavor, false)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(versions).To(ConsistOf(
+				newExpirableVersion("1.14.5"),
 				newExpirableVersion("1.14.6"),
 			))
 		})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind test

**What this PR does / why we need it**:
Add more unit tests K8s version selection patterns

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @hendrikKahl 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
