### PR TITLE
rename argo-ui to argo-server

### DIFF
--- a/examples/02-dev-configuration.yaml
+++ b/examples/02-dev-configuration.yaml
@@ -21,7 +21,7 @@ testmachinery:
   cleanWorkflowPods: false
 
 argo:
-  argoUI:
+  argoserver:
     ingress:
       enabled: true
       host: argoui.example.com

--- a/pkg/apis/config/constants.go
+++ b/pkg/apis/config/constants.go
@@ -34,7 +34,7 @@ const (
 	ArgoManagedResourceName = "argo"
 
 	// ArgoUIImageName is the name of the argo ui image in the image vector
-	ArgoUIImageName = "argo-ui"
+	ArgoUIImageName = "argo-server"
 
 	// ArgoWorkflowControllerImageName is the name of the argo workflow controller image in the image vector
 	ArgoWorkflowControllerImageName = "argo-workflow-controller"
@@ -43,7 +43,7 @@ const (
 	ArgoExecutorImageName = "argo-executor"
 
 	// ArgoUIIngressName is the name of the argo ui ingress resource deployed to the cluster
-	ArgoUIIngressName = "argo-ui"
+	ArgoUIIngressName = "argo-server"
 
 	// ArgoWorkflowControllerDeploymentName is the name workflow controller deployment
 	ArgoWorkflowControllerDeploymentName = "workflow-controller"

--- a/pkg/testrunner/util.go
+++ b/pkg/testrunner/util.go
@@ -45,7 +45,7 @@ func GetArgoURLFromHost(host string, tr *tmv1beta1.Testrun) string {
 
 // GetArgoHost returns the host of the argo ui
 func GetArgoHost(ctx context.Context, tmClient client.Client) (string, error) {
-	return GetHostURLFromIngress(ctx, tmClient, client.ObjectKey{Name: "argo-ui", Namespace: "default"})
+	return GetHostURLFromIngress(ctx, tmClient, client.ObjectKey{Name: "argo-server", Namespace: "default"})
 }
 
 // GetGrafanaURLFromHostForWorkflow returns the path to the logs in grafana for a whole workflow


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
Adjust some static strings that still contained `argo-ui` as the name for the ingress/service for the argo front-end. Its new name is `argo-server`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @dguendisch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix argo-ui references.
```
