### PR TITLE
Fix metrics port

### DIFF
--- a/charts/testmachinery/charts/argo/templates/config.yaml
+++ b/charts/testmachinery/charts/argo/templates/config.yaml
@@ -63,4 +63,4 @@ data:
     metricsConfig:
       enabled: true # fixed in 2.4.2
       path: /metrics
-      port: 8081
+      port: 9090


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:
Metrics port seems to have changed to 9090 (https://github.com/gardener/test-infra/blob/a9fb65f9535300a69eb95211020a9ea5c8e5ab75/charts/testmachinery/charts/argo/templates/argo.yaml#L144) so the config needs to adapt.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @hendrikKahl 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
