### PR TITLE
use workflow namespace for pod garbage collection

### DIFF
--- a/pkg/testmachinery/garbagecollection/workflow.go
+++ b/pkg/testmachinery/garbagecollection/workflow.go
@@ -59,7 +59,7 @@ func CleanWorkflowPods(c client.Client, wf *argov1.Workflow) error {
 	if testmachinery.CleanWorkflowPods() {
 		for nodeName, node := range wf.Status.Nodes {
 			if node.Type == argov1.NodeTypePod {
-				if err := deletePod(c, testmachinery.GetNamespace(), nodeName); err != nil {
+				if err := deletePod(c, wf.Namespace, nodeName); err != nil {
 					result = multierror.Append(result, fmt.Errorf("unable delete pod %s: %s", nodeName, err.Error()))
 				}
 			}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
The testmachinery controller implements some basic garbage collection to clean-up pods related to completed workflows. Even though the controller deploys workflows into different namespaces, it tries to find any pod in its own namespace. 

This PR changes the behavior to look into the namespace of the actual workflow for garbage collectoin.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @dguendisch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix pod garbage collection when using multiple namespaces
```
