### PR TITLE
Don't add ValidatingWebhookConfiguration in chart local mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,10 @@ deploy-controller:
 remove-controller:
 	helm template --namespace ${NS} -f ./charts/testmachinery/local-values.yaml ./charts/testmachinery | kubectl delete -f -
 
+.PHONY: remove-controller-local
+remove-controller-local:
+	helm template --namespace ${NS} -f ./charts/testmachinery/local-values.yaml  --set "testmachinery.local=true,testmachinery.insecure=true,controller.hostPath=/tmp/tm" \
+		./charts/testmachinery | kubectl delete -f -
 
 #####################
 # Local development #
@@ -131,7 +135,7 @@ run-controller:
 
 .PHONY: install-controller-local
 install-controller-local:
-	helm template --namespace ${NS} -f ./charts/testmachinery/local-values.yaml --set "local.enabled=true,local.hostPath=/tmp/tm" \
+	helm template --namespace ${NS} -f ./charts/testmachinery/local-values.yaml --set "testmachinery.local=true,testmachinery.insecure=true,controller.hostPath=/tmp/tm" \
 		./charts/testmachinery | kubectl create -f -
 
 .PHONY: run-it-tests

--- a/charts/testmachinery/templates/validating-webhook.yaml
+++ b/charts/testmachinery/templates/validating-webhook.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
+{{- if not .Values.testmachinery.local }}
 {{- if semverCompare ">= 1.16-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: admissionregistration.k8s.io/v1
 {{- else }}
@@ -42,3 +43,4 @@ webhooks:
       name: testmachinery-controller
       path: /webhooks/validate-testrun
     caBundle: {{ required ".Values.controller.tls.caBundle is required" (b64enc .Values.controller.tls.caBundle) }}
+{{- end }}


### PR DESCRIPTION
Don't add `ValidatingWebhookConfiguration` object if `.Values.testmachinery.local` is set. `local` mode causes the admission controller endpoint to not be added.

Signed-off-by: Brian Topping <brian.topping@sap.com>

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

