### PR TITLE
Render all test results if multiple results exist for a single cell

### DIFF
--- a/pkg/testrunner/result/result_suite_test.go
+++ b/pkg/testrunner/result/result_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package result
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestTestrunnerResult(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Testrunner Result Test Suite")
+}

--- a/pkg/testrunner/result/result_suite_test.go
+++ b/pkg/testrunner/result/result_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+// Copyright 2022 Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/testrunner/result/summary-poster_test.go
+++ b/pkg/testrunner/result/summary-poster_test.go
@@ -1,0 +1,58 @@
+package result
+
+import (
+	tmv1beta1 "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
+	"github.com/gardener/test-infra/pkg/testmachinery/metadata"
+	"github.com/gardener/test-infra/pkg/testrunner"
+	"github.com/gardener/test-infra/pkg/util"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("summary-poster", func() {
+
+	It("should render summary with 1 and 2 results for the same line", func() {
+		run := &testrunner.Run{
+			Info: nil,
+			Testrun: &tmv1beta1.Testrun{
+				Status: tmv1beta1.TestrunStatus{
+					Phase: tmv1beta1.RunPhaseSuccess,
+				},
+			},
+			Metadata: &metadata.Metadata{
+				CloudProvider: "foo",
+			},
+			Error:      nil,
+			Rerenderer: nil,
+		}
+		var runs testrunner.RunList
+		runs = append(runs, run)
+		items := parseTestrunsToTableItems(runs)
+		Expect(items).To(HaveLen(1))
+		slack, err := util.RenderTableForSlack(nil, items)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(slack).To(ContainSubstring(string(util.StatusSymbolSuccess)))
+		Expect(slack).ToNot(ContainSubstring(string(util.StatusSymbolNA)))
+
+		run = &testrunner.Run{
+			Info: nil,
+			Testrun: &tmv1beta1.Testrun{
+				Status: tmv1beta1.TestrunStatus{
+					Phase: tmv1beta1.RunPhaseFailed,
+				},
+			},
+			Metadata: &metadata.Metadata{
+				CloudProvider: "foo",
+			},
+			Error:      nil,
+			Rerenderer: nil,
+		}
+		runs = append(runs, run)
+		items = parseTestrunsToTableItems(runs)
+		Expect(items).To(HaveLen(2))
+		slack, err = util.RenderTableForSlack(nil, items)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(slack).To(ContainSubstring(string(util.StatusSymbolSuccess) + util.SymbolOffset + string(util.StatusSymbolFailure)))
+		Expect(slack).ToNot(ContainSubstring(string(util.StatusSymbolNA)))
+	})
+})

--- a/pkg/testrunner/result/summary-poster_test.go
+++ b/pkg/testrunner/result/summary-poster_test.go
@@ -1,17 +1,32 @@
+// Copyright 2022 Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package result
 
 import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
 	tmv1beta1 "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
 	"github.com/gardener/test-infra/pkg/testmachinery/metadata"
 	"github.com/gardener/test-infra/pkg/testrunner"
 	"github.com/gardener/test-infra/pkg/util"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("summary-poster", func() {
 
-	It("should render summary with 1 and 2 results for the same line", func() {
+	It("should render summary with single result", func() {
 		run := &testrunner.Run{
 			Info: nil,
 			Testrun: &tmv1beta1.Testrun{
@@ -33,7 +48,24 @@ var _ = Describe("summary-poster", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(slack).To(ContainSubstring(string(util.StatusSymbolSuccess)))
 		Expect(slack).ToNot(ContainSubstring(string(util.StatusSymbolNA)))
+	})
 
+	It("should render summary with two results for the same line", func() {
+		var runs testrunner.RunList
+		run := &testrunner.Run{
+			Info: nil,
+			Testrun: &tmv1beta1.Testrun{
+				Status: tmv1beta1.TestrunStatus{
+					Phase: tmv1beta1.RunPhaseSuccess,
+				},
+			},
+			Metadata: &metadata.Metadata{
+				CloudProvider: "foo",
+			},
+			Error:      nil,
+			Rerenderer: nil,
+		}
+		runs = append(runs, run)
 		run = &testrunner.Run{
 			Info: nil,
 			Testrun: &tmv1beta1.Testrun{
@@ -48,9 +80,9 @@ var _ = Describe("summary-poster", func() {
 			Rerenderer: nil,
 		}
 		runs = append(runs, run)
-		items = parseTestrunsToTableItems(runs)
+		items := parseTestrunsToTableItems(runs)
 		Expect(items).To(HaveLen(2))
-		slack, err = util.RenderTableForSlack(nil, items)
+		slack, err := util.RenderTableForSlack(nil, items)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(slack).To(ContainSubstring(string(util.StatusSymbolSuccess) + util.SymbolOffset + string(util.StatusSymbolFailure)))
 		Expect(slack).ToNot(ContainSubstring(string(util.StatusSymbolNA)))

--- a/pkg/util/slack-table-post.go
+++ b/pkg/util/slack-table-post.go
@@ -27,7 +27,7 @@ import (
 // SymbolOffset is the offset that the symbol is prefixed for better readability
 const SymbolOffset = " "
 
-// StatusSymbol is a unicode symbol for dieplaying in a table
+// StatusSymbol is a unicode symbol for displaying in a table
 type StatusSymbol string
 
 const (
@@ -122,7 +122,13 @@ func (r *results) AddResult(meta ItemMeta, symbol StatusSymbol) {
 			content:   content,
 		}
 	}
-	r.content[key].content[cpIndex] = SymbolOffset + string(symbol)
+
+	column := r.content[key].content[cpIndex]
+	if strings.Contains(column, string(StatusSymbolNA)) {
+		r.content[key].content[cpIndex] = SymbolOffset + string(symbol)
+	} else {
+		r.content[key].content[cpIndex] = column + SymbolOffset + string(symbol)
+	}
 }
 
 func computeDimensionKey(meta ItemMeta) string {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
Render all test results if multiple results exist for a single key, i.e. there were was a succesfull result for GCP+1.21+GL576 but a failed one for GCP+1.21+GL387 and the result matrix has only one line for GCP+1.21.
Does not add new dimensions for now (but can be added later), but just ensures that all results are visible.
Previously only one of the two results was rendered.
With this fix all are rendered:
```
      +---+--------+
      |   |  GCP   |
      +---+--------+
      |   |  ✅ ❌ |
      +---+--------+
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @hendrikKahl 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
