### PR TITLE
Report correct file when testrunner failis to build a client

### DIFF
--- a/cmd/testrunner/cmd/run_template/options.go
+++ b/cmd/testrunner/cmd/run_template/options.go
@@ -86,7 +86,7 @@ func (o *options) Complete() error {
 			Scheme: gardener.GardenScheme,
 		})
 		if err != nil {
-			logger.Log.Error(err, "unable to build garden kubernetes client", "file", o.tmKubeconfigPath)
+			logger.Log.Error(err, "unable to build garden kubernetes client", "file", o.testrunnerKubeconfigPath)
 			os.Exit(1)
 		}
 		flavors, err := GetShootFlavors(o.shootParameters.FlavorConfigPath, gardenK8sClient, o.shootPrefix, o.filterPatchVersions)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
To complete the `run_template` command, `testrunner` builds a client from a kubeconfig and fetches cloud profiles. In case this fails, the logged error contains a reference to the kubeconfig file used. Unfortunately, the wrong file name is given, which will be changed here.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @dguendisch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bug user
Reference correct kubeconfig file when testrunner fails to fetch cloud profiles.
```
