### PR TITLE
improve caching and parallel requests

### DIFF
--- a/pkg/testmachinery/controller/testmachinery_controller.go
+++ b/pkg/testmachinery/controller/testmachinery_controller.go
@@ -17,6 +17,8 @@ package controller
 import (
 	"fmt"
 
+	"github.com/gardener/test-infra/pkg/testmachinery/ghcache"
+
 	argov1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	"github.com/go-logr/logr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -75,6 +77,8 @@ func RegisterTestMachineryController(mgr manager.Manager, log logr.Logger, confi
 	if err := bldr.Complete(tmReconciler); err != nil {
 		return err
 	}
+
+	ghcache.InitGitHubCache(config.GitHub.Cache)
 
 	if !config.Controller.TTLController.Disable {
 		return ttl.AddControllerToManager(log, mgr, config.Controller.TTLController)

--- a/pkg/testmachinery/ghcache/cache.go
+++ b/pkg/testmachinery/ghcache/cache.go
@@ -17,6 +17,9 @@ package ghcache
 import (
 	"fmt"
 	"net/http"
+	"sync"
+
+	"github.com/gregjones/httpcache"
 )
 
 // cache extends the default http caching by adding caching behavior to errornous responses like 404.
@@ -24,9 +27,75 @@ import (
 type cache struct {
 	delegate      http.RoundTripper
 	maxAgeSeconds int
+	httpCache     httpcache.Cache
 }
 
+var (
+	// parallelRequests stores a Condition for each ongoing http request
+	parallelRequests     map[string]*sync.Cond
+	parallelRequestsLock sync.Mutex
+)
+
 func (c *cache) RoundTrip(req *http.Request) (*http.Response, error) {
+
+	// avoid parallel requests in case the response is not yet cached
+	// only GET and HEAD requests are cachable, thus we care only about those here
+	if req.Method != http.MethodGet && req.Method != http.MethodHead {
+		return c.roundTrip(req)
+	}
+
+	isCached, err := httpcache.CachedResponse(c.httpCache, req)
+	if err != nil {
+		return nil, err
+	}
+
+	// in case of a cache miss, we check for parallel requests
+	// if there is an ongoing request, wait on the Condition and proceed to get the response via the cache
+	// if we are the first, a new Condition is added to the map and the request will be sent
+	// once the request returns, remove the condition and then broadcast to awake waiting routines
+	if isCached == nil {
+		key := req.URL.String()
+
+		parallelRequestsLock.Lock()
+		activeRequest, ok := parallelRequests[key]
+		if !ok {
+			// no active request yet, we are the first!
+			activeRequest = sync.NewCond(&sync.Mutex{})
+			parallelRequests[key] = activeRequest
+			parallelRequestsLock.Unlock()
+
+			// run the actual request via the cache
+			res, err := c.roundTrip(req)
+
+			// remove the Condition for this key so no other requests can subscribe here
+			parallelRequestsLock.Lock()
+			delete(parallelRequests, key)
+			parallelRequestsLock.Unlock()
+
+			// lock the condition and wake up all other routines waiting
+			activeRequest.L.Lock()
+			activeRequest.Broadcast()
+			activeRequest.L.Unlock()
+
+			return res, err
+		} else {
+			// first, lock the Condition and then unlock the map access
+			// this ensures Broadcast() will be sent to all subscribers
+			activeRequest.L.Lock()
+			parallelRequestsLock.Unlock()
+
+			// being awaken from Wait() includes acquiring the lock, hence unlock is called
+			activeRequest.Wait()
+			activeRequest.L.Unlock()
+		}
+	}
+
+	// a cache hit can be expected now
+	return c.roundTrip(req)
+
+}
+
+func (c *cache) roundTrip(req *http.Request) (*http.Response, error) {
 	if c.maxAgeSeconds <= 0 {
 		return c.delegate.RoundTrip(req)
 	}

--- a/pkg/testmachinery/ghcache/cache.go
+++ b/pkg/testmachinery/ghcache/cache.go
@@ -32,7 +32,7 @@ type cache struct {
 
 var (
 	// parallelRequests stores a Condition for each ongoing http request
-	parallelRequests     map[string]*sync.Cond
+	parallelRequests     = make(map[string]*sync.Cond)
 	parallelRequestsLock sync.Mutex
 )
 

--- a/pkg/testmachinery/ghcache/ghcache.go
+++ b/pkg/testmachinery/ghcache/ghcache.go
@@ -50,12 +50,12 @@ func Cache(log logr.Logger, cfg *config.GitHubCache, delegate http.RoundTripper)
 	cachedTransport.Transport = &cache{
 		delegate:      delegate,
 		maxAgeSeconds: cfg.MaxAgeSeconds,
-		httpCache:     githubCache,
 	}
 
-	return &rateLimitLogger{
+	return &rateLimitControl{
 		log:      log,
 		delegate: cachedTransport,
+		cache:    githubCache,
 	}, nil
 
 }

--- a/pkg/testmachinery/ghcache/ghcache.go
+++ b/pkg/testmachinery/ghcache/ghcache.go
@@ -20,81 +20,77 @@ import (
 	"path"
 	"sync"
 
+	"github.com/gregjones/httpcache/diskcache"
+	"github.com/peterbourgon/diskv"
+
 	"github.com/gardener/test-infra/pkg/apis/config"
 
 	"github.com/go-logr/logr"
 	"github.com/gregjones/httpcache"
-	"github.com/gregjones/httpcache/diskcache"
-	"github.com/peterbourgon/diskv"
 	"github.com/pkg/errors"
 	flag "github.com/spf13/pflag"
 )
 
 var (
-	ghCache   httpcache.Cache
-	initCache sync.Mutex
+	ghCache       httpcache.Cache
+	maxAgeSeconds int
+	initOnce      sync.Once
 )
 
-// WithRateLimitControlCache adds github caching to a http client.
-// The very first call will init the cache once, based on the config handed over.
-// It returns a mem cache by default and a disk cache if a directory is defined
-func WithRateLimitControlCache(log logr.Logger, cfg *config.GitHubCache, delegate http.RoundTripper) (http.RoundTripper, error) {
-	if cfg == nil && internalConfig == nil {
-		return nil, errors.New("no configuration is provided for the github cache")
-	}
-	if cfg == nil {
-		cfg = internalConfig
+// WithRateLimitControlCache adds the central GitHub cache to a http client.
+// Call InitGitHubCache in advance for bootstrapping the cache
+func WithRateLimitControlCache(log logr.Logger, delegate http.RoundTripper) (http.RoundTripper, error) {
+
+	if ghCache == nil {
+		return nil, errors.New("cache has not been initialized yet")
 	}
 
-	githubCache, err := getOrCreateCache(cfg)
-	if err != nil {
-		return nil, err
-	}
-
-	cachedTransport := httpcache.NewTransport(githubCache)
+	cachedTransport := httpcache.NewTransport(ghCache)
 	cachedTransport.Transport = &cache{
 		delegate:      delegate,
-		maxAgeSeconds: cfg.MaxAgeSeconds,
+		maxAgeSeconds: maxAgeSeconds,
 	}
 
 	return &rateLimitControl{
 		log:      log,
 		delegate: cachedTransport,
-		cache:    githubCache,
+		cache:    ghCache,
 	}, nil
 
 }
 
-func getOrCreateCache(cfg *config.GitHubCache) (httpcache.Cache, error) {
-	if ghCache != nil {
-		return ghCache, nil
-	}
+// InitGitHubCache initializes a central cache exactly once
+// It returns a mem cache by default and a disk cache if a directory is defined
+func InitGitHubCache(cfg *config.GitHubCache) {
+	initOnce.Do(func() {
+		if cfg == nil && internalConfig == nil {
+			panic("no configuration is provided for the github cache")
+		}
+		if cfg == nil {
+			cfg = internalConfig
+		}
 
-	initCache.Lock()
-	defer initCache.Unlock()
-	if ghCache != nil {
-		return ghCache, nil
-	}
+		maxAgeSeconds = cfg.MaxAgeSeconds
 
-	if cfg.CacheDir == "" {
-		ghCache = httpcache.NewMemoryCache()
-		return ghCache, nil
-	}
+		if cfg.CacheDir == "" {
+			ghCache = httpcache.NewMemoryCache()
+			return
+		}
 
-	if err := os.MkdirAll(cfg.CacheDir, os.ModePerm); err != nil {
-		return nil, err
-	}
-	if cfg.CacheDiskSizeGB == 0 {
-		return nil, errors.New("disk cache size ha to be grater than 0")
-	}
+		if err := os.MkdirAll(cfg.CacheDir, os.ModePerm); err != nil {
+			panic(err)
+		}
+		if cfg.CacheDiskSizeGB == 0 {
+			panic("disk cache size ha to be grater than 0")
+		}
 
-	ghCache = diskcache.NewWithDiskv(
-		diskv.New(diskv.Options{
-			BasePath:     path.Join(cfg.CacheDir, "data"),
-			TempDir:      path.Join(cfg.CacheDir, "temp"),
-			CacheSizeMax: uint64(cfg.CacheDiskSizeGB) * uint64(1000000000), // GB to B
-		}))
-	return ghCache, nil
+		ghCache = diskcache.NewWithDiskv(
+			diskv.New(diskv.Options{
+				BasePath:     path.Join(cfg.CacheDir, "data"),
+				TempDir:      path.Join(cfg.CacheDir, "temp"),
+				CacheSizeMax: uint64(cfg.CacheDiskSizeGB) * uint64(1000000000), // GB to B
+			}))
+	})
 }
 
 var internalConfig *config.GitHubCache

--- a/pkg/testmachinery/ghcache/ratelimitcontrol.go
+++ b/pkg/testmachinery/ghcache/ratelimitcontrol.go
@@ -118,19 +118,18 @@ func (l *rateLimitControl) wakeUpCallFromCache(req *http.Request, reqCondition *
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
-	for {
+	for run := true; run; {
 		isCached, err := httpcache.CachedResponse(l.cache, req)
 		if err != nil || isCached != nil {
-			break
+			run = false
 		}
 		select {
 		case <-ctx.Done():
-			break
+			run = false
 		default:
 			time.Sleep(5 * time.Millisecond)
 		}
 	}
-
 	reqCondition.L.Lock()
 	reqCondition.Broadcast()
 	reqCondition.L.Unlock()

--- a/pkg/testmachinery/ghcache/ratelimitlogger.go
+++ b/pkg/testmachinery/ghcache/ratelimitlogger.go
@@ -16,24 +16,101 @@ package ghcache
 
 import (
 	"net/http"
+	"sync"
 
 	"github.com/go-logr/logr"
 	"github.com/gregjones/httpcache"
 )
 
-var _ http.RoundTripper = &rateLimitLogger{}
+var (
+	_ http.RoundTripper = &rateLimitControl{}
+	// parallelRequests stores a Condition for each ongoing http request
+	parallelRequests     = make(map[string]*sync.Cond)
+	parallelRequestsLock sync.Mutex
+)
 
-type rateLimitLogger struct {
+type rateLimitControl struct {
 	log      logr.Logger
 	delegate http.RoundTripper
+	cache    httpcache.Cache
 }
 
-func (l *rateLimitLogger) RoundTrip(req *http.Request) (*http.Response, error) {
+func (l *rateLimitControl) RoundTrip(req *http.Request) (*http.Response, error) {
+	key := req.URL.String()
+	l.log.V(5).Info("Starting RoundTrip", "key", key)
+	// avoid parallel requests in case the response is not yet cached
+	// only GET and HEAD requests are cachable, thus we care only about those here
+	if req.Method == http.MethodGet || req.Method == http.MethodHead {
+		isCached, err := httpcache.CachedResponse(l.cache, req)
+		if err != nil {
+			return nil, err
+		}
+
+		// in case of a cache miss, we check for parallel requests
+		// if there is an ongoing request, wait on the Condition and proceed to get the response via the cache
+		// if we are the first, a new Condition is added to the map and the request will be sent
+		// once the request returns, remove the condition and then broadcast to awake waiting routines
+		if isCached == nil {
+			l.log.V(5).Info("Request not yet cached", "key", key)
+			parallelRequestsLock.Lock()
+			activeRequest, ok := parallelRequests[key]
+			if !ok {
+				// no active request yet, we are the first!
+				l.log.V(5).Info("First request", "key", key)
+				activeRequest = sync.NewCond(&sync.Mutex{})
+				parallelRequests[key] = activeRequest
+				parallelRequestsLock.Unlock()
+
+				l.log.V(5).Info("First request roundtrip", "key", key)
+				// run the actual request via the cache
+				res, err := l.delegate.RoundTrip(req)
+				// remove the Condition for this key so no other requests can subscribe here
+				parallelRequestsLock.Lock()
+				delete(parallelRequests, key)
+				parallelRequestsLock.Unlock()
+
+				// lock the condition and wake up all other routines waiting
+				activeRequest.L.Lock()
+				isCached, err = httpcache.CachedResponse(l.cache, req)
+				if isCached == nil {
+					l.log.V(5).Info("Not yet cached", "key", key)
+				} else {
+					l.log.V(5).Info("Cache entry is present", "key", key)
+				}
+				l.log.V(5).Info("Wake up waiting requests", "key", key)
+				activeRequest.Broadcast()
+				activeRequest.L.Unlock()
+
+				l.logRateLimitInfo(req, res)
+				return res, err
+			} else {
+				// first, lock the Condition and then unlock the map access
+				// this ensures Broadcast() will be sent to all subscribers
+				l.log.V(5).Info("Similar request already in-flight", "key", key)
+				activeRequest.L.Lock()
+				parallelRequestsLock.Unlock()
+
+				// being awakened from Wait() includes acquiring the lock, hence unlock is called
+				activeRequest.Wait()
+				activeRequest.L.Unlock()
+				l.log.V(5).Info("Awaken", "key", key)
+
+			}
+		}
+
+	}
+
+	l.log.V(5).Info("Roundtrip with cache", "key", key)
+	// a cache hit for GET/HEAD requests is expected now
 	resp, err := l.delegate.RoundTrip(req)
 	if err != nil {
 		return nil, err
 	}
+	l.logRateLimitInfo(req, resp)
+	return resp, nil
+}
 
+func (l *rateLimitControl) logRateLimitInfo(req *http.Request, resp *http.Response) {
 	total := resp.Header.Get("X-RateLimit-Limit")
 	remaining := resp.Header.Get("X-RateLimit-Remaining")
 	hit := resp.Header.Get(httpcache.XFromCache)
@@ -41,6 +118,4 @@ func (l *rateLimitLogger) RoundTrip(req *http.Request) (*http.Response, error) {
 	if remaining == "0" {
 		l.log.Error(nil, "GitHub request limit exceeded", "total", total, "remaining", remaining, "url", req.URL.String())
 	}
-
-	return resp, nil
 }

--- a/pkg/testmachinery/locations/location/gitlocation.go
+++ b/pkg/testmachinery/locations/location/gitlocation.go
@@ -176,7 +176,7 @@ func (l *GitLocation) getGitHubClient() (*github.Client, *http.Client, error) {
 
 func (l *GitLocation) getHTTPClient() (*http.Client, error) {
 	if l.config != nil {
-		trp, err := ghcache.Cache(l.log.WithName("ghCache"), testmachinery.GetConfig().GitHub.Cache, &http.Transport{
+		trp, err := ghcache.WithRateLimitControlCache(l.log.WithName("ghCache"), testmachinery.GetConfig().GitHub.Cache, &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: l.config.SkipTls},
 		})
 		if err != nil {
@@ -193,7 +193,7 @@ func (l *GitLocation) getHTTPClient() (*http.Client, error) {
 	}
 
 	l.log.V(3).Info("insecure and unauthenticated git connection is used")
-	trp, err := ghcache.Cache(l.log.WithName("ghCache"), testmachinery.GetConfig().GitHub.Cache, &http.Transport{
+	trp, err := ghcache.WithRateLimitControlCache(l.log.WithName("ghCache"), testmachinery.GetConfig().GitHub.Cache, &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	})
 	if err != nil {

--- a/pkg/testmachinery/locations/location/gitlocation.go
+++ b/pkg/testmachinery/locations/location/gitlocation.go
@@ -176,7 +176,7 @@ func (l *GitLocation) getGitHubClient() (*github.Client, *http.Client, error) {
 
 func (l *GitLocation) getHTTPClient() (*http.Client, error) {
 	if l.config != nil {
-		trp, err := ghcache.WithRateLimitControlCache(l.log.WithName("ghCache"), testmachinery.GetConfig().GitHub.Cache, &http.Transport{
+		trp, err := ghcache.WithRateLimitControlCache(l.log.WithName("ghCache"), &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: l.config.SkipTls},
 		})
 		if err != nil {
@@ -193,7 +193,7 @@ func (l *GitLocation) getHTTPClient() (*http.Client, error) {
 	}
 
 	l.log.V(3).Info("insecure and unauthenticated git connection is used")
-	trp, err := ghcache.WithRateLimitControlCache(l.log.WithName("ghCache"), testmachinery.GetConfig().GitHub.Cache, &http.Transport{
+	trp, err := ghcache.WithRateLimitControlCache(l.log.WithName("ghCache"), &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	})
 	if err != nil {

--- a/pkg/tm-bot/github/manager.go
+++ b/pkg/tm-bot/github/manager.go
@@ -91,7 +91,7 @@ func (m *manager) getGitHubClient(installationID int64) (*internalClientItem, er
 		return ghClient, nil
 	}
 
-	trp, err := ghcache.WithRateLimitControlCache(m.log.WithName("ghCache"), m.cacheConfig, http.DefaultTransport)
+	trp, err := ghcache.WithRateLimitControlCache(m.log.WithName("ghCache"), http.DefaultTransport)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tm-bot/github/manager.go
+++ b/pkg/tm-bot/github/manager.go
@@ -91,7 +91,7 @@ func (m *manager) getGitHubClient(installationID int64) (*internalClientItem, er
 		return ghClient, nil
 	}
 
-	trp, err := ghcache.Cache(m.log.WithName("ghCache"), m.cacheConfig, http.DefaultTransport)
+	trp, err := ghcache.WithRateLimitControlCache(m.log.WithName("ghCache"), m.cacheConfig, http.DefaultTransport)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tm-bot/options.go
+++ b/pkg/tm-bot/options.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/gardener/test-infra/pkg/testmachinery/ghcache"
+
 	"github.com/go-logr/logr"
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
@@ -76,6 +78,7 @@ func (o *options) setupGitHubBot(router *mux.Router, runs *tests.Runs) error {
 	if !cfg.Enabled {
 		return nil
 	}
+	ghcache.InitGitHubCache(&cfg.GitHubCache)
 	ghClient, err := github.NewManager(o.log.WithName("github"), cfg)
 	if err != nil {
 		return errors.Wrap(err, "unable to initialize github client")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:
Testmachinery fetches lots of github repositories to resolve test definitions. It already uses a cache but when it is empty or has lots of misses while multiple testruns are processed, multiple requests for the same URI can happen in parallel. 

This causes unnecessary traffic and consumes requests subject to rate-limiting leading to quota exhaustion in the worst case. 

To improve the situation, the number of cache clients will be reduced. Parallel requests to the same URI will wait for the first to succeed and try to obtain the cached answer.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @dguendisch @BeckerMax 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Improve handling of parallel request to avoid exhaustion of request quotas
```
