### PR TITLE
Filter machine image based on CPU architecture of machines in worker pool.

### DIFF
--- a/docs/testrunner/README.md
+++ b/docs/testrunner/README.md
@@ -121,6 +121,7 @@ flavors:
         image:
           name: coreos
           version: latest
+        # architecture: amd64 # optional
       minimum: 1
       maximum: 2
       volume:

--- a/docs/testrunner/README.md
+++ b/docs/testrunner/README.md
@@ -121,7 +121,7 @@ flavors:
         image:
           name: coreos
           version: latest
-        # architecture: amd64 # optional
+        architecture: amd64 # optional
       minimum: 1
       maximum: 2
       volume:

--- a/pkg/shootflavors/extendedflavors.go
+++ b/pkg/shootflavors/extendedflavors.go
@@ -70,6 +70,8 @@ func NewExtended(k8sClient client.Client, rawFlavors []*common.ExtendedShootFlav
 
 	shoots := make([]*ExtendedFlavorInstance, 0)
 	for i, rawFlavor := range rawFlavors {
+		DefaultShootMachineArchitecture(rawFlavor.Workers)
+
 		if err := ValidateExtendedFlavor(fmt.Sprintf("Flavors.%d", i), rawFlavor); err != nil {
 			return nil, err
 		}

--- a/pkg/shootflavors/extendedflavors.go
+++ b/pkg/shootflavors/extendedflavors.go
@@ -18,7 +18,9 @@ import (
 	"fmt"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/hashicorp/go-multierror"
+	"k8s.io/utils/strings/slices"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/test-infra/pkg/common"
@@ -56,6 +58,12 @@ func ValidateExtendedFlavor(identifier string, flavor *common.ExtendedShootFlavo
 	for i, pool := range flavor.Workers {
 		if len(pool.WorkerPools) == 0 {
 			allErrs = multierror.Append(allErrs, fmt.Errorf("%s.%d.workerPools: at least one worker pool has to be defined", identifier, i))
+		}
+
+		for j, worker := range pool.WorkerPools {
+			if worker.Machine.Architecture != nil && !slices.Contains(v1beta1constants.ValidArchitectures, *worker.Machine.Architecture) {
+				allErrs = multierror.Append(allErrs, fmt.Errorf("%s[%d].machine.architecture: value is invalid", identifier, j))
+			}
 		}
 	}
 

--- a/pkg/shootflavors/extendedflavors_test.go
+++ b/pkg/shootflavors/extendedflavors_test.go
@@ -62,7 +62,7 @@ var _ = Describe("extended flavor test", func() {
 				MachineImages: []gardencorev1beta1.MachineImage{
 					{
 						Name:     "test-os",
-						Versions: MachineImageVersions("0.0.2", "0.0.1"),
+						Versions: MachineImageVersions(map[string][]string{"0.0.2": []string{"amd64"}, "0.0.1": []string{"amd64"}}),
 					},
 				},
 			},

--- a/pkg/shootflavors/extendedflavors_test.go
+++ b/pkg/shootflavors/extendedflavors_test.go
@@ -64,6 +64,10 @@ var _ = Describe("extended flavor test", func() {
 						Name:     "test-os",
 						Versions: MachineImageVersions(map[string][]string{"0.0.2": []string{"amd64"}, "0.0.1": []string{"amd64"}}),
 					},
+					{
+						Name:     "test-os-2",
+						Versions: MachineImageVersions(map[string][]string{"0.0.4": []string{"arm64"}, "0.0.3": []string{"arm64"}}),
+					},
 				},
 			},
 		}
@@ -115,9 +119,76 @@ var _ = Describe("extended flavor test", func() {
 			AdditionalAnnotations:     map[string]string{"a": "b"},
 			AdditionalLocations:       []common.AdditionalLocation{{Type: "git", Repo: "https:// github.com/gardener/gardener", Revision: "master"}},
 			KubernetesVersion:         gardencorev1beta1.ExpirableVersion{Version: "1.15"},
-			Workers:                   []gardencorev1beta1.Worker{{Name: "wp1"}},
+			Workers:                   []gardencorev1beta1.Worker{{Name: "wp1", Machine: gardencorev1beta1.Machine{Architecture: pointer.String("amd64")}}},
 		}))
 		Expect(shoot.Get().ExtendedConfiguration).To(Equal(defaultExtendedCfg))
+	})
+
+	It("should return 1 shoot with worker pool having machine of CPU architecture arm64", func() {
+		rawFlavors := []*common.ExtendedShootFlavor{{
+			ExtendedConfiguration: defaultExtendedCfg,
+			ShootFlavor: common.ShootFlavor{
+				AllowPrivilegedContainers: pointer.BoolPtr(true),
+				AdditionalAnnotations:     map[string]string{"a": "b"},
+				AdditionalLocations:       []common.AdditionalLocation{{Type: "git", Repo: "https:// github.com/gardener/gardener", Revision: "master"}},
+				Provider:                  common.CloudProviderGCP,
+				KubernetesVersions: common.ShootKubernetesVersionFlavor{
+					Versions: &[]gardencorev1beta1.ExpirableVersion{
+						{
+							Version: "1.15",
+						},
+					},
+				},
+				Workers: []common.ShootWorkerFlavor{
+					{
+						WorkerPools: []gardencorev1beta1.Worker{{Name: "wp1", Machine: gardencorev1beta1.Machine{Architecture: pointer.String("arm64")}}},
+					},
+				},
+			},
+		}}
+
+		c.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: "test-profile"}, gomock.Any()).Times(1)
+		flavors, err := NewExtended(c, rawFlavors, "test-pref", false)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(flavors.GetShoots()).To(HaveLen(1))
+
+		shoot := flavors.GetShoots()[0]
+		Expect(shoot.Get().Shoot).To(Equal(common.Shoot{
+			Provider:                  common.CloudProviderGCP,
+			AllowPrivilegedContainers: pointer.BoolPtr(true),
+			AdditionalAnnotations:     map[string]string{"a": "b"},
+			AdditionalLocations:       []common.AdditionalLocation{{Type: "git", Repo: "https:// github.com/gardener/gardener", Revision: "master"}},
+			KubernetesVersion:         gardencorev1beta1.ExpirableVersion{Version: "1.15"},
+			Workers:                   []gardencorev1beta1.Worker{{Name: "wp1", Machine: gardencorev1beta1.Machine{Architecture: pointer.String("arm64")}}},
+		}))
+		Expect(shoot.Get().ExtendedConfiguration).To(Equal(defaultExtendedCfg))
+	})
+
+	It("should fail with invalid CPU architecture of machine in a worker pool", func() {
+		rawFlavors := []*common.ExtendedShootFlavor{{
+			ExtendedConfiguration: defaultExtendedCfg,
+			ShootFlavor: common.ShootFlavor{
+				AllowPrivilegedContainers: pointer.BoolPtr(true),
+				AdditionalAnnotations:     map[string]string{"a": "b"},
+				AdditionalLocations:       []common.AdditionalLocation{{Type: "git", Repo: "https:// github.com/gardener/gardener", Revision: "master"}},
+				Provider:                  common.CloudProviderGCP,
+				KubernetesVersions: common.ShootKubernetesVersionFlavor{
+					Versions: &[]gardencorev1beta1.ExpirableVersion{
+						{
+							Version: "1.15",
+						},
+					},
+				},
+				Workers: []common.ShootWorkerFlavor{
+					{
+						WorkerPools: []gardencorev1beta1.Worker{{Name: "wp1", Machine: gardencorev1beta1.Machine{Architecture: pointer.String("foo")}}},
+					},
+				},
+			},
+		}}
+
+		_, err := NewExtended(c, rawFlavors, "test-pref", false)
+		Expect(err).To(HaveOccurred())
 	})
 
 	It("should select the correct 3 versions", func() {
@@ -247,15 +318,27 @@ var _ = Describe("extended flavor test", func() {
 				},
 				Workers: []common.ShootWorkerFlavor{
 					{
-						WorkerPools: []gardencorev1beta1.Worker{{
-							Name: "wp1",
-							Machine: gardencorev1beta1.Machine{
-								Image: &gardencorev1beta1.ShootMachineImage{
-									Name:    "test-os",
-									Version: pointer.StringPtr("latest"),
+						WorkerPools: []gardencorev1beta1.Worker{
+							{
+								Name: "wp1",
+								Machine: gardencorev1beta1.Machine{
+									Image: &gardencorev1beta1.ShootMachineImage{
+										Name:    "test-os",
+										Version: pointer.StringPtr("latest"),
+									},
 								},
 							},
-						}},
+							{
+								Name: "wp1",
+								Machine: gardencorev1beta1.Machine{
+									Image: &gardencorev1beta1.ShootMachineImage{
+										Name:    "test-os-2",
+										Version: pointer.StringPtr("latest"),
+									},
+									Architecture: pointer.String("arm64"),
+								},
+							},
+						},
 					},
 				},
 			},
@@ -270,6 +353,7 @@ var _ = Describe("extended flavor test", func() {
 		Expect(flavors.GetShoots()).To(HaveLen(1))
 
 		Expect(*flavors.GetShoots()[0].Get().Workers[0].Machine.Image.Version).To(Equal("0.0.2"))
+		Expect(*flavors.GetShoots()[0].Get().Workers[1].Machine.Image.Version).To(Equal("0.0.4"))
 	})
 
 	It("should generate a shoot with correct networkingType", func() {
@@ -308,7 +392,7 @@ var _ = Describe("extended flavor test", func() {
 			AdditionalAnnotations:     map[string]string{"a": "b"},
 			AdditionalLocations:       []common.AdditionalLocation{{Type: "git", Repo: "https:// github.com/gardener/gardener", Revision: "master"}},
 			KubernetesVersion:         gardencorev1beta1.ExpirableVersion{Version: "1.15"},
-			Workers:                   []gardencorev1beta1.Worker{{Name: "wp1"}},
+			Workers:                   []gardencorev1beta1.Worker{{Name: "wp1", Machine: gardencorev1beta1.Machine{Architecture: pointer.String("amd64")}}},
 		}))
 		Expect(shoot.Get().ExtendedConfiguration).To(Equal(defaultExtendedCfg))
 	})

--- a/pkg/shootflavors/flavors.go
+++ b/pkg/shootflavors/flavors.go
@@ -19,8 +19,11 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
+	"k8s.io/utils/pointer"
+	"k8s.io/utils/strings/slices"
 
 	"github.com/gardener/test-infra/pkg/common"
 	"github.com/gardener/test-infra/pkg/util"
@@ -48,6 +51,9 @@ func Validate(identifier string, flavor *common.ShootFlavor) error {
 			for j, workers := range pool.WorkerPools {
 				if workers.Machine.Image == nil {
 					allErrs = multierror.Append(allErrs, fmt.Errorf("%s[%d].machine.image: value has to be defined", identifier, j))
+				}
+				if workers.Machine.Architecture != nil && !slices.Contains(v1beta1constants.ValidArchitectures, *workers.Machine.Architecture) {
+					allErrs = multierror.Append(allErrs, fmt.Errorf("%s[%d].machine.architecture: value is invalid", identifier, j))
 				}
 			}
 		}

--- a/pkg/shootflavors/flavors.go
+++ b/pkg/shootflavors/flavors.go
@@ -70,6 +70,17 @@ func Validate(identifier string, flavor *common.ShootFlavor) error {
 	return util.ReturnMultiError(allErrs)
 }
 
+// DefaultShootMachineArchitecture defaults machine architecture of a worker pool to `amd64` if it is not set.
+func DefaultShootMachineArchitecture(workers []common.ShootWorkerFlavor) {
+	for i := range workers {
+		for j := range workers[i].WorkerPools {
+			if workers[i].WorkerPools[j].Machine.Architecture == nil {
+				workers[i].WorkerPools[j].Machine.Architecture = pointer.String(v1beta1constants.ArchitectureAMD64)
+			}
+		}
+	}
+}
+
 // New creates an internal representation of raw shoot flavors.
 // It also parses the flavors and creates the resulting shoots.
 func New(rawFlavors []*common.ShootFlavor) (*Flavors, error) {

--- a/pkg/shootflavors/flavors.go
+++ b/pkg/shootflavors/flavors.go
@@ -91,6 +91,8 @@ func New(rawFlavors []*common.ShootFlavor) (*Flavors, error) {
 
 	shoots := make([]*common.Shoot, 0)
 	for i, rawFlavor := range rawFlavors {
+		DefaultShootMachineArchitecture(rawFlavor.Workers)
+
 		if err := Validate(fmt.Sprintf("flavor[%d]", i), rawFlavor); err != nil {
 			return nil, err
 		}

--- a/pkg/shootflavors/flavors_test.go
+++ b/pkg/shootflavors/flavors_test.go
@@ -25,13 +25,20 @@ import (
 
 var _ = Describe("flavor test", func() {
 	var (
-		defaultMachine gardencorev1beta1.Machine
+		defaultMachine, defaultExpectedMachine gardencorev1beta1.Machine
 	)
 	BeforeEach(func() {
 		defaultMachine = gardencorev1beta1.Machine{
 			Type:  "test-machine",
 			Image: &gardencorev1beta1.ShootMachineImage{Name: "coreos", Version: pointer.StringPtr("0.0.1")},
 		}
+
+		defaultExpectedMachine = gardencorev1beta1.Machine{
+			Type:         "test-machine",
+			Image:        &gardencorev1beta1.ShootMachineImage{Name: "coreos", Version: pointer.StringPtr("0.0.1")},
+			Architecture: pointer.String("amd64"),
+		}
+
 	})
 	It("should return no shoots if no flavors are defined", func() {
 		rawFlavors := []*common.ShootFlavor{}
@@ -127,6 +134,64 @@ var _ = Describe("flavor test", func() {
 				KubernetesVersion:   gardencorev1beta1.ExpirableVersion{Version: "1.15"},
 			},
 		))
+	})
+
+	It("should return one shoot with worker pool machine architecture arm64", func() {
+		machine := defaultMachine
+		machine.Architecture = pointer.String("arm64")
+
+		rawFlavors := []*common.ShootFlavor{
+			{
+				Provider: common.CloudProviderGCP,
+				KubernetesVersions: common.ShootKubernetesVersionFlavor{
+					Versions: &[]gardencorev1beta1.ExpirableVersion{
+						{
+							Version: "1.15",
+						},
+					},
+				},
+				Workers: []common.ShootWorkerFlavor{
+					{
+						WorkerPools: []gardencorev1beta1.Worker{{Name: "wp1", Machine: machine}},
+					},
+				},
+			},
+		}
+		flavors, err := New(rawFlavors)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(flavors.GetShoots()).To(HaveLen(1))
+		Expect(flavors.GetShoots()).To(ConsistOf(
+			&common.Shoot{
+				Provider:          common.CloudProviderGCP,
+				KubernetesVersion: gardencorev1beta1.ExpirableVersion{Version: "1.15"},
+				Workers:           []gardencorev1beta1.Worker{{Name: "wp1", Machine: machine}},
+			},
+		))
+	})
+
+	It("should fail with an inavlid architecture type", func() {
+		machine := defaultMachine
+		machine.Architecture = pointer.String("foo")
+
+		rawFlavors := []*common.ShootFlavor{
+			{
+				Provider: common.CloudProviderGCP,
+				KubernetesVersions: common.ShootKubernetesVersionFlavor{
+					Versions: &[]gardencorev1beta1.ExpirableVersion{
+						{
+							Version: "1.15",
+						},
+					},
+				},
+				Workers: []common.ShootWorkerFlavor{
+					{
+						WorkerPools: []gardencorev1beta1.Worker{{Name: "wp1", Machine: machine}},
+					},
+				},
+			},
+		}
+		_, err := New(rawFlavors)
+		Expect(err).To(HaveOccurred())
 	})
 
 	It("should fail with an incomplete additional location missing 'repo'", func() {
@@ -289,22 +354,22 @@ var _ = Describe("flavor test", func() {
 			&common.Shoot{
 				Provider:          common.CloudProviderGCP,
 				KubernetesVersion: gardencorev1beta1.ExpirableVersion{Version: "1.15"},
-				Workers:           []gardencorev1beta1.Worker{{Name: "wp1", Machine: defaultMachine}},
+				Workers:           []gardencorev1beta1.Worker{{Name: "wp1", Machine: defaultExpectedMachine}},
 			},
 			&common.Shoot{
 				Provider:          common.CloudProviderGCP,
 				KubernetesVersion: gardencorev1beta1.ExpirableVersion{Version: "1.14"},
-				Workers:           []gardencorev1beta1.Worker{{Name: "wp1", Machine: defaultMachine}},
+				Workers:           []gardencorev1beta1.Worker{{Name: "wp1", Machine: defaultExpectedMachine}},
 			},
 			&common.Shoot{
 				Provider:          common.CloudProviderGCP,
 				KubernetesVersion: gardencorev1beta1.ExpirableVersion{Version: "1.15"},
-				Workers:           []gardencorev1beta1.Worker{{Name: "wp2", Machine: defaultMachine}},
+				Workers:           []gardencorev1beta1.Worker{{Name: "wp2", Machine: defaultExpectedMachine}},
 			},
 			&common.Shoot{
 				Provider:          common.CloudProviderGCP,
 				KubernetesVersion: gardencorev1beta1.ExpirableVersion{Version: "1.14"},
-				Workers:           []gardencorev1beta1.Worker{{Name: "wp2", Machine: defaultMachine}},
+				Workers:           []gardencorev1beta1.Worker{{Name: "wp2", Machine: defaultExpectedMachine}},
 			},
 		))
 	})
@@ -352,17 +417,89 @@ var _ = Describe("flavor test", func() {
 			&common.Shoot{
 				Provider:          common.CloudProviderGCP,
 				KubernetesVersion: gardencorev1beta1.ExpirableVersion{Version: "1.14"},
-				Workers:           []gardencorev1beta1.Worker{{Name: "wp1", Machine: defaultMachine}},
+				Workers:           []gardencorev1beta1.Worker{{Name: "wp1", Machine: defaultExpectedMachine}},
 			},
 			&common.Shoot{
 				Provider:          common.CloudProviderGCP,
 				KubernetesVersion: gardencorev1beta1.ExpirableVersion{Version: "1.13"},
-				Workers:           []gardencorev1beta1.Worker{{Name: "wp1", Machine: defaultMachine}},
+				Workers:           []gardencorev1beta1.Worker{{Name: "wp1", Machine: defaultExpectedMachine}},
 			},
 			&common.Shoot{
 				Provider:          common.CloudProviderGCP,
 				KubernetesVersion: gardencorev1beta1.ExpirableVersion{Version: "1.15"},
-				Workers:           []gardencorev1beta1.Worker{{Name: "wp1", Machine: defaultMachine}, {Name: "wp2", Machine: defaultMachine}},
+				Workers:           []gardencorev1beta1.Worker{{Name: "wp1", Machine: defaultExpectedMachine}, {Name: "wp2", Machine: defaultExpectedMachine}},
+			},
+		))
+	})
+
+	It("should return 1 gcp shoots with mulitple worker pool of different machine CPU architecture", func() {
+		machine := defaultMachine
+		machine.Architecture = pointer.String("arm64")
+		rawFlavors := []*common.ShootFlavor{
+			{
+				Provider: common.CloudProviderGCP,
+				KubernetesVersions: common.ShootKubernetesVersionFlavor{
+					Versions: &[]gardencorev1beta1.ExpirableVersion{
+						{
+							Version: "1.15",
+						},
+					},
+				},
+				Workers: []common.ShootWorkerFlavor{
+					{
+						WorkerPools: []gardencorev1beta1.Worker{{Name: "wp1", Machine: defaultMachine}, {Name: "wp2", Machine: machine}},
+					},
+				},
+			},
+		}
+		flavors, err := New(rawFlavors)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(flavors.GetShoots()).To(HaveLen(1))
+		Expect(flavors.GetShoots()).To(ConsistOf(
+			&common.Shoot{
+				Provider:          common.CloudProviderGCP,
+				KubernetesVersion: gardencorev1beta1.ExpirableVersion{Version: "1.15"},
+				Workers:           []gardencorev1beta1.Worker{{Name: "wp1", Machine: defaultExpectedMachine}, {Name: "wp2", Machine: machine}},
+			},
+		))
+	})
+
+	It("should return 2 gcp shoots with specified CPU architecture of machine in a worker pool", func() {
+		machine := defaultMachine
+		machine.Architecture = pointer.String("arm64")
+		rawFlavors := []*common.ShootFlavor{
+			{
+				Provider: common.CloudProviderGCP,
+				KubernetesVersions: common.ShootKubernetesVersionFlavor{
+					Versions: &[]gardencorev1beta1.ExpirableVersion{
+						{
+							Version: "1.15",
+						},
+					},
+				},
+				Workers: []common.ShootWorkerFlavor{
+					{
+						WorkerPools: []gardencorev1beta1.Worker{{Name: "wp1", Machine: defaultMachine}},
+					},
+					{
+						WorkerPools: []gardencorev1beta1.Worker{{Name: "wp2", Machine: machine}},
+					},
+				},
+			},
+		}
+		flavors, err := New(rawFlavors)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(flavors.GetShoots()).To(HaveLen(2))
+		Expect(flavors.GetShoots()).To(ConsistOf(
+			&common.Shoot{
+				Provider:          common.CloudProviderGCP,
+				KubernetesVersion: gardencorev1beta1.ExpirableVersion{Version: "1.15"},
+				Workers:           []gardencorev1beta1.Worker{{Name: "wp1", Machine: defaultExpectedMachine}},
+			},
+			&common.Shoot{
+				Provider:          common.CloudProviderGCP,
+				KubernetesVersion: gardencorev1beta1.ExpirableVersion{Version: "1.15"},
+				Workers:           []gardencorev1beta1.Worker{{Name: "wp2", Machine: machine}},
 			},
 		))
 	})

--- a/pkg/shootflavors/flavors_test.go
+++ b/pkg/shootflavors/flavors_test.go
@@ -512,7 +512,7 @@ var _ = Describe("flavor test", func() {
 			images := flavors.GetUsedMachineImages()
 			Expect(images).To(HaveKeyWithValue(common.CloudProviderGCP, []gardencorev1beta1.MachineImage{{
 				Name:     "coreos",
-				Versions: MachineImageVersions("0.0.1"),
+				Versions: MachineImageVersions(map[string][]string{"0.0.1": []string{"amd64"}}),
 			}}))
 		})
 
@@ -540,8 +540,8 @@ var _ = Describe("flavor test", func() {
 
 			images := flavors.GetUsedMachineImages()
 			Expect(images).To(HaveKeyWithValue(common.CloudProviderGCP, []gardencorev1beta1.MachineImage{
-				{Name: "coreos", Versions: MachineImageVersions("0.0.1")},
-				{Name: "jeos", Versions: MachineImageVersions("0.0.2")},
+				{Name: "coreos", Versions: MachineImageVersions(map[string][]string{"0.0.1": []string{"amd64"}})},
+				{Name: "jeos", Versions: MachineImageVersions(map[string][]string{"0.0.2": []string{"amd64"}})},
 			}))
 		})
 
@@ -575,8 +575,8 @@ var _ = Describe("flavor test", func() {
 
 			images := flavors.GetUsedMachineImages()
 			Expect(images).To(HaveKeyWithValue(common.CloudProviderGCP, []gardencorev1beta1.MachineImage{
-				{Name: "coreos", Versions: MachineImageVersions("0.0.1")},
-				{Name: "jeos", Versions: MachineImageVersions("0.0.2")},
+				{Name: "coreos", Versions: MachineImageVersions(map[string][]string{"0.0.1": []string{"amd64"}})},
+				{Name: "jeos", Versions: MachineImageVersions(map[string][]string{"0.0.2": []string{"amd64"}})},
 			}))
 		})
 	})

--- a/pkg/shootflavors/worker.go
+++ b/pkg/shootflavors/worker.go
@@ -12,7 +12,7 @@ func SetupWorker(cloudprofile gardencorev1beta1.CloudProfile, workers []gardenco
 	for i, w := range workers {
 		worker := w.DeepCopy()
 		if worker.Machine.Image != nil && (worker.Machine.Image.Version == nil || *worker.Machine.Image.Version == common.PatternLatest) {
-			version, err := util.GetLatestMachineImageVersion(cloudprofile, worker.Machine.Image.Name)
+			version, err := util.GetLatestMachineImageVersion(cloudprofile, worker.Machine.Image.Name, *worker.Machine.Architecture)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/backlog/issues/19

**Special notes for your reviewer**:
~~Depends on https://github.com/gardener/test-infra/pull/414~~

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
