### PR TITLE
Raise default from 50 to 200 elements before pagination starts

### DIFF
--- a/pkg/tm-bot/ui/pages/pagination/pagination.go
+++ b/pkg/tm-bot/ui/pages/pagination/pagination.go
@@ -40,7 +40,7 @@ type Page struct {
 }
 
 // defaultItems that are displayed on one page - 1
-const defaultItemsPerPage = 49
+const defaultItemsPerPage = 199
 
 // SliceFromValues slices the given list into the values gathered form the url values
 func SliceFromValues(list Interface, values url.Values) (Interface, Pages) {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
Raises the default amount of entries in the tm-bot UI before pagination happens from `50` to `200`.
Background: We regularly have some > 100 testruns and the UI does not slow down with a few hundred entries. Hence no need for pagination in such cases.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
