### PR TITLE
Adapt publish-tm-chart to work with helm v3.8 or later

### DIFF
--- a/.ci/publish-helm
+++ b/.ci/publish-helm
@@ -31,13 +31,8 @@ else
   export SOURCE_PATH="$(readlink -f "${SOURCE_PATH}")"
 fi
 
-export DESIRED_VERSION=v3.2.1
-curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
-
 cli.py config attribute --cfg-type container_registry --cfg-name gcr-readwrite --key password > /tmp/serviceaccount.yaml
 
-
-export HELM_EXPERIMENTAL_OCI=1
 helm registry login eu.gcr.io -u _json_key -p "$(cat /tmp/serviceaccount.yaml)"
 cd ${SOURCE_PATH}
 make publish-tm-chart

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ REGISTRY            := eu.gcr.io/gardener-project/gardener/testmachinery
 HELM_REGISTRY       := eu.gcr.io/gardener-project/charts/gardener/testmachinery
 
 TM_CONTROLLER_IMAGE := $(REGISTRY)/testmachinery-controller
-TM_CONTROLLER_CHART := $(HELM_REGISTRY)/testmachinery-controller
+TM_CONTROLLER_CHART := testmachinery-controller
 VERSION             ?= $(shell cat ${REPO_ROOT}/VERSION)
 IMAGE_TAG           := ${VERSION}
 
@@ -222,8 +222,8 @@ docker-image-golang:
 
 .PHONY: build-tm-chart
 build-tm-chart:
-	@helm chart save $(REPO_ROOT)/charts/testmachinery $(TM_CONTROLLER_CHART):$(VERSION)
+	@helm package $(REPO_ROOT)/charts/testmachinery --version $(VERSION) -d $(REPO_ROOT)/charts
 
 .PHONY: publish-tm-chart
 publish-tm-chart: build-tm-chart
-	@helm chart push $(TM_CONTROLLER_CHART):$(VERSION)
+	@helm push $(REPO_ROOT)/charts/$(TM_CONTROLLER_CHART)-$(VERSION).tgz oci://$(HELM_REGISTRY)

--- a/charts/testmachinery/Chart.yaml
+++ b/charts/testmachinery/Chart.yaml
@@ -15,5 +15,5 @@
 apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for deploying the testmachinery-controller, admissionwebhook and its roles and secrets.
-name: testmachinery
+name: testmachinery-controller
 version: 0.1.0


### PR DESCRIPTION
Signed-off-by: hendrikKahl <hendrik.kahl@sap.com>

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind technical-debt

**What this PR does / why we need it**:
Due to some changes in the concourse setup, the release job for this repo fails to publish the helm chart.
This PR adapts the scripts / make targets to work with helm v3 or later:
- stop downloading helm but assume a helm binary >= v3.8.0 will be present within it's concourse execution context
- rename the chart to `testmachinery-controller` as the metadata is used during upload. This way everything stays as it was from an external perspective and we avoid potentially breaking things
- use `package` and `push` to continue publishing the chart as an oci artifact 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @dguendisch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
