### PR TITLE
Support version patterns to go back 1,2,3 or 4 minor versions

### DIFF
--- a/docs/testrunner/README.md
+++ b/docs/testrunner/README.md
@@ -84,7 +84,7 @@ For example: 3 kubernetes versions and 4 worker pools will result in 12 differen
 flavors:
 - provider: aws|gcp|azure|alicloud|openstack|...
   kubernetes:
-    pattern: "latest|<semver constraint>" # latest or semver constraint see https://github.com/Masterminds/semver#checking-version-constraints
+    pattern: "latest|oneMinorBeforeLatest|...|fourMinorBeforeLatest|<semver constraint>" # latest or semver constraint see https://github.com/Masterminds/semver#checking-version-constraints
     filterPatchVersions: true|false # filter patch versions and only keep the latest patch versions per minor
     versions: # list of specific versions to test (a version is a expirable version as defined in the cloudprofiles)
     - version: "<specific version>"

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -111,7 +111,11 @@ const (
 	GardenSetupRepo = "https://github.com/gardener/garden-setup.git"
 	GardenerRepo    = "https://github.com/gardener/gardener.git"
 
-	PatternLatest = "latest"
+	PatternLatest                 = "latest"
+	PatternOneMinorBeforeLatest   = "oneMinorBeforeLatest"
+	PatternTwoMinorBeforeLatest   = "twoMinorBeforeLatest"
+	PatternThreeMinorBeforeLatest = "threeMinorBeforeLatest"
+	PatternFourMinorBeforeLatest  = "fourMinorBeforeLatest"
 
 	// TM Dashboard
 	DashboardExecutionGroupParameter = "runID"

--- a/pkg/util/kubernetes_version_test.go
+++ b/pkg/util/kubernetes_version_test.go
@@ -68,6 +68,69 @@ var _ = Describe("kubernetes version util", func() {
 			))
 		})
 
+		It("should return all patch versions of (latest minor - 1) version", func() {
+			pattern := "oneMinorBeforeLatest"
+			versionFlavor := common.ShootKubernetesVersionFlavor{
+				Pattern: &pattern,
+			}
+
+			versions, err := util.GetK8sVersions(cloudprofile, versionFlavor, false)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(versions).To(ConsistOf(
+				newExpirableVersion("1.14.5"),
+				newExpirableVersion("1.14.6"),
+			))
+		})
+
+		It("should return latest patch version of (latest minor - 1) version and filtering", func() {
+			pattern := "oneMinorBeforeLatest"
+			filter := true
+			versionFlavor := common.ShootKubernetesVersionFlavor{
+				Pattern:             &pattern,
+				FilterPatchVersions: &filter,
+			}
+
+			versions, err := util.GetK8sVersions(cloudprofile, versionFlavor, false)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(versions).To(ConsistOf(
+				newExpirableVersion("1.14.6"),
+			))
+		})
+
+		It("should return latest patch version of (latest minor - 2) version and filtering", func() {
+			pattern := "twoMinorBeforeLatest"
+			filter := true
+			versionFlavor := common.ShootKubernetesVersionFlavor{
+				Pattern:             &pattern,
+				FilterPatchVersions: &filter,
+			}
+
+			versions, err := util.GetK8sVersions(cloudprofile, versionFlavor, false)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(versions).To(ConsistOf(
+				newExpirableVersion("1.13.5"),
+			))
+		})
+
+		It("should not be possible to decrement beyond 0", func() {
+			pattern := "twoMinorBeforeLatest"
+			filter := true
+			versionFlavor := common.ShootKubernetesVersionFlavor{
+				Pattern:             &pattern,
+				FilterPatchVersions: &filter,
+			}
+
+			cloudprofile = gardencorev1beta1.CloudProfile{Spec: gardencorev1beta1.CloudProfileSpec{
+				Kubernetes: gardencorev1beta1.KubernetesSettings{
+					Versions: []gardencorev1beta1.ExpirableVersion{
+						newExpirableVersion("2.1.4"),
+					},
+				},
+			}}
+			_, err := util.GetK8sVersions(cloudprofile, versionFlavor, false)
+			Expect(err).To(HaveOccurred())
+		})
+
 		It("should return latest patch of old minor version omitting patch and `filterPatchVersions: true`", func() {
 			pattern := "1.14"
 			filter := true


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
K8s version patterns in flavors now support going a few minors back __relative__ to the latest supported K8s versions.
This allows to define test flavors that can test older K8s versions without regularly updating the flavor files.
Can be used with or without `filterPatchVersions: true` depending on whether you only want the latest patch version of some old minor version or all patch versions of this old minor version.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/test-infra/issues/419

**Special notes for your reviewer**:
/invite @hendrikKahl 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Test flavor K8s version patterns in addition to `latest` now support `oneMinorBeforeLatest`, ... up to `fourMinorBeforeLatest`. Can be used with or without `filterPatchVersions: true`.
```
