### PR TITLE
Skip `Kubectl client Simple pod should handle in-cluster config e2e test`

### DIFF
--- a/integration-tests/e2e/kubetest/description/1.21/skip.json
+++ b/integration-tests/e2e/kubetest/description/1.21/skip.json
@@ -74,6 +74,7 @@
   { "testcase": "[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale up with two External metrics from Stackdriver [Feature:CustomMetricsAutoscaling]"},
   { "testcase": "[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale up with two metrics of type Pod from Stackdriver [Feature:CustomMetricsAutoscaling]"},
   { "testcase": "[sig-cli] Kubectl alpha client [k8s.io] Kubectl run CronJob should create a CronJob"},
+  { "testcase": "[sig-cli] Kubectl client Simple pod should handle in-cluster config", "groups": ["fast"]},
   { "testcase": "[sig-cluster-lifecycle] Addon update should propagate add-on file changes [Slow]"},
   { "testcase": "[sig-cluster-lifecycle] kube-proxy migration [Feature:KubeProxyDaemonSetMigration] Downgrade kube-proxy from a DaemonSet to static pods should maintain a functioning cluster [Feature:KubeProxyDaemonSetDowngrade]"},
   { "testcase": "[sig-cluster-lifecycle] kube-proxy migration [Feature:KubeProxyDaemonSetMigration] Upgrade kube-proxy from static pods to a DaemonSet should maintain a functioning cluster [Feature:KubeProxyDaemonSetUpgrade]"},

--- a/integration-tests/e2e/kubetest/description/1.21/working.json
+++ b/integration-tests/e2e/kubetest/description/1.21/working.json
@@ -382,7 +382,6 @@
   { "testcase": "[sig-network] Networking Granular Checks: Services should function for node-Service: udp", "groups": ["fast"]},
   { "testcase": "[sig-cli] Kubectl client Simple pod should return command exit codes", "groups": ["fast"]},
   { "testcase": "[sig-network] Networking Granular Checks: Services should function for pod-Service: http", "groups": ["fast"]},
-  { "testcase": "[sig-cli] Kubectl client Simple pod should handle in-cluster config", "groups": ["fast"]},
   { "testcase": "[sig-apps] Job should remove pods when job is deleted", "groups": ["fast"]},
   { "testcase": "[sig-storage] CSI mock volume CSI Volume expansion should expand volume by restarting pod if attach=off, nodeExpansion=on", "groups": ["fast"]},
   { "testcase": "[sig-network] Networking Granular Checks: Services should function for client IP based session affinity: udp [LinuxOnly]", "groups": ["fast"]},

--- a/integration-tests/e2e/kubetest/description/1.22/skip.json
+++ b/integration-tests/e2e/kubetest/description/1.22/skip.json
@@ -74,6 +74,7 @@
   { "testcase": "[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale up with two External metrics from Stackdriver [Feature:CustomMetricsAutoscaling]"},
   { "testcase": "[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale up with two metrics of type Pod from Stackdriver [Feature:CustomMetricsAutoscaling]"},
   { "testcase": "[sig-cli] Kubectl alpha client [k8s.io] Kubectl run CronJob should create a CronJob"},
+  { "testcase": "[sig-cli] Kubectl client Simple pod should handle in-cluster config", "groups": ["fast"]},
   { "testcase": "[sig-cluster-lifecycle] Addon update should propagate add-on file changes [Slow]"},
   { "testcase": "[sig-cluster-lifecycle] kube-proxy migration [Feature:KubeProxyDaemonSetMigration] Downgrade kube-proxy from a DaemonSet to static pods should maintain a functioning cluster [Feature:KubeProxyDaemonSetDowngrade]"},
   { "testcase": "[sig-cluster-lifecycle] kube-proxy migration [Feature:KubeProxyDaemonSetMigration] Upgrade kube-proxy from static pods to a DaemonSet should maintain a functioning cluster [Feature:KubeProxyDaemonSetUpgrade]"},

--- a/integration-tests/e2e/kubetest/description/1.22/working.json
+++ b/integration-tests/e2e/kubetest/description/1.22/working.json
@@ -382,7 +382,6 @@
   { "testcase": "[sig-network] Networking Granular Checks: Services should function for node-Service: udp", "groups": ["fast"]},
   { "testcase": "[sig-cli] Kubectl client Simple pod should return command exit codes", "groups": ["fast"]},
   { "testcase": "[sig-network] Networking Granular Checks: Services should function for pod-Service: http", "groups": ["fast"]},
-  { "testcase": "[sig-cli] Kubectl client Simple pod should handle in-cluster config", "groups": ["fast"]},
   { "testcase": "[sig-apps] Job should remove pods when job is deleted", "groups": ["fast"]},
   { "testcase": "[sig-storage] CSI mock volume CSI Volume expansion should expand volume by restarting pod if attach=off, nodeExpansion=on", "groups": ["fast"]},
   { "testcase": "[sig-network] Networking Granular Checks: Services should function for client IP based session affinity: udp [LinuxOnly]", "groups": ["fast"]},

--- a/integration-tests/e2e/kubetest/description/1.23/skip.json
+++ b/integration-tests/e2e/kubetest/description/1.23/skip.json
@@ -74,6 +74,7 @@
   { "testcase": "[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale up with two External metrics from Stackdriver [Feature:CustomMetricsAutoscaling]"},
   { "testcase": "[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale up with two metrics of type Pod from Stackdriver [Feature:CustomMetricsAutoscaling]"},
   { "testcase": "[sig-cli] Kubectl alpha client [k8s.io] Kubectl run CronJob should create a CronJob"},
+  { "testcase": "[sig-cli] Kubectl client Simple pod should handle in-cluster config", "groups": ["fast"]},
   { "testcase": "[sig-cluster-lifecycle] Addon update should propagate add-on file changes [Slow]"},
   { "testcase": "[sig-cluster-lifecycle] kube-proxy migration [Feature:KubeProxyDaemonSetMigration] Downgrade kube-proxy from a DaemonSet to static pods should maintain a functioning cluster [Feature:KubeProxyDaemonSetDowngrade]"},
   { "testcase": "[sig-cluster-lifecycle] kube-proxy migration [Feature:KubeProxyDaemonSetMigration] Upgrade kube-proxy from static pods to a DaemonSet should maintain a functioning cluster [Feature:KubeProxyDaemonSetUpgrade]"},

--- a/integration-tests/e2e/kubetest/description/1.23/working.json
+++ b/integration-tests/e2e/kubetest/description/1.23/working.json
@@ -382,7 +382,6 @@
   { "testcase": "[sig-network] Networking Granular Checks: Services should function for node-Service: udp", "groups": ["fast"]},
   { "testcase": "[sig-cli] Kubectl client Simple pod should return command exit codes", "groups": ["fast"]},
   { "testcase": "[sig-network] Networking Granular Checks: Services should function for pod-Service: http", "groups": ["fast"]},
-  { "testcase": "[sig-cli] Kubectl client Simple pod should handle in-cluster config", "groups": ["fast"]},
   { "testcase": "[sig-apps] Job should remove pods when job is deleted", "groups": ["fast"]},
   { "testcase": "[sig-storage] CSI mock volume CSI Volume expansion should expand volume by restarting pod if attach=off, nodeExpansion=on", "groups": ["fast"]},
   { "testcase": "[sig-network] Networking Granular Checks: Services should function for client IP based session affinity: udp [LinuxOnly]", "groups": ["fast"]},

--- a/integration-tests/e2e/kubetest/description/1.24/skip.json
+++ b/integration-tests/e2e/kubetest/description/1.24/skip.json
@@ -74,6 +74,7 @@
   { "testcase": "[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale up with two External metrics from Stackdriver [Feature:CustomMetricsAutoscaling]"},
   { "testcase": "[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale up with two metrics of type Pod from Stackdriver [Feature:CustomMetricsAutoscaling]"},
   { "testcase": "[sig-cli] Kubectl alpha client [k8s.io] Kubectl run CronJob should create a CronJob"},
+  { "testcase": "[sig-cli] Kubectl client Simple pod should handle in-cluster config", "groups": ["fast"]},
   { "testcase": "[sig-cluster-lifecycle] Addon update should propagate add-on file changes [Slow]"},
   { "testcase": "[sig-cluster-lifecycle] kube-proxy migration [Feature:KubeProxyDaemonSetMigration] Downgrade kube-proxy from a DaemonSet to static pods should maintain a functioning cluster [Feature:KubeProxyDaemonSetDowngrade]"},
   { "testcase": "[sig-cluster-lifecycle] kube-proxy migration [Feature:KubeProxyDaemonSetMigration] Upgrade kube-proxy from static pods to a DaemonSet should maintain a functioning cluster [Feature:KubeProxyDaemonSetUpgrade]"},

--- a/integration-tests/e2e/kubetest/description/1.24/working.json
+++ b/integration-tests/e2e/kubetest/description/1.24/working.json
@@ -382,7 +382,6 @@
   { "testcase": "[sig-network] Networking Granular Checks: Services should function for node-Service: udp", "groups": ["fast"]},
   { "testcase": "[sig-cli] Kubectl client Simple pod should return command exit codes", "groups": ["fast"]},
   { "testcase": "[sig-network] Networking Granular Checks: Services should function for pod-Service: http", "groups": ["fast"]},
-  { "testcase": "[sig-cli] Kubectl client Simple pod should handle in-cluster config", "groups": ["fast"]},
   { "testcase": "[sig-apps] Job should remove pods when job is deleted", "groups": ["fast"]},
   { "testcase": "[sig-storage] CSI mock volume CSI Volume expansion should expand volume by restarting pod if attach=off, nodeExpansion=on", "groups": ["fast"]},
   { "testcase": "[sig-network] Networking Granular Checks: Services should function for client IP based session affinity: udp [LinuxOnly]", "groups": ["fast"]},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
This PR skip `Kubectl client Simple pod should handle in-cluster config e2e test` test as it doesn't work with arm64 machines/shoot. The test is supposed to run only on amd64 machines for more details check - https://github.com/kubernetes/kubernetes/blob/67d75db8905f16bb0d9d0a14b13a8736cb614533/test/e2e/kubectl/kubectl.go#L682-L691

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
