### PR TITLE
Cleanup S3 client

### DIFF
--- a/pkg/testmachinery/collector/collector_test.go
+++ b/pkg/testmachinery/collector/collector_test.go
@@ -158,7 +158,7 @@ var _ = Describe("collector summary", func() {
 		Expect(err).ToNot(HaveOccurred())
 		s3Object, err := mock_collector.CreateS3ObjectFromFile(filepath.Join(testdataDir, "11_export_artifact.tar.gz"))
 		Expect(err).ToNot(HaveOccurred())
-		s3Client.EXPECT().GetObject("testbucket", "/testing/my/export.tar.gz", gomock.Any()).Return(s3Object, nil)
+		s3Client.EXPECT().GetObject("testbucket", "/testing/my/export.tar.gz").Return(s3Object, nil)
 
 		// esClient.Request(http.MethodGet, "/testmachinery-*/_search", strings.NewReader(payload))
 		hits := `{ "hits": { "total": { "value": 0 } } }`

--- a/pkg/testmachinery/collector/exports.go
+++ b/pkg/testmachinery/collector/exports.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	argov1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
-	"github.com/minio/minio-go"
 
 	tmv1beta1 "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
 	"github.com/gardener/test-infra/pkg/testmachinery/metadata"
@@ -44,7 +43,7 @@ func (c *collector) getExportedDocuments(status tmv1beta1.TestrunStatus, meta *m
 				Duration:  step.Duration,
 				PodName:   step.PodName,
 			}
-			reader, err := c.s3Client.GetObject(c.s3Config.BucketName, step.ExportArtifactKey, minio.GetObjectOptions{})
+			reader, err := c.s3Client.GetObject(c.s3Config.BucketName, step.ExportArtifactKey)
 			if err != nil {
 				c.log.Info(fmt.Sprintf("cannot get exportet artifact %s", err.Error()), "artifact", step.ExportArtifactKey)
 				if reader != nil {

--- a/pkg/testmachinery/collector/exports_test.go
+++ b/pkg/testmachinery/collector/exports_test.go
@@ -77,7 +77,7 @@ var _ = Describe("collector summary", func() {
 
 		s3Object, err := mock_collector.CreateS3ObjectFromFile(filepath.Join(testdataDir, "11_export_artifact.tar.gz"))
 		Expect(err).ToNot(HaveOccurred())
-		s3Client.EXPECT().GetObject("testbucket", "/testing/my/export.tar.gz", gomock.Any()).Return(s3Object, nil)
+		s3Client.EXPECT().GetObject("testbucket", "/testing/my/export.tar.gz").Return(s3Object, nil)
 
 		err = c.collectSummaryAndExports(tmpDir, tr, &metadata.Metadata{Testrun: metadata.TestrunMetadata{ID: tr.Name}})
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/util/s3/mocks/client.go
+++ b/pkg/util/s3/mocks/client.go
@@ -36,18 +36,18 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // GetObject mocks base method.
-func (m *MockClient) GetObject(arg0, arg1 string, arg2 minio.GetObjectOptions) (s3.Object, error) {
+func (m *MockClient) GetObject(arg0, arg1 string) (s3.Object, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetObject", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetObject", arg0, arg1)
 	ret0, _ := ret[0].(s3.Object)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetObject indicates an expected call of GetObject.
-func (mr *MockClientMockRecorder) GetObject(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) GetObject(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetObject", reflect.TypeOf((*MockClient)(nil).GetObject), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetObject", reflect.TypeOf((*MockClient)(nil).GetObject), arg0, arg1)
 }
 
 // RemoveObject mocks base method.

--- a/pkg/util/s3/s3.go
+++ b/pkg/util/s3/s3.go
@@ -25,7 +25,7 @@ import (
 
 // Client is a interface to interact with a S3 object store
 type Client interface {
-	GetObject(bucketName, objectName string, opts minio.GetObjectOptions) (Object, error)
+	GetObject(bucketName, objectName string) (Object, error)
 	RemoveObject(bucketName, key string) error
 }
 
@@ -70,11 +70,11 @@ func New(config *Config) (Client, error) {
 	}, nil
 }
 
-func (c *client) GetObject(bucketName, objectName string, opts minio.GetObjectOptions) (Object, error) {
+func (c *client) GetObject(bucketName, objectName string) (Object, error) {
 	if bucketName == "" {
 		bucketName = c.defaultBucketName
 	}
-	return c.minioClient.GetObject(bucketName, objectName, opts)
+	return c.minioClient.GetObject(bucketName, objectName, minio.GetObjectOptions{})
 }
 
 func (c *client) RemoveObject(bucketName, key string) error {


### PR DESCRIPTION
Signed-off-by: Brian Topping <brian.topping@sap.com>

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area storage
/kind cleanup

**What this PR does / why we need it**:
Tighten the abstraction around the Minio S3 client down to a single file. Move the instantiation of empty options into the driver so a new driver can be built. Simple refactoring, no semantic changes.