### PR TITLE
Adapt to kubetests format for K8s 1.25

### DIFF
--- a/integration-tests/e2e/kubetest/desc_generator.go
+++ b/integration-tests/e2e/kubetest/desc_generator.go
@@ -203,7 +203,14 @@ func UnmarshalJunitXMLResult(junitXmlPath string) (junitXml JunitXMLResult, err 
 		return xmlResult, err
 	}
 	if err = xml.Unmarshal(junitXML, &xmlResult); err != nil {
-		return xmlResult, err
+		// alternatively try new K8s 1.25 format
+		log.Infof("couldn't unmarshal pre-1.25 format, trying new format (error was: %s)", err)
+		var nestedXmlResult NestedJunitXMLResult
+		if err = xml.Unmarshal(junitXML, &nestedXmlResult); err != nil {
+			return xmlResult, err
+		}
+		log.Info("success with 1.25 format")
+		xmlResult = nestedXmlResult.SingleResult
 	}
 
 	xmlResult.CalculateAdditionalFields()

--- a/integration-tests/e2e/kubetest/kubetest_runner.go
+++ b/integration-tests/e2e/kubetest/kubetest_runner.go
@@ -67,12 +67,18 @@ func Run(descFile string) (resultsPath string) {
 	parallelTestsFocus, serialTestsFocus := escapeAndConcat(descFile)
 	if serialTestsFocus != "" {
 		kubtestArgs := createKubetestArgs(serialTestsFocus, false, false, config.FlakeAttempts)
+		if len(config.TestcaseGroup) == 1 && config.TestcaseGroup[0] == "conformance" {
+			kubtestArgs.GinkgoFocus = "--ginkgo.focus=\\[Serial\\].*\\[Conformance\\]"
+		}
 		log.Info("run kubetest in serial way")
 		log.Infof("kubetest dump dir: %s", kubtestArgs.LogDir)
 		runKubetest(kubtestArgs, false)
 	}
 	if parallelTestsFocus != "" {
 		kubtestArgs := createKubetestArgs(parallelTestsFocus, true, false, config.FlakeAttempts)
+		if len(config.TestcaseGroup) == 1 && config.TestcaseGroup[0] == "conformance" {
+			kubtestArgs.GinkgoFocus = "--ginkgo.focus=\\[Conformance\\] --ginkgo.skip=\\[Serial\\]"
+		}
 		log.Info("run kubetest in parallel way")
 		log.Infof("kubetest dump dir: %s", kubtestArgs.LogDir)
 		runKubetest(kubtestArgs, false)

--- a/integration-tests/e2e/kubetest/xml_junit_result.go
+++ b/integration-tests/e2e/kubetest/xml_junit_result.go
@@ -43,6 +43,11 @@ func (testcase *TestcaseResult) calculateAdditionalFields(regexpSigGroup *regexp
 	testcase.K8sMajor = config.K8sReleaseMajorMinor
 }
 
+type NestedJunitXMLResult struct {
+	XMLName      xml.Name       `xml:"testsuites"`
+	SingleResult JunitXMLResult `xml:"testsuite"`
+}
+
 type JunitXMLResult struct {
 	XMLName         xml.Name         `xml:"testsuite"`
 	ExecutedTests   int              `xml:"tests,attr"`


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
Adapt the e2e test runner to be able to parse newer kubetest result formats for K8s 1.25 clusters and fix kubetest invocations for conformance tests which no longer worked for 1.25, instead use for 1.25 the suggested format of https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md#running-conformance-tests-with-kubetest.

/invite @hendrikKahl 
**Which issue(s) this PR fixes**:
Fixes errors like
```
couldn't unmarshal junit.xml /tmp/e2e/artifacts/1668608047/junit_01.xml: expected element type <testsuite> but have <testsuites>
```

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
