### PR TITLE
fix ioutil deprecation, make oauth github host configurable

### DIFF
--- a/cmd/elasticsearch/cmd/precompute/precompute.go
+++ b/cmd/elasticsearch/cmd/precompute/precompute.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"reflect"
 
@@ -163,7 +162,7 @@ func queryAndRecomputeAndStore(esClient elasticsearch.Client, path string, paylo
 	}
 
 	if !updateES {
-		payloadBytes, err := ioutil.ReadAll(payload)
+		payloadBytes, err := io.ReadAll(payload)
 		if err != nil {
 			logger.Log.Error(err, "could not parse bulk update payload into string")
 		}

--- a/cmd/local-validator/main.go
+++ b/cmd/local-validator/main.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -40,7 +39,7 @@ func main() {
 	trFilePath := flag.String("testrun", "examples/int-testrun.yaml", "Filepath to the testrun")
 	flag.Parse()
 
-	data, err := ioutil.ReadFile(*configPath)
+	data, err := os.ReadFile(*configPath)
 	if err != nil {
 		fmt.Print(err.Error())
 		os.Exit(1)

--- a/cmd/logging/main.go
+++ b/cmd/logging/main.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -81,7 +80,7 @@ func run(ctx context.Context) error {
 		return fmt.Errorf("host kubeconfig at %s does not exists", kubeconfigPath)
 	}
 
-	kubeconfigBytes, err := ioutil.ReadFile(kubeconfigPath)
+	kubeconfigBytes, err := os.ReadFile(kubeconfigPath)
 	if err != nil {
 		return fmt.Errorf("unable to read host kubeconfig: %w", err)
 	}
@@ -160,5 +159,5 @@ func writePodLogs(podName, outputPath string, logs []byte) error {
 	}
 	fileName := fmt.Sprintf("%s.log", podName)
 
-	return ioutil.WriteFile(path.Join(outputPath, fileName), logs, os.ModePerm)
+	return os.WriteFile(path.Join(outputPath, fileName), logs, os.ModePerm)
 }

--- a/cmd/prepare/prepare.go
+++ b/cmd/prepare/prepare.go
@@ -41,7 +41,6 @@ done
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -87,7 +86,7 @@ func createTMKubeconfigFile(log logr.Logger) error {
 	}
 
 	log.Info("Write TestMachinery kubeconfig to file", "file", tmFilePath)
-	return ioutil.WriteFile(tmFilePath, kubeconfig, os.ModePerm)
+	return os.WriteFile(tmFilePath, kubeconfig, os.ModePerm)
 }
 
 func createDirectories(log logr.Logger, directories []string) error {
@@ -144,7 +143,7 @@ func cloneRepository(log logr.Logger, repo *prepare.Repository, repoBasePath str
 }
 
 func readConfigFile(file string) (*prepare.Config, error) {
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/testrunner/cmd/run_template/options.go
+++ b/cmd/testrunner/cmd/run_template/options.go
@@ -16,7 +16,6 @@ package run_template
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -102,7 +101,7 @@ func (o *options) Complete() error {
 
 func GetShootFlavors(cfgPath string, k8sClient client.Client, shootPrefix string, filterPatchVersions bool) (*shootflavors.ExtendedFlavors, error) {
 	// read and parse test shoot configuration
-	dat, err := ioutil.ReadFile(cfgPath)
+	dat, err := os.ReadFile(cfgPath)
 	if err != nil {
 		return nil, pkgerrors.Wrapf(err, "unable to read test shoot configuration file from %s", cfgPath)
 	}

--- a/cmd/tm-bot/app/options.go
+++ b/cmd/tm-bot/app/options.go
@@ -16,7 +16,7 @@ package app
 
 import (
 	goflag "flag"
-	"io/ioutil"
+	"os"
 
 	"github.com/go-logr/logr"
 	flag "github.com/spf13/pflag"
@@ -69,7 +69,7 @@ func (o *options) Complete() error {
 }
 
 func (o *options) readConfig() error {
-	data, err := ioutil.ReadFile(o.configPath)
+	data, err := os.ReadFile(o.configPath)
 	if err != nil {
 		return err
 	}

--- a/integration-tests/e2e/kubetest/desc_generator.go
+++ b/integration-tests/e2e/kubetest/desc_generator.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -186,7 +185,7 @@ func getAllE2eTestCases() sets.StringSet {
 
 func UnmarshalDescription(descPath string) []TestcaseDesc {
 	var testcases []TestcaseDesc
-	descFile, err := ioutil.ReadFile(descPath)
+	descFile, err := os.ReadFile(descPath)
 	if err != nil {
 		log.Fatal(errors.Wrapf(err, "couldn't read file %s: %s", descPath, descFile))
 	}
@@ -198,7 +197,7 @@ func UnmarshalDescription(descPath string) []TestcaseDesc {
 
 func UnmarshalJunitXMLResult(junitXmlPath string) (junitXml JunitXMLResult, err error) {
 	var xmlResult JunitXMLResult
-	junitXML, err := ioutil.ReadFile(junitXmlPath)
+	junitXML, err := os.ReadFile(junitXmlPath)
 	if err != nil {
 		return xmlResult, err
 	}

--- a/integration-tests/e2e/kubetest/kubetest_runner.go
+++ b/integration-tests/e2e/kubetest/kubetest_runner.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -90,7 +89,7 @@ func getFileContent(filepath string) string {
 	if file, err := os.Open(filepath); err != nil {
 		log.Fatal(err)
 	} else {
-		b, err := ioutil.ReadAll(file)
+		b, err := io.ReadAll(file)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/integration-tests/e2e/kubetest/publisher.go
+++ b/integration-tests/e2e/kubetest/publisher.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -40,7 +39,7 @@ func Publish(kubetestResultsPath string, resultSummary Summary) {
 
 func createMetadataFiles(startedJsonPath, finishedJsonPath string, testSummary Summary) {
 	startedJsonContent := []byte(fmt.Sprintf("{\"timestamp\": %d}", testSummary.StartTime.Unix()))
-	if err := ioutil.WriteFile(startedJsonPath, startedJsonContent, 06444); err != nil {
+	if err := os.WriteFile(startedJsonPath, startedJsonContent, 06444); err != nil {
 		log.Fatal(err)
 	}
 
@@ -49,7 +48,7 @@ func createMetadataFiles(startedJsonPath, finishedJsonPath string, testSummary S
 		testStatus = "SUCCESS"
 	}
 	finishedJsonContent := []byte(fmt.Sprintf("{\"timestamp\": %d, \"result\": \"%s\", \"metadata\": {\"shoot-k8s-release\": \"%s\", \"gardener\": \"%s\"}}", testSummary.FinishedTime.Unix(), testStatus, config.K8sRelease, config.GardenerVersion))
-	if err := ioutil.WriteFile(finishedJsonPath, finishedJsonContent, 06444); err != nil {
+	if err := os.WriteFile(finishedJsonPath, finishedJsonContent, 06444); err != nil {
 		log.Fatal(err)
 	}
 

--- a/integration-tests/e2e/kubetest/results_evaluator.go
+++ b/integration-tests/e2e/kubetest/results_evaluator.go
@@ -5,7 +5,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -63,7 +62,7 @@ func writeSummaryToFile(summary Summary) {
 		log.Fatal(errors.Wrapf(err, "couldn't marshal testsuite summary %s", summary))
 	}
 	summaryFilePath := path.Join(config.ExportPath, TestSummaryFileName)
-	if err := ioutil.WriteFile(summaryFilePath, file, 0644); err != nil {
+	if err := os.WriteFile(summaryFilePath, file, 0644); err != nil {
 		log.Fatal(errors.Wrapf(err, "Couldn't write %s to file", summaryFilePath))
 	}
 }
@@ -192,7 +191,7 @@ func writeTestcaseToJSONFile(testcase TestcaseResult) error {
 
 	jsonFileName := fmt.Sprintf("test-%s.json", strconv.FormatInt(time.Now().UnixNano(), 10))
 	testcaseJsonFilePath := path.Join(config.ExportPath, jsonFileName)
-	if err := ioutil.WriteFile(testcaseJsonFilePath, testcaseJSON, 0644); err != nil {
+	if err := os.WriteFile(testcaseJsonFilePath, testcaseJSON, 0644); err != nil {
 		return errors.Wrapf(err, "Couldn't write %s to file", testcaseJsonFilePath)
 	}
 	return nil
@@ -232,7 +231,7 @@ func saveJunitXmlToFile(junitXMLFilePaths []string, mergedJunitXmlResult *JunitX
 	}
 	output = append([]byte(xml.Header), output...)
 
-	if err = ioutil.WriteFile(mergedJunitXmlFilePath, output, 0644); err != nil {
+	if err = os.WriteFile(mergedJunitXmlFilePath, output, 0644); err != nil {
 		return err
 	}
 	return nil
@@ -265,7 +264,7 @@ func analyzeE2eLogs(e2eLogFilePaths []string) (Summary, error) {
 			}
 		}
 		if summary.TestsuiteDuration == 0 {
-			contentBytes, err := ioutil.ReadFile(e2eLogPath)
+			contentBytes, err := os.ReadFile(e2eLogPath)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/integration-tests/e2e/kubetest/setup/setup.go
+++ b/integration-tests/e2e/kubetest/setup/setup.go
@@ -2,7 +2,6 @@ package setup
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -155,7 +154,7 @@ func areTestUtilitiesReady() error {
 	}
 
 	kubernetesVersionFile := path.Join(config.K8sRoot, "kubernetes/version")
-	currentKubernetesVersionByte, err := ioutil.ReadFile(kubernetesVersionFile)
+	currentKubernetesVersionByte, err := os.ReadFile(kubernetesVersionFile)
 	if err != nil || len(currentKubernetesVersionByte) == 0 {
 		res = multierror.Append(res, fmt.Errorf("Required file %s does not exist or is empty: ", kubernetesVersionFile))
 	} else if currentKubernetesVersion := strings.TrimSpace(string(currentKubernetesVersionByte[1:])); currentKubernetesVersion != config.K8sRelease {

--- a/integration-tests/e2e/util/dump/dump.go
+++ b/integration-tests/e2e/util/dump/dump.go
@@ -41,7 +41,7 @@ type KubernetesDumper struct {
 	k8sClient client.Client
 }
 
-//NewKubernetesDumper creates a new default k8s dumper.
+// NewKubernetesDumper creates a new default k8s dumper.
 func NewKubernetesDumper(log Logger, k8sClient client.Client) *KubernetesDumper {
 	return &KubernetesDumper{
 		log:       log,

--- a/integration-tests/e2e/util/util.go
+++ b/integration-tests/e2e/util/util.go
@@ -129,7 +129,7 @@ type CmdOutput struct {
 }
 
 /*
-	CommandExists checks whether the given command executable exists and returns a boolean result value
+CommandExists checks whether the given command executable exists and returns a boolean result value
 */
 func CommandExists(cmd string) bool {
 	_, err := exec.LookPath(cmd)

--- a/pkg/alert/alert.go
+++ b/pkg/alert/alert.go
@@ -38,14 +38,14 @@ type Alert struct {
 	cfg Config
 }
 
-//ElasticsearchConfig represents the elasticsearch configuration
+// ElasticsearchConfig represents the elasticsearch configuration
 type ElasticsearchConfig struct {
 	Endpoint *url.URL
 	User     string
 	Pass     string
 }
 
-//Config represents alerting configuration
+// Config represents alerting configuration
 type Config struct {
 	EvalTimeDays                int // EvalTimeDays time range to consinder for evaluation in days (now - n days before)
 	SuccessRateThresholdPercent int // SuccessRateThresholdPercent if test success rate falls below threshold post an alert
@@ -55,7 +55,7 @@ type Config struct {
 	TestsFocus                  []string
 }
 
-//New creates a new instance of alert
+// New creates a new instance of alert
 func New(log logr.Logger, cfg Config) *Alert {
 	return &Alert{
 		log: log,
@@ -182,7 +182,7 @@ func (alerter *Alert) removeExcludedTests(tests *map[string]TestDetails) error {
 	return nil
 }
 
-//removeAlreadyFiledAlerts filters out tests that have already been alerted in recent n days
+// removeAlreadyFiledAlerts filters out tests that have already been alerted in recent n days
 func (alerter *Alert) removeAlreadyFiledAlerts(tests map[string]TestDetails, alreadyFiledAlerts AlertDocs) {
 	testsSizeBefore := len(tests)
 	for _, alertItem := range alreadyFiledAlerts.Hits.AlertItems {
@@ -191,7 +191,7 @@ func (alerter *Alert) removeAlreadyFiledAlerts(tests map[string]TestDetails, alr
 	alerter.log.V(3).Info(fmt.Sprintf("%d/%d tests alerts have been discarded, since they have already been posted in slack", testsSizeBefore-len(tests), testsSizeBefore))
 }
 
-//getFiledAlerts gets list of existing alert docs in elasticsearch
+// getFiledAlerts gets list of existing alert docs in elasticsearch
 func (alerter *Alert) getFiledAlerts() (AlertDocs, error) {
 	var alreadyFiledAlerts AlertDocs
 	if err := alerter.elasticRequest("/tm-alerter*/_search", http.MethodGet, `{"size": 10000}`, &alreadyFiledAlerts); err != nil {
@@ -201,7 +201,7 @@ func (alerter *Alert) getFiledAlerts() (AlertDocs, error) {
 	return alreadyFiledAlerts, nil
 }
 
-//deleteOutdatedAlertDocsPayload deletes all elasticsearch documents that are older than n days
+// deleteOutdatedAlertDocsPayload deletes all elasticsearch documents that are older than n days
 func (alerter *Alert) deleteOutdatedAlertsFromDB() error {
 	alerter.log.V(3).Info("delete outdated elasticsearch alerter docs")
 	deleteOutdatedAlertDocsPayload := fmt.Sprintf(`{ "query": { "range": { "datetime": { "lt": "now-%dd" } } } }`, alerter.cfg.EvalTimeDays)
@@ -211,7 +211,7 @@ func (alerter *Alert) deleteOutdatedAlertsFromDB() error {
 	return nil
 }
 
-//PostAlertMessageToSlack posts alerts to slack
+// PostAlertMessageToSlack posts alerts to slack
 func (alerter *Alert) PostAlertMessageToSlack(client slack.Client, channel string, failedTests map[string]TestDetails) error {
 	if len(failedTests) == 0 {
 		alerter.log.Info("no new failed tests found, nothing to post in slack")
@@ -240,7 +240,7 @@ func (alerter *Alert) PostAlertMessageToSlack(client slack.Client, channel strin
 	return nil
 }
 
-//createAlertMessage creates the alert message
+// createAlertMessage creates the alert message
 func createAlertMessage(failedTests map[string]TestDetails, alert *Alert) string {
 	sortedKeys := make([]string, 0, len(failedTests))
 	for k := range failedTests {
@@ -282,7 +282,7 @@ func createAlertMessage(failedTests map[string]TestDetails, alert *Alert) string
 	return writer.String()
 }
 
-//PostRecoverMessageToSlack posts alerts to slack
+// PostRecoverMessageToSlack posts alerts to slack
 func (alerter *Alert) PostRecoverMessageToSlack(client slack.Client, channel string, recoveredTests map[string]TestDetails) error {
 	if len(recoveredTests) == 0 {
 		alerter.log.Info("no new recovered tests found, nothing to post in slack")
@@ -312,7 +312,7 @@ func (alerter *Alert) PostRecoverMessageToSlack(client slack.Client, channel str
 	return nil
 }
 
-//createAlertMessage creates the alert message
+// createAlertMessage creates the alert message
 func createRecoverMessage(recoveredTests map[string]TestDetails) string {
 	sortedKeys := make([]string, 0, len(recoveredTests))
 	for k := range recoveredTests {
@@ -354,7 +354,7 @@ func (alerter *Alert) deleteRecoveredTestsFromAlertIndex(testNames []string) err
 	return nil
 }
 
-//splitSlackMessage split message line wise based on given characters limit
+// splitSlackMessage split message line wise based on given characters limit
 func splitSlackMessage(message string, charactersLimit int) []string {
 	var messageSplits []string
 	lines := strings.Split(message, "\n")

--- a/pkg/alert/alerttypes.go
+++ b/pkg/alert/alerttypes.go
@@ -60,7 +60,7 @@ type AlertDocs struct {
 	} `json:"hits"`
 }
 
-//TestDetails describes a test which is used for alert message
+// TestDetails describes a test which is used for alert message
 type TestDetails struct {
 	Name                string  `json:"name"`               //Name test name
 	Context             string  `json:"testContext"`        //Context is the concatenation of name and several test dimensions
@@ -76,7 +76,7 @@ type TestDetails struct {
 	TestrunID           string  `json:"testrunID"`
 }
 
-//ElasticsearchBulkString creates an elastic search bulk string for ingestion
+// ElasticsearchBulkString creates an elastic search bulk string for ingestion
 func (test TestDetails) ElasticsearchBulkString() (string, error) {
 	testDetailsMarshaled, err := json.Marshal(test)
 	if err != nil {

--- a/pkg/apis/config/bot.go
+++ b/pkg/apis/config/bot.go
@@ -79,19 +79,23 @@ type DashboardAuthentication struct {
 	// +optional
 	CookieSecret string `json:"cookieSecret"`
 
-	// GitHub holds the github provider specific configuration
+	// GitHub holds the GitHub provider specific configuration
 	// +optional
 	GitHub *GitHubAuthentication `json:"githubConfig"`
 }
 
 type GitHubAuthentication struct {
-	// OAuth Github configuration that is used to protect parts of the dashboard
+	// OAuth GitHub configuration that is used to protect parts of the dashboard
 	// +optional
 	OAuth *OAuth `json:"oAuth"`
 
 	// Organization is the GitHub organization to restrict access to the bot
 	// +optional
 	Organization string `json:"organization"`
+
+	// Hostname points to the GitHub instance used for the authentication flow
+	// +optional
+	Hostname string `json:"hostname"`
 }
 
 type OAuth struct {

--- a/pkg/apis/config/config_testmachinery.go
+++ b/pkg/apis/config/config_testmachinery.go
@@ -78,7 +78,7 @@ type GitHubCache struct {
 	MaxAgeSeconds   int    `json:"maxAgeSeconds,omitempty"`
 }
 
-//LandscapeMapping defines how to connect to a landscape using an OpenIDConnect IDP
+// LandscapeMapping defines how to connect to a landscape using an OpenIDConnect IDP
 type LandscapeMapping struct {
 	// Namespace indicates the namespace where TestRuns for a specific landscape should run
 	Namespace string `json:"namespace,omitempty"`

--- a/pkg/apis/config/v1beta1/bot.go
+++ b/pkg/apis/config/v1beta1/bot.go
@@ -79,19 +79,23 @@ type DashboardAuthentication struct {
 	// +optional
 	CookieSecret string `json:"cookieSecret"`
 
-	// GitHub holds the github provider specific configuration
+	// GitHub holds the GitHub provider specific configuration
 	// +optional
 	GitHub *GitHubAuthentication `json:"githubConfig"`
 }
 
 type GitHubAuthentication struct {
-	// OAuth Github configuration that is used to protect parts of the dashboard
+	// OAuth GitHub configuration that is used to protect parts of the dashboard
 	// +optional
 	OAuth *OAuth `json:"oAuth"`
 
 	// Organization is the GitHub organization to restrict access to the bot
 	// +optional
 	Organization string `json:"organization"`
+
+	// Hostname points to the GitHub instance used for the authentication flow
+	// +optional
+	Hostname string `json:"hostname"`
 }
 
 type OAuth struct {

--- a/pkg/apis/config/v1beta1/config_testmachinery.go
+++ b/pkg/apis/config/v1beta1/config_testmachinery.go
@@ -78,7 +78,7 @@ type GitHubCache struct {
 	MaxAgeSeconds   int    `json:"maxAgeSeconds,omitempty"`
 }
 
-//LandscapeMapping defines how to connect to a landscape using an OpenIDConnect IDP
+// LandscapeMapping defines how to connect to a landscape using an OpenIDConnect IDP
 type LandscapeMapping struct {
 	// Namespace indicates the namespace where TestRuns for a specific landscape should run
 	Namespace string `json:"namespace,omitempty"`

--- a/pkg/apis/config/v1beta1/defaults.go
+++ b/pkg/apis/config/v1beta1/defaults.go
@@ -117,4 +117,7 @@ func SetDefaults_GitHubAuthentication(obj *GitHubAuthentication) {
 	if len(obj.Organization) == 0 {
 		obj.Organization = "gardener"
 	}
+	if len(obj.Hostname) == 0 {
+		obj.Hostname = "github.com"
+	}
 }

--- a/pkg/apis/config/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/config/v1beta1/zz_generated.conversion.go
@@ -492,6 +492,7 @@ func Convert_config_GitHub_To_v1beta1_GitHub(in *config.GitHub, out *GitHub, s c
 func autoConvert_v1beta1_GitHubAuthentication_To_config_GitHubAuthentication(in *GitHubAuthentication, out *config.GitHubAuthentication, s conversion.Scope) error {
 	out.OAuth = (*config.OAuth)(unsafe.Pointer(in.OAuth))
 	out.Organization = in.Organization
+	out.Hostname = in.Hostname
 	return nil
 }
 
@@ -503,6 +504,7 @@ func Convert_v1beta1_GitHubAuthentication_To_config_GitHubAuthentication(in *Git
 func autoConvert_config_GitHubAuthentication_To_v1beta1_GitHubAuthentication(in *config.GitHubAuthentication, out *GitHubAuthentication, s conversion.Scope) error {
 	out.OAuth = (*OAuth)(unsafe.Pointer(in.OAuth))
 	out.Organization = in.Organization
+	out.Hostname = in.Hostname
 	return nil
 }
 

--- a/pkg/hostscheduler/gardenerscheduler/helper.go
+++ b/pkg/hostscheduler/gardenerscheduler/helper.go
@@ -17,7 +17,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -41,7 +41,7 @@ func isHibernated(shoot *gardencorev1beta1.Shoot) bool {
 }
 
 func getNamespaceOfKubeconfig(kubeconfigPath string) (string, error) {
-	data, err := ioutil.ReadFile(kubeconfigPath)
+	data, err := os.ReadFile(kubeconfigPath)
 	if err != nil {
 		return "", errors.Wrapf(err, "cannot read file from %s", kubeconfigPath)
 	}
@@ -139,7 +139,7 @@ func readHostInformationFromFile() (*client.ObjectKey, error) {
 	if err != nil {
 		return nil, err
 	}
-	data, err := ioutil.ReadFile(hostConfigPath)
+	data, err := os.ReadFile(hostConfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("cannot read file %s: %s", hostConfigPath, err.Error())
 	}

--- a/pkg/hostscheduler/gardenerscheduler/lock.go
+++ b/pkg/hostscheduler/gardenerscheduler/lock.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -179,7 +178,7 @@ func downloadHostKubeconfig(ctx context.Context, logger logr.Logger, k8sClient c
 	if err != nil {
 		return fmt.Errorf("cannot create folder %s for kubeconfig: %s", filepath.Dir(kubeconfigPath), err.Error())
 	}
-	err = ioutil.WriteFile(kubeconfigPath, secret.Data["kubeconfig"], os.ModePerm)
+	err = os.WriteFile(kubeconfigPath, secret.Data["kubeconfig"], os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("cannot write kubeconfig to %s: %s", kubeconfigPath, err.Error())
 	}
@@ -207,7 +206,7 @@ func writeHostInformationToFile(log logr.Logger, shoot *gardencorev1beta1.Shoot)
 	if err != nil {
 		return fmt.Errorf("cannot create folder %s for host config: %s", filepath.Dir(hostConfigPath), err.Error())
 	}
-	err = ioutil.WriteFile(hostConfigPath, data, os.ModePerm)
+	err = os.WriteFile(hostConfigPath, data, os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("cannot write host config to %s: %s", hostConfigPath, err.Error())
 	}

--- a/pkg/hostscheduler/gkescheduler/helper.go
+++ b/pkg/hostscheduler/gkescheduler/helper.go
@@ -18,7 +18,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -133,7 +132,7 @@ func writeHostInformationToFile(hostName string) error {
 	if err != nil {
 		return fmt.Errorf("cannot create folder %s for host config: %s", filepath.Dir(hostConfigPath), err.Error())
 	}
-	err = ioutil.WriteFile(hostConfigPath, data, os.ModePerm)
+	err = os.WriteFile(hostConfigPath, data, os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("cannot write host config to %s: %s", hostConfigPath, err.Error())
 	}
@@ -146,7 +145,7 @@ func readHostInformationFromFile() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	dat, err := ioutil.ReadFile(hostConfigPath)
+	dat, err := os.ReadFile(hostConfigPath)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/hostscheduler/helper.go
+++ b/pkg/hostscheduler/helper.go
@@ -16,7 +16,6 @@ package hostscheduler
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -45,7 +44,7 @@ func WriteHostKubeconfig(log logr.Logger, restConfig *rest.Config) error {
 	if err != nil {
 		return fmt.Errorf("cannot create folder %s for kubeconfig: %s", filepath.Dir(kubeconfigPath), err.Error())
 	}
-	err = ioutil.WriteFile(kubeconfigPath, kubeconfig, os.ModePerm)
+	err = os.WriteFile(kubeconfigPath, kubeconfig, os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("cannot write kubeconfig to %s: %s", kubeconfigPath, err.Error())
 	}

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -350,7 +350,7 @@ func schema_pkg_apis_config_v1beta1_DashboardAuthentication(ref common.Reference
 					},
 					"githubConfig": {
 						SchemaProps: spec.SchemaProps{
-							Description: "GitHub holds the github provider specific configuration",
+							Description: "GitHub holds the GitHub provider specific configuration",
 							Ref:         ref("github.com/gardener/test-infra/pkg/apis/config/v1beta1.GitHubAuthentication"),
 						},
 					},
@@ -429,13 +429,21 @@ func schema_pkg_apis_config_v1beta1_GitHubAuthentication(ref common.ReferenceCal
 				Properties: map[string]spec.Schema{
 					"oAuth": {
 						SchemaProps: spec.SchemaProps{
-							Description: "OAuth Github configuration that is used to protect parts of the dashboard",
+							Description: "OAuth GitHub configuration that is used to protect parts of the dashboard",
 							Ref:         ref("github.com/gardener/test-infra/pkg/apis/config/v1beta1.OAuth"),
 						},
 					},
 					"organization": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Organization is the GitHub organization to restrict access to the bot",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"hostname": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Hostname points to the GitHub instance used for the authentication flow",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",

--- a/pkg/shoot-telemetry/controller/controller.go
+++ b/pkg/shoot-telemetry/controller/controller.go
@@ -16,7 +16,6 @@ package controller
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"sync"
@@ -80,7 +79,7 @@ func StartController(config *config.Config, signalCh chan os.Signal) error {
 	// Setup the necessary informer factories to initialize the required informers.
 	if config.KubeConfigPath != "" {
 		// Read the kubeconfig from disk.
-		kubeconfigRaw, err := ioutil.ReadFile(config.KubeConfigPath)
+		kubeconfigRaw, err := os.ReadFile(config.KubeConfigPath)
 		if err != nil {
 			return err
 		}

--- a/pkg/testmachinery/collector/collector.go
+++ b/pkg/testmachinery/collector/collector.go
@@ -15,7 +15,6 @@
 package collector
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/go-logr/logr"
@@ -94,7 +93,7 @@ func (c *collector) Collect(tr *tmv1beta1.Testrun, metadata *metadata.Metadata) 
 	}
 
 	// generate temporary result directory for downloaded artifacts
-	tmpDir, err := ioutil.TempDir("", "collector")
+	tmpDir, err := os.MkdirTemp("", "collector")
 	if err != nil {
 		return errors.Wrapf(err, "unable to create cache directory for results")
 	}

--- a/pkg/testmachinery/collector/collector_test.go
+++ b/pkg/testmachinery/collector/collector_test.go
@@ -17,7 +17,6 @@ package collector
 import (
 	"bufio"
 	"context"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -53,7 +52,7 @@ var _ = Describe("collector summary", func() {
 
 	BeforeEach(func() {
 		var err error
-		tmpDir, err = ioutil.TempDir("", "test")
+		tmpDir, err = os.MkdirTemp("", "test")
 		Expect(err).ToNot(HaveOccurred())
 		esCtrl = gomock.NewController(GinkgoT())
 		s3Ctrl = gomock.NewController(GinkgoT())
@@ -85,7 +84,7 @@ var _ = Describe("collector summary", func() {
 		err = c.collectSummaryAndExports(tmpDir, tr, &metadata.Metadata{Testrun: metadata.TestrunMetadata{ID: tr.Name}})
 		Expect(err).ToNot(HaveOccurred())
 
-		files, err := ioutil.ReadDir(tmpDir)
+		files, err := os.ReadDir(tmpDir)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(len(files)).To(Equal(1), "Expected 1 file output")
 
@@ -126,7 +125,7 @@ var _ = Describe("collector summary", func() {
 		err = c.collectSummaryAndExports(tmpDir, tr, &metadata.Metadata{Testrun: metadata.TestrunMetadata{ID: tr.Name}})
 		Expect(err).ToNot(HaveOccurred())
 
-		files, err := ioutil.ReadDir(tmpDir)
+		files, err := os.ReadDir(tmpDir)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(len(files)).To(Equal(1), "Expected 1 file output")
 

--- a/pkg/testmachinery/collector/elasticsearch.go
+++ b/pkg/testmachinery/collector/elasticsearch.go
@@ -16,7 +16,7 @@ package collector
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	tmv1beta1 "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
@@ -34,7 +34,7 @@ func (c *collector) ingestIntoElasticsearch(path string, tr *tmv1beta1.Testrun) 
 		return nil
 	}
 
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		return fmt.Errorf("cannot read directory '%s'd: %s", path, err.Error())
 	}

--- a/pkg/testmachinery/collector/exports.go
+++ b/pkg/testmachinery/collector/exports.go
@@ -19,7 +19,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 
 	argov1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
@@ -107,7 +106,7 @@ func getFilesFromTar(r io.Reader) ([][]byte, error) {
 		}
 
 		if header.Typeflag == tar.TypeReg && header.Size > 0 {
-			file, err := ioutil.ReadAll(tarReader)
+			file, err := io.ReadAll(tarReader)
 			if err != nil {
 				return nil, fmt.Errorf("cannot read from file %s in tar %s", header.Name, err.Error())
 			}

--- a/pkg/testmachinery/collector/exports_test.go
+++ b/pkg/testmachinery/collector/exports_test.go
@@ -17,7 +17,6 @@ package collector
 import (
 	"bufio"
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -48,7 +47,7 @@ var _ = Describe("collector summary", func() {
 
 	BeforeEach(func() {
 		var err error
-		tmpDir, err = ioutil.TempDir("", "test")
+		tmpDir, err = os.MkdirTemp("", "test")
 		Expect(err).ToNot(HaveOccurred())
 		esCtrl = gomock.NewController(GinkgoT())
 		s3Ctrl = gomock.NewController(GinkgoT())
@@ -84,7 +83,7 @@ var _ = Describe("collector summary", func() {
 		err = c.collectSummaryAndExports(tmpDir, tr, &metadata.Metadata{Testrun: metadata.TestrunMetadata{ID: tr.Name}})
 		Expect(err).ToNot(HaveOccurred())
 
-		files, err := ioutil.ReadDir(tmpDir)
+		files, err := os.ReadDir(tmpDir)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(len(files)).To(Equal(1), "Expected 1 file output")
 

--- a/pkg/testmachinery/collector/helper.go
+++ b/pkg/testmachinery/collector/helper.go
@@ -16,7 +16,6 @@ package collector
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -34,7 +33,7 @@ func writeBulks(path string, bufs [][]byte) error {
 	}
 	for _, buf := range bufs {
 		file := filepath.Join(path, fmt.Sprintf("res-%s", util.RandomString(5)))
-		if err := ioutil.WriteFile(file, buf, 0644); err != nil {
+		if err := os.WriteFile(file, buf, 0644); err != nil {
 			return err
 		}
 	}

--- a/pkg/testmachinery/controller/configwatcher/configwatcher.go
+++ b/pkg/testmachinery/controller/configwatcher/configwatcher.go
@@ -16,7 +16,7 @@ package configwatcher
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"sync"
 
 	"github.com/fsnotify/fsnotify"
@@ -147,7 +147,7 @@ func (cw *ConfigWatcher) GetConfiguration() *config.Configuration {
 
 // ReadConfiguration reads the configuration from the file system
 func (cw *ConfigWatcher) ReadConfiguration() error {
-	file, err := ioutil.ReadFile(cw.configpath)
+	file, err := os.ReadFile(cw.configpath)
 	if err != nil {
 		return err
 	}

--- a/pkg/testmachinery/locations/location/locallocation.go
+++ b/pkg/testmachinery/locations/location/locallocation.go
@@ -18,7 +18,7 @@ import (
 	"encoding/base32"
 	"fmt"
 	"hash/fnv"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -93,14 +93,14 @@ func (l *LocalLocation) Type() tmv1beta1.LocationType {
 
 func (l *LocalLocation) readTestDefs() ([]*testdefinition.TestDefinition, error) {
 	definitions := []*testdefinition.TestDefinition{}
-	files, err := ioutil.ReadDir(l.testdefPath)
+	files, err := os.ReadDir(l.testdefPath)
 	if err != nil {
 		return nil, err
 	}
 
 	for _, file := range files {
 		if !file.IsDir() {
-			data, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", l.testdefPath, file.Name()))
+			data, err := os.ReadFile(fmt.Sprintf("%s/%s", l.testdefPath, file.Name()))
 			if err != nil {
 				l.log.Info(fmt.Sprintf("unable to read file from %s: %s", l.testdefPath, err.Error()), "filename", file.Name())
 				continue

--- a/pkg/testmachinery/testmachinery.go
+++ b/pkg/testmachinery/testmachinery.go
@@ -16,7 +16,6 @@ package testmachinery
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -155,7 +154,7 @@ func readSecretsFromFile(path string) ([]GitHubInstanceConfig, error) {
 	if _, err := os.Stat(path); err != nil {
 		return nil, errors.Wrapf(err, "file %s does not exist", path)
 	}
-	rawSecrets, err := ioutil.ReadFile(path)
+	rawSecrets, err := os.ReadFile(path)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to read file from %s", path)
 	}

--- a/pkg/testmachinery/util.go
+++ b/pkg/testmachinery/util.go
@@ -1,7 +1,6 @@
 package testmachinery
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/pkg/errors"
@@ -17,7 +16,7 @@ func ParseTestrunFromFile(filePath string) (*v1beta1.Testrun, error) {
 	if _, err := os.Stat(filePath); os.IsNotExist(err) {
 		return nil, err
 	}
-	data, err := ioutil.ReadFile(filePath)
+	data, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/testrunner/componentdescriptor/componentdescriptor.go
+++ b/pkg/testrunner/componentdescriptor/componentdescriptor.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,6 @@ package componentdescriptor
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -92,7 +91,7 @@ func GetComponentsFromFile(ctx context.Context, log logr.Logger, ociClient ocicl
 	if file == "" {
 		return make(ComponentList, 0), nil
 	}
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		return nil, fmt.Errorf("cannot read component descriptor file %s: %s", file, err.Error())
 	}
@@ -127,11 +126,12 @@ func GetComponentsFromLocations(tr *tmv1beta1.Testrun) (ComponentList, error) {
 
 // JSON returns the json output for a list of components
 // The list is converted into the format:
-// {
-//	"component_name": {
-//	 	"version": "0.0.0"
+//
+//	{
+//		"component_name": {
+//		 	"version": "0.0.0"
+//		}
 //	}
-// }
 func (c ComponentList) JSON() map[string]ComponentJSON {
 	components := make(map[string]ComponentJSON)
 	for _, component := range c {

--- a/pkg/testrunner/componentdescriptor/componentdescriptor_test.go
+++ b/pkg/testrunner/componentdescriptor/componentdescriptor_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,6 @@ package componentdescriptor
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -53,7 +52,7 @@ var _ = Describe("componentdescriptor test", func() {
 	})
 
 	It("Should parse a component descriptor and return 2 dependencies", func() {
-		input, err := ioutil.ReadFile("./testdata/component_descriptor_1")
+		input, err := os.ReadFile("./testdata/component_descriptor_1")
 		Expect(err).ToNot(HaveOccurred(), "Cannot read json file from ./testdata/component_descriptor_1")
 		Expect(os.Setenv(constants.ComponentRepositoryCacheDirEnvVar, "./testdata")).To(Succeed())
 		defer os.Unsetenv(constants.ComponentRepositoryCacheDirEnvVar)
@@ -65,7 +64,7 @@ var _ = Describe("componentdescriptor test", func() {
 	})
 
 	It("Should parse a component descriptor that was not already in the local cache", func() {
-		input, err := ioutil.ReadFile("./testdata/component_descriptor_2")
+		input, err := os.ReadFile("./testdata/component_descriptor_2")
 		Expect(err).ToNot(HaveOccurred(), "Cannot read json file from ./testdata/component_descriptor_2")
 		Expect(os.Setenv(constants.ComponentRepositoryCacheDirEnvVar, "./testdata")).To(Succeed())
 		defer os.Unsetenv(constants.ComponentRepositoryCacheDirEnvVar)
@@ -80,7 +79,7 @@ var _ = Describe("componentdescriptor test", func() {
 	})
 
 	It("Should parse a component descriptor and ignore duplicates", func() {
-		input, err := ioutil.ReadFile("./testdata/registry.example/example.com/repo1-0.17.0")
+		input, err := os.ReadFile("./testdata/registry.example/example.com/repo1-0.17.0")
 		Expect(err).ToNot(HaveOccurred(), "Cannot read json file from ./testdata/component_descriptor_2")
 
 		result := []*Component{

--- a/pkg/testrunner/componentdescriptor/types.go
+++ b/pkg/testrunner/componentdescriptor/types.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/testrunner/result/notification.go
+++ b/pkg/testrunner/result/notification.go
@@ -16,7 +16,7 @@ package result
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	argov1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	log "github.com/sirupsen/logrus"
@@ -37,7 +37,7 @@ func GenerateNotificationConfigForAlerting(tr []*tmv1beta1.Testrun, concourseOnE
 	}
 
 	notifyConfigFilePath := fmt.Sprintf("%s/notify.cfg", concourseOnErrorDir)
-	if err := ioutil.WriteFile(notifyConfigFilePath, notifyConfig, 0777); err != nil {
+	if err := os.WriteFile(notifyConfigFilePath, notifyConfig, 0777); err != nil {
 		log.Warnf("Cannot write file email notification config to %s: %s", notifyConfigFilePath, err.Error())
 		return
 	}

--- a/pkg/testrunner/result/status-uploader.go
+++ b/pkg/testrunner/result/status-uploader.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -59,7 +58,7 @@ func UploadStatusToGithub(log logr.Logger, runs testrunner.RunList, components [
 		if err != nil {
 			return err
 		}
-		if testrunsToUpload == nil || len(testrunsToUpload) == 0 {
+		if len(testrunsToUpload) == 0 {
 			log.Info("no testrun updates, therefore not assets to upload")
 			continue
 		}
@@ -213,7 +212,7 @@ func writeOverviewToFile(assetOverview AssetOverview, overviewFilepath string) e
 	if err != nil {
 		return errors.Wrapf(err, "failed to marshal %s", overviewFilepath)
 	}
-	if err := ioutil.WriteFile(overviewFilepath, overviewJSONBytes, 0644); err != nil {
+	if err := os.WriteFile(overviewFilepath, overviewJSONBytes, 0644); err != nil {
 		return errors.Wrapf(err, "failed to write file %s", overviewFilepath)
 	}
 	return nil
@@ -228,7 +227,7 @@ func storeRunsStatusAsFiles(log logr.Logger, runs testrunner.RunList, prefix, de
 		output.RenderStatusTable(&tableString, tr.Status.Steps)
 		statusOutput := fmt.Sprintf("Testrun: %s\n\n%s\n%s", tr.Name, tableString.String(), util.PrettyPrintStruct(tr.Status))
 		assetFilepath := filepath.Join(dest, generateTestrunAssetName(*run, prefix))
-		if err := ioutil.WriteFile(assetFilepath, []byte(statusOutput), 0644); err != nil {
+		if err := os.WriteFile(assetFilepath, []byte(statusOutput), 0644); err != nil {
 			return errors.Wrapf(err, "failed to write file %s", assetFilepath)
 		}
 	}
@@ -297,7 +296,7 @@ func removeFailedItems(assetOverview *AssetOverview) (failedOverviewItems []stri
 
 func unmarshalOverview(overviewFilepath string) (AssetOverview, error) {
 	var assetOverview AssetOverview
-	assetOverviewBytes, err := ioutil.ReadFile(overviewFilepath)
+	assetOverviewBytes, err := os.ReadFile(overviewFilepath)
 	if err != nil {
 		return AssetOverview{}, errors.Wrapf(err, "failed to read file %s", overviewFilepath)
 	}

--- a/pkg/testrunner/template/helper.go
+++ b/pkg/testrunner/template/helper.go
@@ -17,7 +17,7 @@ package template
 import (
 	"encoding/base64"
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 
@@ -52,7 +52,7 @@ func readFileValues(files []string) (map[string]interface{}, error) {
 	values := make(map[string]interface{})
 	for _, file := range files {
 		var newValues map[string]interface{}
-		data, err := ioutil.ReadFile(file)
+		data, err := os.ReadFile(file)
 		if err != nil {
 			return nil, errors.Wrapf(err, "unable to read file %s", file)
 		}

--- a/pkg/testrunner/template/template.go
+++ b/pkg/testrunner/template/template.go
@@ -17,7 +17,7 @@ package template
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -70,7 +70,7 @@ func getInternalParametersFunc(ctx context.Context, log logr.Logger, parameters 
 	}
 	var gardenerKubeconfig []byte
 	if len(parameters.GardenKubeconfigPath) != 0 {
-		gardenerKubeconfig, err = ioutil.ReadFile(parameters.GardenKubeconfigPath)
+		gardenerKubeconfig, err = os.ReadFile(parameters.GardenKubeconfigPath)
 		if err != nil {
 			return nil, errors.Wrapf(err, "cannot read gardener kubeconfig %s", parameters.GardenKubeconfigPath)
 		}

--- a/pkg/tm-bot/options.go
+++ b/pkg/tm-bot/options.go
@@ -62,7 +62,7 @@ func (o *options) setupDashboard(router *mux.Router, runs *tests.Runs) error {
 	case config.DummyAuthProvider:
 		authProvider = auth.NewDummyAuth()
 	case config.GitHubAuthProvider:
-		authProvider = auth.NewGitHubOAuth(o.log.WithName("authentication"),
+		authProvider = auth.NewGitHubOAuth(o.log.WithName("authentication"), authCfg.GitHub.Hostname,
 			authCfg.GitHub.Organization, authCfg.GitHub.OAuth.ClientID, authCfg.GitHub.OAuth.ClientSecret,
 			authCfg.GitHub.OAuth.RedirectURL, authCfg.CookieSecret)
 	default:

--- a/pkg/tm-bot/ui/auth/auth.go
+++ b/pkg/tm-bot/ui/auth/auth.go
@@ -69,8 +69,11 @@ type githubOAuth struct {
 	org string
 }
 
-func NewGitHubOAuth(log logr.Logger, org, clientID, clientSecret, redirectURL, cookieSecret string) *githubOAuth {
+func NewGitHubOAuth(log logr.Logger, githubHostname, org, clientID, clientSecret, redirectURL, cookieSecret string) *githubOAuth {
 	gob.Register(AuthContext{})
+	authURL := "https://" + githubHostname + "/login/oauth/authorize"
+	tokenURL := "https://" + githubHostname + "/login/oauth/access_token"
+
 	return &githubOAuth{
 		log:   log,
 		org:   org,
@@ -79,8 +82,8 @@ func NewGitHubOAuth(log logr.Logger, org, clientID, clientSecret, redirectURL, c
 			ClientID:     clientID,
 			ClientSecret: clientSecret,
 			Endpoint: oauth2.Endpoint{
-				AuthURL:  "https://github.com/login/oauth/authorize",
-				TokenURL: "https://github.com/login/oauth/access_token",
+				AuthURL:  authURL,
+				TokenURL: tokenURL,
 			},
 			RedirectURL: redirectURL,
 			Scopes:      []string{"read:org"},

--- a/pkg/tm-bot/ui/auth/auth.go
+++ b/pkg/tm-bot/ui/auth/auth.go
@@ -247,7 +247,8 @@ func (a *githubOAuth) Logout(w http.ResponseWriter, r *http.Request) {
 // getGHClient returns a GitHub client or GitHub enterprise client based on the hostname of the oauth config
 func (a *githubOAuth) getGHClient(client *http.Client) (*github.Client, error) {
 	if a.hostname != "github.com" {
-		return github.NewEnterpriseClient(a.hostname, a.hostname, client)
+		githubUrl := "https://" + a.hostname
+		return github.NewEnterpriseClient(githubUrl, githubUrl, client)
 	}
 	return github.NewClient(client), nil
 }

--- a/pkg/util/elasticsearch/bulk/es_bulk_suite_test.go
+++ b/pkg/util/elasticsearch/bulk/es_bulk_suite_test.go
@@ -19,7 +19,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 
@@ -43,10 +43,10 @@ var _ = Describe("elasticsearch test", func() {
 
 	Context("Parse default json format", func() {
 		It("should parse default json and add testmachinery index", func() {
-			input, err := ioutil.ReadFile("./testdata/json")
+			input, err := os.ReadFile("./testdata/json")
 			Expect(err).ToNot(HaveOccurred(), "Cannot read json file from ./testdata/json")
 
-			output, err := ioutil.ReadFile("./testdata/json_output")
+			output, err := os.ReadFile("./testdata/json_output")
 			Expect(err).ToNot(HaveOccurred(), "Cannot read json file from ./testdata/json_output")
 
 			bulks := ParseExportedFiles(logr.Discard(), "TestDef", tmMeta, input)
@@ -61,10 +61,10 @@ var _ = Describe("elasticsearch test", func() {
 
 	Context("Parse bulk format", func() {
 		It("should parse bulk with index and not add an testmachinery index", func() {
-			input, err := ioutil.ReadFile("./testdata/bulk_with_meta")
+			input, err := os.ReadFile("./testdata/bulk_with_meta")
 			Expect(err).ToNot(HaveOccurred(), "Cannot read json file from ./testdata/bulk_with_meta")
 
-			output, err := ioutil.ReadFile("./testdata/bulk_with_meta_output")
+			output, err := os.ReadFile("./testdata/bulk_with_meta_output")
 			Expect(err).ToNot(HaveOccurred(), "Cannot read json file from ./testdata/bulk_with_meta_output")
 
 			bulks := ParseExportedFiles(logr.Discard(), "TestDef", tmMeta, input)
@@ -77,10 +77,10 @@ var _ = Describe("elasticsearch test", func() {
 		})
 
 		It("should parse bulk with index and add an testmachinery index", func() {
-			input, err := ioutil.ReadFile("./testdata/bulk_no_meta")
+			input, err := os.ReadFile("./testdata/bulk_no_meta")
 			Expect(err).ToNot(HaveOccurred(), "Cannot read json file from ./testdata/bulk_no_meta")
 
-			output, err := ioutil.ReadFile("./testdata/bulk_no_meta_output")
+			output, err := os.ReadFile("./testdata/bulk_no_meta_output")
 			Expect(err).ToNot(HaveOccurred(), "Cannot read json file from ./testdata/bulk_no_meta_output")
 
 			bulks := ParseExportedFiles(logr.Discard(), "TestDef", tmMeta, input)
@@ -93,7 +93,7 @@ var _ = Describe("elasticsearch test", func() {
 		})
 
 		It("should parse a large bulk file", func() {
-			input, err := ioutil.ReadFile("./testdata/large_bulk")
+			input, err := os.ReadFile("./testdata/large_bulk")
 			Expect(err).ToNot(HaveOccurred(), "Cannot read json file from ./testdata/bulk_with_meta")
 
 			bulks := ParseExportedFiles(logr.Discard(), "TestDef", tmMeta, input)

--- a/pkg/util/elasticsearch/elasticsearch.go
+++ b/pkg/util/elasticsearch/elasticsearch.go
@@ -19,9 +19,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
 
 	"golang.org/x/net/context"
@@ -95,11 +95,11 @@ func (c *client) RequestWithCtx(ctx context.Context, httpMethod, rawPath string,
 	}
 	defer res.Body.Close()
 	if res.StatusCode < 200 || res.StatusCode > 299 {
-		errorResponse, _ := ioutil.ReadAll(res.Body)
+		errorResponse, _ := io.ReadAll(res.Body)
 		return nil, errors.Errorf("request %s returned status code %d with body %s", esURL, res.StatusCode, errorResponse)
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to read response body")
 	}
@@ -140,7 +140,7 @@ func (c *client) Bulk(data []byte) error {
 }
 
 func (c *client) BulkFromFile(file string) error {
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/kubernetes/kubernetes.go
+++ b/pkg/util/kubernetes/kubernetes.go
@@ -6,7 +6,7 @@ package kubernetes
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -40,7 +40,7 @@ func NewClientFromSecretObject(secret *corev1.Secret, opts client.Options) (clie
 
 // NewClientFromFile creates a new Client struct from a kubconfig file.
 func NewClientFromFile(kubeconfigPath string, opts client.Options) (client.Client, error) {
-	data, err := ioutil.ReadFile(kubeconfigPath)
+	data, err := os.ReadFile(kubeconfigPath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/slack/slack.go
+++ b/pkg/util/slack/slack.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/go-logr/logr"
@@ -91,7 +91,7 @@ func (s *slack) PostRawMessage(message MessageRequest) error {
 		return errors.New("unable to send slack message")
 	}
 
-	rawBody, err := ioutil.ReadAll(resp.Body)
+	rawBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"net/http"
@@ -109,7 +108,7 @@ func DownloadFile(client *http.Client, url string) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("Cannot downdload file from %s: \n %v", url, err.Error())
 	}
@@ -289,7 +288,7 @@ func CreateKubeconfigFromInternal() ([]byte, error) {
 	}
 
 	rootCAFile := "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-	caCert, err := ioutil.ReadFile(rootCAFile)
+	caCert, err := os.ReadFile(rootCAFile)
 	if err != nil {
 		return nil, err
 	}

--- a/test/controller/testflow/testflow_kubeconfig_test.go
+++ b/test/controller/testflow/testflow_kubeconfig_test.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/gardener/test-infra/pkg/testmachinery"
@@ -44,7 +44,7 @@ var _ = Describe("Testflow execution tests", func() {
 			defer ctx.Done()
 
 			// get kubeconfigfile from testdata
-			file, err := ioutil.ReadFile("./testdata/kubeconfig")
+			file, err := os.ReadFile("./testdata/kubeconfig")
 			Expect(err).ToNot(HaveOccurred())
 
 			tr := resources.GetBasicTestrun(operation.TestNamespace(), operation.Commit())
@@ -78,7 +78,7 @@ var _ = Describe("Testflow execution tests", func() {
 			defer ctx.Done()
 
 			// get kubeconfigfile from testdata
-			file, err := ioutil.ReadFile("./testdata/kubeconfig")
+			file, err := os.ReadFile("./testdata/kubeconfig")
 			Expect(err).ToNot(HaveOccurred())
 
 			secret := &corev1.Secret{
@@ -136,7 +136,7 @@ var _ = Describe("Testflow execution tests", func() {
 			defer ctx.Done()
 
 			// get kubeconfigfile from testdata
-			file, err := ioutil.ReadFile("./testdata/kubeconfig")
+			file, err := os.ReadFile("./testdata/kubeconfig")
 			Expect(err).ToNot(HaveOccurred())
 
 			tr := resources.GetBasicTestrun(operation.TestNamespace(), operation.Commit())

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -21,7 +21,6 @@ import (
 	"github.com/gardener/test-infra/pkg/apis/config"
 	kutil "github.com/gardener/test-infra/pkg/util/kubernetes"
 
-	"io/ioutil"
 	"os"
 
 	corev1 "k8s.io/api/core/v1"
@@ -77,7 +76,7 @@ func (o *Operation) setTestMachineryConfig(ctx context.Context) error {
 	)
 
 	if len(o.testConfig.TMConfigPath) != 0 {
-		data, err = ioutil.ReadFile(o.testConfig.TMConfigPath)
+		data, err = os.ReadFile(o.testConfig.TMConfigPath)
 		if err != nil {
 			return err
 		}

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -28,8 +28,8 @@ import (
 
 	kutil "github.com/gardener/test-infra/pkg/util/kubernetes"
 
-	"io/ioutil"
 	"net/http"
+	"os"
 	"reflect"
 	"strings"
 	"time"
@@ -234,7 +234,7 @@ func HTTPGet(url string) (*http.Response, error) {
 
 // ReadJSONFile reads a file and deserializes the json into the given object
 func ReadJSONFile(path string, obj interface{}) error {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
@@ -243,7 +243,7 @@ func ReadJSONFile(path string, obj interface{}) error {
 
 // ReadYAMLFile reads a file and deserializes the yaml into the given object
 func ReadYAMLFile(path string, obj interface{}) error {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind technical-debt

**What this PR does / why we need it**:

Update all calls to deprecated `io/ioutil` package and replace them with corresponding functions from `os` / `io` package. See https://pkg.go.dev/io/ioutil@go1.17.13 for details.

Add a new, optional field to the github oauth configuration for the testmachinery bot. This will enable support for instances other than github.com. If not specified, it will default to github.com.

A bot config for another github instance would look like this:

```
apiVersion: config.testmachinery.gardener.cloud/v1beta1
kind: BotConfiguration
dashboard:
  authentication:
    cookieSecret: abc
    githubConfig:
      oAuth:
        clientId: abc
        clientSecret: abc
        redirectUrl: https://tm-bot.test/oauth/redirect
      organization: my-org
      hostname: some-github-instance.com
    provider: github
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @dguendisch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
testmachinery bot supports configuration of github hostname for oauth.
```
