### PR TITLE
Ensure "normal" testgrid jobs have no flakes

### DIFF
--- a/.test-defs/conformanceTestgrid.yaml
+++ b/.test-defs/conformanceTestgrid.yaml
@@ -55,7 +55,7 @@ spec:
     export E2E_EXPORT_PATH=$TM_EXPORT_PATH &&
     export E2E_KUBECONFIG_PATH=$TM_KUBECONFIG_PATH/shoot.config &&
     export GARDEN_KUBECONFIG_PATH=$TM_KUBECONFIG_PATH/gardener.config &&
-    go run -mod=vendor ./integration-tests/e2e --cleanUpAfterwards=true --flakeAttempts=5
+    go run -mod=vendor ./integration-tests/e2e --cleanUpAfterwards=true --flakeAttempts=1
   image: golang:1.17
   resources:
     requests:

--- a/integration-tests/e2e/config/config.go
+++ b/integration-tests/e2e/config/config.go
@@ -8,7 +8,6 @@ import (
 	"regexp"
 	"runtime"
 	"sort"
-	"strconv"
 	"strings"
 
 	flag "github.com/spf13/pflag"
@@ -175,8 +174,8 @@ func init() {
 	if _, err := os.Stat(DescriptionFilePath); err != nil {
 		log.Fatal(errors.Wrapf(err, "file %s does not exist: ", DescriptionFilePath))
 	}
-	if FlakeAttempts == 0 || FlakeAttempts == 2 {
-		FlakeAttempts, _ = strconv.Atoi(tiutil.Getenv("FLAKE_ATTEMPTS", "2"))
+	if FlakeAttempts == 0 {
+		log.Fatal("flakeAttempts of 0 zero doesn't make sense. Use >= 1 to have at least 1 execution.")
 	}
 	PublishResultsToTestgrid = tiutil.GetenvBool("PUBLISH_RESULTS_TO_TESTGRID", false)
 	IgnoreSkipList = tiutil.GetenvBool("IGNORE_SKIP_LIST", false)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
Ensures our serial execution of testgrid conformance jobs have no flakes. There's no point in executing them with flake tolerance while we don't tolerate flakes on cncf submission.

Changes a magic defaulting on the way where wrong startup flags were silently replaced with sane defaults to fail-fast instead.

/invite @hendrikKahl 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
