### PR TITLE
Ensure conformance test's compatibility with ginkgo v1

### DIFF
--- a/integration-tests/e2e/config/config.go
+++ b/integration-tests/e2e/config/config.go
@@ -71,7 +71,7 @@ var (
 
 const (
 	// points to a commit in https://github.com/kubernetes/test-infra/commits/master
-	TestInfraVersion = "590bc3fef25c06032c5cc53792c2a444a257d575"
+	TestInfraVersion = "0fdffe60e81f1a3e22d5c1ae86e9e2631c5eb96a"
 )
 
 var Debug bool

--- a/integration-tests/e2e/kubetest/kubetest_runner.go
+++ b/integration-tests/e2e/kubetest/kubetest_runner.go
@@ -119,7 +119,7 @@ func createKubetestArgs(ginkgoFocus string, parallel, dryRun bool, flakeAttempts
 func runKubetest(args KubetestArgs, logToStd bool) {
 	//  -clean-start
 	//    	If true, purge all namespaces except default and system before running tests. This serves to Cleanup test namespaces from failed/interrupted e2e runs in a long-lived cluster.
-	ginkgoArgs := fmt.Sprintf("--test_args=--ginkgo.flake-attempts=%o --ginkgo.dry-run=%t --minStartupPods=1 %s", args.FlakeAttempts, args.DryRun, args.GinkgoFocus)
+	ginkgoArgs := fmt.Sprintf("--test_args=--ginkgo.flakeAttempts=%o --ginkgo.dryRun=%t --minStartupPods=1 %s", args.FlakeAttempts, args.DryRun, args.GinkgoFocus)
 	cmd := exec.Command("kubetest", "--provider=skeleton", "--deployment=local", "--test", "--check-version-skew=false", args.GinkgoParallel, ginkgoArgs, fmt.Sprintf("--dump=%s", args.LogDir))
 	cmd.Dir = config.KubernetesPath
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind technical-debt

**What this PR does / why we need it**:
Ginkgo v1 is used by older k8s versions incl. v1.24. Only with v1.25 and later, k8s migrated everything to ginkgo v2. This leads to a situation, where we cannot run conformance tests with kubetest using ginkgo arguments that have been introduced with v2.

For now, I would opt to switch back to using deprecated ginkgo arguments. If those will be dropped in future while we still have to run conformance tests for k8s versions that come with ginkgo v1, we have determine the target cluster's version and set up the arguments accordingly.

Ref: https://github.com/kubernetes/kubernetes/commit/857458cfa5b0083bc55736aaccbcf1dc796ba320

Additionally, this PR contains an update to the latest version of `kubetest`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @dguendisch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
