### PR TITLE
Request and use a shoot/adminkubeconfig, if possible

### DIFF
--- a/integration-tests/e2e/kubetest/setup/kubeconfig.go
+++ b/integration-tests/e2e/kubetest/setup/kubeconfig.go
@@ -1,0 +1,76 @@
+// Copyright 2019 Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package setup
+
+import (
+	"context"
+	"os"
+
+	authenticationv1alpha1 "github.com/gardener/gardener/pkg/apis/authentication/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/core/clientset/versioned/typed/core/v1beta1"
+	"github.com/gardener/test-infra/integration-tests/e2e/config"
+	log "github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/utils/pointer"
+)
+
+// tokenExpiresAfterSeconds sets the token to expire after 24h. All tests running longer will be considered as failed.
+const tokenExpiresAfterSeconds int64 = 86400
+
+// setupKubeconfig requests an admin kubeconfig for a given shoot
+func setupKubeconfig() error {
+
+	// check, if a shoots/adminkubeconfig can be requested
+	// see https://gardener.cloud/docs/gardener/usage/shoot_access/#shootsadminkubeconfig-subresource for details
+	if config.GardenKubeconfigPath != "" && config.ProjectNamespace != "" && config.ShootName != "" {
+
+		adminKubeconfigRequest := &authenticationv1alpha1.AdminKubeconfigRequest{
+			Spec: authenticationv1alpha1.AdminKubeconfigRequestSpec{
+				ExpirationSeconds: pointer.Int64(tokenExpiresAfterSeconds),
+			},
+		}
+
+		gardenKubeconfigData, err := os.ReadFile(config.GardenKubeconfigPath)
+		if err != nil {
+			return err
+		}
+		gardenClientConfig, err := clientcmd.NewClientConfigFromBytes(gardenKubeconfigData)
+		if err != nil {
+			return err
+		}
+		restConfig, err := gardenClientConfig.ClientConfig()
+		if err != nil {
+			return err
+		}
+		gardenerRestClient, err := v1beta1.NewForConfig(restConfig)
+		if err != nil {
+			return err
+		}
+		adminKubeconfigRequest, err = gardenerRestClient.Shoots(config.ProjectNamespace).CreateAdminKubeconfigRequest(context.Background(), config.ShootName, adminKubeconfigRequest, metav1.CreateOptions{})
+		if err != nil {
+			return err
+		}
+
+		err = os.WriteFile(config.ShootKubeconfigPath, adminKubeconfigRequest.Status.Kubeconfig, 0755)
+		if err != nil {
+			return err
+		}
+
+		log.Info("shoot admin kubeconfig successfully obtained")
+	}
+
+	return nil
+}

--- a/integration-tests/e2e/kubetest/setup/setup.go
+++ b/integration-tests/e2e/kubetest/setup/setup.go
@@ -19,6 +19,10 @@ import (
 )
 
 func Setup() error {
+	if err := setupKubeconfig(); err != nil {
+		return err
+	}
+
 	cleanUpPreviousRuns()
 	if err := areTestUtilitiesReady(); err == nil {
 		log.Info("all test utilities were already ready")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind test

**What this PR does / why we need it**:
In case a gardener project namespace, shoot name and gardener kubeconfig are specified to the invocation of `integration-tests/e2e`, a `shoot/adminkubeconfig` will be requested. The reply will be stored unter "/tmp/shoot.config" and all environment variables are changed accordingly. The kubeconfig will expire after 24h hours. All conformance tests running longer would be considered a failure anyways.

Otherwise the existing contract prevails where a valid kubeconfig is supplied by the invoking entity.

**Which issue(s) this PR fixes**:
Fixes #435

**Special notes for your reviewer**:
/invite @dguendisch 
cc @ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Allow conformance testframework to request a short-lived shoot/adminkubeconfig
```
