### PR TITLE
Cleanup missed todo's 

### DIFF
--- a/charts/testmachinery/charts/argo/templates/rbac.yaml
+++ b/charts/testmachinery/charts/argo/templates/rbac.yaml
@@ -322,30 +322,19 @@ rules:
       - update
       - patch
       - delete
---- # TODO still needed?
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: argo-workflow-role
 rules:
-# pod get/watch is used to identify the container IDs of the current pod
-# pod patch is used to annotate the step's outputs back to controller (e.g. artifact location)
 - apiGroups:
-  - ""
+    - argoproj.io
   resources:
-  - pods
+    - workflowtaskresults
   verbs:
-  - get
-  - watch
-  - patch
-# logs get/watch are used to get the pods logs for script outputs, and for log archival
-- apiGroups:
-  - ""
-  resources:
-  - pods/log
-  verbs:
-  - get
-  - watch
+    - create
+    - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/hack/build-test-defs.sh
+++ b/hack/build-test-defs.sh
@@ -23,7 +23,7 @@ fi
 
 DOCKERFILE_DIR="$REPO_ROOT/tmp/build-defs-dockerfiles"
 mkdir -p $DOCKERFILE_DIR
-BASE_IMAGE="golang:1.19"
+BASE_IMAGE="golang:1.20"
 
 # build integration-tests/e2e
 cat << __EOF > $DOCKERFILE_DIR/e2e


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind cleanup

**What this PR does / why we need it**:
- Update the golang image used for testing, if the test definitions in this repo actually compile.
- adjust RBAC rule for the argo workflow executor. So far, it was still using the legacy approach of patching the pod. With v3.4.x however, the `workflowtaskresults` resource can be used for it ([ref](https://argoproj.github.io/argo-workflows/workflow-rbac/)).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @dguendisch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Use golang 1.20 for `build-test-defs.sh` and adjust argo wf executor role
```
