### PR TITLE
Switch PSPs off by default

### DIFF
--- a/charts/testmachinery/charts/logging/charts/loki/values.yaml
+++ b/charts/testmachinery/charts/logging/charts/loki/values.yaml
@@ -143,7 +143,7 @@ podManagementPolicy: OrderedReady
 
 rbac:
   create: true
-  pspEnabled: true
+  pspEnabled: false
 
 readinessProbe:
   httpGet:

--- a/charts/testmachinery/charts/logging/charts/promtail/values.yaml
+++ b/charts/testmachinery/charts/logging/charts/promtail/values.yaml
@@ -46,7 +46,7 @@ podAnnotations:
 
 rbac:
   create: true
-  pspEnabled: true
+  pspEnabled: false
 
 readinessProbe:
   failureThreshold: 5

--- a/charts/testmachinery/charts/logging/values.yaml
+++ b/charts/testmachinery/charts/logging/values.yaml
@@ -27,7 +27,7 @@ loki:
       memory: 8Gi
   terminationGracePeriodSeconds: 300
   rbac:
-    pspEnabled: true
+    pspEnabled: false
 
 promtail:
   nameOverride: promtail
@@ -47,7 +47,7 @@ promtail:
       value: testload
       effect: NoSchedule
   rbac:
-    pspEnabled: true
+    pspEnabled: false
   scrapeConfigs:
     - job_name: pods
       pipeline_stages:

--- a/charts/testmachinery/values.yaml
+++ b/charts/testmachinery/values.yaml
@@ -161,13 +161,13 @@ logging:
     loggingEnabled: true
   promtail:
     rbac:
-      pspEnabled: true
+      pspEnabled: false
     image:
       repository: grafana/promtail
       tag: 2.0.0
   loki:
     rbac:
-      pspEnabled: true
+      pspEnabled: false
     image:
       repository: grafana/loki
       tag: 2.0.0


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind task

**What this PR does / why we need it**:
K8s 1.24 is reaching it's EOL and Argo WF supports K8s v1.25. Hence, the default should be adapted to work with the latest supported K8s version.

https://argoproj.github.io/argo-workflows/releases/#kubernetes-compatibility-matrix

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @dguendisch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Switch PSPs off by default
```
