### PR TITLE
Add `vsphere` to the list of supported providers

### DIFF
--- a/cmd/cncf-conformance-pr-creator/create_pr_k8s_conformance.py
+++ b/cmd/cncf-conformance-pr-creator/create_pr_k8s_conformance.py
@@ -45,7 +45,7 @@ except KeyError:
     print("Error: Environment variable CONTACT_EMAIL_ADDRESS not set. This is required for opening any conformance PR.")
     sys.exit(1)
 
-provider_list = ['gce', 'aws', 'azure', 'openstack', 'alicloud']
+provider_list = ['gce', 'aws', 'azure', 'openstack', 'alicloud', 'vsphere']
 content_product_yaml = {}
 content_product_yaml['gardener'] = """vendor: SAP
 name: Gardener (https://github.com/gardener/gardener) shoot cluster deployed on {0}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind task

**What this PR does / why we need it**:
Now that we have the `vsphere` provider on the testgrid, we should also submit our test results for CNCF certification. This PR enhances the list of supported providers to include `vsphere`.  

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @dguendisch @briantopping 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
