### PR TITLE
Don't panic on unexpected git url scheme but error out

### DIFF
--- a/pkg/testmachinery/locations/location/gitlocation.go
+++ b/pkg/testmachinery/locations/location/gitlocation.go
@@ -24,6 +24,7 @@ import (
 	argov1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	"github.com/go-logr/logr"
 	"github.com/google/go-github/v54/github"
+	"github.com/pkg/errors"
 
 	tmv1beta1 "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
 	"github.com/gardener/test-infra/pkg/testmachinery"
@@ -53,7 +54,10 @@ func NewGitLocation(log logr.Logger, testDefLocation *tmv1beta1.TestLocation) (t
 		return nil, fmt.Errorf("unable to parse url %s", testDefLocation.Repo)
 	}
 	config := getGitConfig(log, repoURL)
-	repoOwner, repoName := util.ParseRepoURL(repoURL)
+	repoOwner, repoName, err := util.ParseRepoURL(repoURL)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to parse repo url %s", repoURL)
+	}
 
 	return &GitLocation{
 		Info:      testDefLocation,

--- a/pkg/testrunner/result/status-uploader.go
+++ b/pkg/testrunner/result/status-uploader.go
@@ -351,7 +351,10 @@ func getGithubArtifacts(componentName, githubUser, githubPassword string) (githu
 	if err != nil {
 		return nil, "", "", errors.Wrapf(err, "url parse failed for %s", urlRaw)
 	}
-	repoOwner, repoName = util.ParseRepoURL(repoURL)
+	repoOwner, repoName, err = util.ParseRepoURL(repoURL)
+	if err != nil {
+		return nil, "", "", errors.Wrapf(err, "repoURL parse failed for %s", repoURL)
+	}
 	githubClient, err = getGithubClient(componentName, githubUser, githubPassword)
 	if err != nil {
 		return nil, "", "", err

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -233,13 +233,19 @@ func ParseRepoURLFromString(repoURL string) (repoOwner, repoName string, err err
 		return "", "", err
 	}
 
-	repoOwner, repoName = ParseRepoURL(u)
+	repoOwner, repoName, err = ParseRepoURL(u)
+	if err != nil {
+		return "", "", err
+	}
 	return repoOwner, repoName, nil
 }
 
 // ParseRepoURL returns the repository owner and name of a github repo url
-func ParseRepoURL(url *url.URL) (repoOwner, repoName string) {
+func ParseRepoURL(url *url.URL) (repoOwner, repoName string, err error) {
 	repoNameComponents := strings.Split(url.Path, "/")
+	if len(repoNameComponents) < 3 {
+		return "", "", errors.Errorf("cannot parse url '%s' into owner/repo scheme", url.Path)
+	}
 	repoOwner = repoNameComponents[1]
 	repoName = strings.Replace(repoNameComponents[2], ".git", "", 1)
 	return

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -30,6 +30,12 @@ var _ = Describe("util test", func() {
 			Expect(repo).To(Equal("gardener-extensions"))
 			Expect(owner).To(Equal("gardener"))
 		})
+		It("urls without owner/repo scheme should not panic", func() {
+			ghUrl := "https://example.com/example"
+
+			_, _, err := ParseRepoURLFromString(ghUrl)
+			Expect(err).To(HaveOccurred())
+		})
 		It("domain should parse from grafana url", func() {
 			hostname := "grafana.ingress.tm.core.shoot.live.k8s-hana.ondemand.com"
 			domain, err := parseDomain(hostname)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind  bug

**What this PR does / why we need it**:
Not sure why exactly all these fields are parsed out from a presumable github.com URL but if it's in an unexpected format we should simply error out and thus skip a test location instead of panic'ing.

/invite @hendrikKahl 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Fix a panic on unexpected git location URLs
```
