### PR TITLE
Improve log line formatting

### DIFF
--- a/pkg/testrunner/result/status-uploader.go
+++ b/pkg/testrunner/result/status-uploader.go
@@ -421,7 +421,7 @@ func getRelease(githubClient *github.Client, repoOwner, repoName, componentVersi
 	if err != nil {
 		return nil, err
 	}
-	log.Info("continuing to search for a release in %s by name %s", repoName, releaseName)
+	log.Info(fmt.Sprintf("continuing to search for a release in %s by name %s", repoName, releaseName))
 
 	opt := &github.ListOptions{
 		PerPage: 50,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
Improve the log output when searching for GitHub releases to upload test results.

Old: `continuing to search for a release in %s by name %s	{"some-repo": "0.1.2"}`

New: `continuing to search for a release in some-repo by name 0.1.2`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @dguendisch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
