### PR TITLE
switch from GCR -> Artifact-Registry

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -1,7 +1,8 @@
 test-infra:
   base_definition:
     traits:
-      component_descriptor: ~
+      component_descriptor:
+        ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
       scheduling:
         suppress_parallel_execution: true
       version:
@@ -19,33 +20,28 @@ test-infra:
       traits:
         publish:
           dockerimages: &default_images
-              tm-base-image:
-                registry: 'gcr-readwrite'
-                image: eu.gcr.io/gardener-project/gardener/testmachinery/base-step
+              tm-base-image: &base_image
+                image: europe-docker.pkg.dev/gardener-project/snapshots/testmachinery/base-step
                 dockerfile: 'Dockerfile'
                 target: base-step
                 tag_as_latest: true
-              tm-controller:
-                registry: 'gcr-readwrite'
-                image: eu.gcr.io/gardener-project/gardener/testmachinery/testmachinery-controller
+              tm-controller: &controller_image
+                image: europe-docker.pkg.dev/gardener-project/snapshots/testmachinery/testmachinery-controller
                 dockerfile: 'Dockerfile'
                 target: tm-controller
                 tag_as_latest: true
-              tm-run:
-                registry: 'gcr-readwrite'
-                image: eu.gcr.io/gardener-project/gardener/testmachinery/testmachinery-run
+              tm-run: &run_image
+                image: europe-docker.pkg.dev/gardener-project/snapshots/testmachinery/testmachinery-run
                 dockerfile: 'Dockerfile'
                 target: tm-run
                 tag_as_latest: true
-              tm-bot:
-                registry: 'gcr-readwrite'
-                image: eu.gcr.io/gardener-project/gardener/testmachinery/bot
+              tm-bot: &bot_image
+                image: europe-docker.pkg.dev/gardener-project/snapshots/testmachinery/bot
                 dockerfile: 'Dockerfile'
                 target: tm-bot
                 tag_as_latest: true
-              tm-prepare-image:
-                registry: 'gcr-readwrite'
-                image: eu.gcr.io/gardener-project/gardener/testmachinery/prepare-step
+              tm-prepare-image: &prepare_image
+                image: europe-docker.pkg.dev/gardener-project/snapshots/testmachinery/prepare-step
                 dockerfile: 'Dockerfile'
                 target: tm-prepare
                 tag_as_latest: true
@@ -68,6 +64,8 @@ test-infra:
       traits:
         version:
           preprocess: 'finalize'
+        component_descriptor:
+          ocm_repository: europe-docker.pkg.dev/gardener-project/releases
         release:
           nextversion: 'bump_minor'
         slack:
@@ -81,6 +79,21 @@ test-infra:
         publish:
           dockerimages:
             <<: *default_images
+            tm-base-image:
+              <<: *base_image
+              image: europe-docker.pkg.dev/gardener-project/releases/testmachinery/base-step
+            tm-controller:
+              <<: *controller_image
+              image: europe-docker.pkg.dev/gardener-project/releases/testmachinery/testmachinery-controller
+            tm-run:
+              <<: *run_image
+              image: europe-docker.pkg.dev/gardener-project/releases/testmachinery/testmachinery-run
+            tm-bot:
+              <<: *bot_image
+              image: europe-docker.pkg.dev/gardener-project/releases/testmachinery/bot
+            tm-prepare-image:
+              <<: *prepare_image
+              image: europe-docker.pkg.dev/gardener-project/releases/testmachinery/prepare-step
       steps:
         <<: *default_steps
         publish-helm:
@@ -101,7 +114,7 @@ test-infra:
         publish:
           dockerimages:
             tm-golang-image:
-              image: eu.gcr.io/gardener-project/gardener/testmachinery/golang
+              image: europe-docker.pkg.dev/gardener-project/releases/testmachinery/golang
               dockerfile: 'Dockerfile'
               dir: 'hack/images/golang'
               tag_as_latest: true

--- a/.ci/publish-helm
+++ b/.ci/publish-helm
@@ -31,7 +31,7 @@ else
   export SOURCE_PATH="$(readlink -f "${SOURCE_PATH}")"
 fi
 
-cli.py config attribute --cfg-type container_registry --cfg-name ar-readwrite --key password > /tmp/serviceaccount.yaml
+cli.py config attribute --cfg-type container_registry --cfg-name ar-delivery-readwrite --key password > /tmp/serviceaccount.yaml
 
 helm registry login europe-docker.pkg.dev -u _json_key -p "$(cat /tmp/serviceaccount.yaml)"
 cd ${SOURCE_PATH}

--- a/.ci/publish-helm
+++ b/.ci/publish-helm
@@ -31,8 +31,8 @@ else
   export SOURCE_PATH="$(readlink -f "${SOURCE_PATH}")"
 fi
 
-cli.py config attribute --cfg-type container_registry --cfg-name gcr-readwrite --key password > /tmp/serviceaccount.yaml
+cli.py config attribute --cfg-type container_registry --cfg-name ar-readwrite --key password > /tmp/serviceaccount.yaml
 
-helm registry login eu.gcr.io -u _json_key -p "$(cat /tmp/serviceaccount.yaml)"
+helm registry login europe-docker.pkg.dev -u _json_key -p "$(cat /tmp/serviceaccount.yaml)"
 cd ${SOURCE_PATH}
 make publish-tm-chart

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 current_dir := $(shell dirname $(mkfile_path))
 current_sha := $(shell GIT_DIR=${current_dir}/.git git rev-parse @)
 
-REGISTRY            := eu.gcr.io/gardener-project/gardener/testmachinery
-HELM_REGISTRY       := eu.gcr.io/gardener-project/charts/gardener/testmachinery
+REGISTRY            := europe-docker.pkg.dev/gardener-project/releases/testmachinery
+HELM_REGISTRY       := europe-docker.pkg.dev/gardener-project/releases/charts/gardener/testmachinery
 
 TM_CONTROLLER_IMAGE := $(REGISTRY)/testmachinery-controller
 TM_CONTROLLER_CHART := testmachinery-controller

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -10,5 +10,5 @@ The following charts of the [`charts`](charts) directory were seeded based on a 
 
 ## Container Images
 
-* eu.gcr.io/sap-se-gcp-scp-k8s/gardener/testmachinery/testmachinery-controller
-* eu.gcr.io/sap-se-gcp-scp-k8s/gardener/testmachinery/prepare-step
+* europe-docker.pkg.dev/gardener/releases/testmachinery/testmachinery-controller
+* europe-docker.pkg.dev/gardener/releases/testmachinery/prepare-step

--- a/charts/testmachinery/values.yaml
+++ b/charts/testmachinery/values.yaml
@@ -23,7 +23,7 @@ global:
 
 controller:
   hostPath: ""
-  image: eu.gcr.io/gardener-project/gardener/testmachinery/testmachinery-controller
+  image: europe-docker.pkg.dev/gardener-project/releases/testmachinery/testmachinery-controller
   tag: latest
   pullPolicy: IfNotPresent
 

--- a/charts/tm-bot/values.yaml
+++ b/charts/tm-bot/values.yaml
@@ -17,7 +17,7 @@ ingress:
   labels: {}
 
 bot:
-  image: eu.gcr.io/gardener-project/gardener/testmachinery/bot
+  image: europe-docker.pkg.dev/gardener-project/releases/testmachinery/bot
   tag: latest
   pullPolicy: IfNotPresent
   imagePullSecretName: ""


### PR DESCRIPTION
GCR has been deprecated [0] in favour of Artifact-Registry.

Thus, change push-targets for OCI-Images:

- europe-docker.pkg.dev/gardener-project/snapshots for snapshots
- europe-docker.pkg.dev/gardener-project/releases for releases

[0]
https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind technical-debt

**What this PR does / why we need it**

switch from GCR -> Artifact-Registry

**Special notes for your reviewer**:

There are some obsolete references to old image-locations in GCR with outdated version-tags in some documentation-files. I did not include this in this pull-request, hoping this is okay-ish.


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Switch from GCR -> Artifact-Registry
```
