### PR TITLE
Filter for duplicate locations and take the greatest revision

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,8 +68,8 @@ RUN  \
     rsync \
     bc \
     linux-headers \
-  && pip install google-crc32c \
-  && pip install --upgrade pip \
+  && pip install --break-system-packages google-crc32c \
+  && pip install --break-system-packages --upgrade pip \
     "gardener-cicd-cli>=1.1437.0" \
     "gardener-cicd-libs>=1.1437.0" \
     awscli \

--- a/pkg/testrun_renderer/renderer_test.go
+++ b/pkg/testrun_renderer/renderer_test.go
@@ -1,0 +1,199 @@
+package testrun_renderer
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	tmv1beta1 "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
+	"github.com/gardener/test-infra/pkg/common"
+	"github.com/gardener/test-infra/pkg/testrunner/componentdescriptor"
+)
+
+const (
+	locationSetName = "default"
+)
+
+func TestLocationRenderer(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "AddLocationsToTestrun Test Suite")
+}
+
+var _ = Describe("AddLocationsToTestrun Test", func() {
+
+	var (
+		baseComponentDescriptor []*componentdescriptor.Component
+		baseTestrun             *tmv1beta1.Testrun
+		additionalLocations     []common.AdditionalLocation
+	)
+
+	BeforeEach(func() {
+		baseComponentDescriptor = []*componentdescriptor.Component{
+			{
+				Name:    "example.com/repo1",
+				Version: "v1.2.3",
+			},
+			{
+				Name:    "example.com/repo2",
+				Version: "v1.2.3",
+			},
+			{
+				Name:    "example.com/repo3",
+				Version: "v1.2.3",
+			},
+		}
+
+		baseTestrun = &tmv1beta1.Testrun{
+			Spec: tmv1beta1.TestrunSpec{},
+		}
+
+		additionalLocations = []common.AdditionalLocation{}
+
+	})
+
+	It("Should parse all components into a locationSet", func() {
+
+		err := AddLocationsToTestrun(baseTestrun, locationSetName, baseComponentDescriptor, true, additionalLocations)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(baseTestrun.Spec.LocationSets)).To(Equal(1))
+		Expect(len(baseTestrun.Spec.LocationSets[0].Locations)).To(Equal(3))
+	})
+
+	It("Should only have duplicates when additionalLocations are specified", func() {
+		additionalLocations = append(additionalLocations, common.AdditionalLocation{
+			Type:     "git",
+			Repo:     "https://example/com/add1",
+			Revision: "v1.2.3",
+		})
+		err := AddLocationsToTestrun(baseTestrun, locationSetName, baseComponentDescriptor, true, additionalLocations)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(baseTestrun.Spec.LocationSets)).To(Equal(1))
+		Expect(len(baseTestrun.Spec.LocationSets[0].Locations)).To(Equal(4))
+	})
+
+	Describe("A repository appears with two different version in the component descriptor", func() {
+		It("Should pick the initial version, if it is higher", func() {
+			repo := "example.com/repo1"
+			baseComponentDescriptor = append(baseComponentDescriptor, &componentdescriptor.Component{
+				Name:    repo,
+				Version: "v1.1.2",
+			})
+			err := AddLocationsToTestrun(baseTestrun, locationSetName, baseComponentDescriptor, true, additionalLocations)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(baseTestrun.Spec.LocationSets)).To(Equal(1))
+			Expect(len(baseTestrun.Spec.LocationSets[0].Locations)).To(Equal(3))
+			for _, location := range baseTestrun.Spec.LocationSets[0].Locations {
+				if location.Repo == repo {
+					Expect(location.Revision).To(Equal("v1.2.3"))
+				}
+			}
+		})
+
+		It("Should pick the incoming version, if it is higher", func() {
+			repo := "example.com/repo1"
+			version := "v1.3.3"
+			baseComponentDescriptor = append(baseComponentDescriptor, &componentdescriptor.Component{
+				Name:    repo,
+				Version: version,
+			})
+			err := AddLocationsToTestrun(baseTestrun, locationSetName, baseComponentDescriptor, true, additionalLocations)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(baseTestrun.Spec.LocationSets)).To(Equal(1))
+			Expect(len(baseTestrun.Spec.LocationSets[0].Locations)).To(Equal(3))
+			for _, location := range baseTestrun.Spec.LocationSets[0].Locations {
+				if location.Repo == repo {
+					Expect(location.Revision).To(Equal(version))
+				}
+			}
+		})
+
+		It("Should pick the master branch", func() {
+			repo1 := "example.com/repo1"
+			repo2 := "example.com/repo2"
+			version := "master"
+			baseComponentDescriptor[1].Version = version
+			baseComponentDescriptor = append(baseComponentDescriptor,
+				&componentdescriptor.Component{
+					Name:    repo1,
+					Version: version,
+				},
+				&componentdescriptor.Component{
+					Name:    repo2,
+					Version: "v1.2.3",
+				})
+			err := AddLocationsToTestrun(baseTestrun, locationSetName, baseComponentDescriptor, true, additionalLocations)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(baseTestrun.Spec.LocationSets)).To(Equal(1))
+			Expect(len(baseTestrun.Spec.LocationSets[0].Locations)).To(Equal(3))
+			for _, location := range baseTestrun.Spec.LocationSets[0].Locations {
+				if location.Repo == repo1 {
+					Expect(location.Revision).To(Equal(version))
+				}
+				if location.Repo == repo2 {
+					Expect(location.Revision).To(Equal(version))
+				}
+			}
+		})
+
+		It("Should pick the main branch", func() {
+			repo1 := "example.com/repo1"
+			repo2 := "example.com/repo2"
+			version := "main"
+			baseComponentDescriptor[1].Version = version
+			baseComponentDescriptor = append(baseComponentDescriptor,
+				&componentdescriptor.Component{
+					Name:    repo1,
+					Version: version,
+				},
+				&componentdescriptor.Component{
+					Name:    repo2,
+					Version: "v1.2.3",
+				})
+			err := AddLocationsToTestrun(baseTestrun, locationSetName, baseComponentDescriptor, true, additionalLocations)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(baseTestrun.Spec.LocationSets)).To(Equal(1))
+			Expect(len(baseTestrun.Spec.LocationSets[0].Locations)).To(Equal(3))
+			for _, location := range baseTestrun.Spec.LocationSets[0].Locations {
+				if location.Repo == repo1 {
+					Expect(location.Revision).To(Equal(version))
+				}
+				if location.Repo == repo2 {
+					Expect(location.Revision).To(Equal(version))
+				}
+			}
+		})
+		It("Should keep the initial version when semVer parsing fails", func() {
+			repo1 := "example.com/repo1"
+			repo4 := "example.com/repo4"
+			version := "abc"
+			baseComponentDescriptor = append(baseComponentDescriptor,
+				&componentdescriptor.Component{
+					Name:    repo1,
+					Version: version,
+				},
+				&componentdescriptor.Component{
+					Name:    repo4,
+					Version: version,
+				},
+				&componentdescriptor.Component{
+					Name:    repo4,
+					Version: "v1.2.3",
+				},
+			)
+			err := AddLocationsToTestrun(baseTestrun, locationSetName, baseComponentDescriptor, true, additionalLocations)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(baseTestrun.Spec.LocationSets)).To(Equal(1))
+			Expect(len(baseTestrun.Spec.LocationSets[0].Locations)).To(Equal(4))
+			for _, location := range baseTestrun.Spec.LocationSets[0].Locations {
+				if location.Repo == repo1 {
+					Expect(location.Revision).To(Equal("v1.2.3"))
+				}
+				if location.Repo == repo4 {
+					Expect(location.Revision).To(Equal(version))
+				}
+			}
+		})
+	})
+
+})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind task

**What this PR does / why we need it**:
Enhance the function that parses components and adds them as locations to the testruns in a way, that it avoids adding duplicates. When a duplicate is found, the greatest version will be chosen ("main" or "master" tops semVer). The overwrite mechanism with additionalLocations will continue to function.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @dguendisch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Filter for duplicate locations and take the greatest revision
```
