### PR TITLE
allow configuration of base/prepare images

### DIFF
--- a/charts/testmachinery/templates/_helper.tpl
+++ b/charts/testmachinery/templates/_helper.tpl
@@ -43,7 +43,12 @@ testmachinery:
   insecure: {{ .Values.testmachinery.insecure }}
   disableCollector: {{ .Values.testmachinery.disableCollector }}
   cleanWorkflowPods: {{ .Values.testmachinery.cleanWorkflowPods }}
-
+  {{- if .Values.testmachinery.baseImage }}
+  baseImage: {{ .Values.testmachinery.baseImage }}
+  {{- end }}
+  {{- if .Values.testmachinery.prepareImage }}
+  prepareImage: {{ .Values.testmachinery.prepareImage }}
+  {{- end }}
   {{- if .Values.testmachinery.locations }}
   locations:
 {{ toYaml .Values.testmachinery.locations | indent 4 }}

--- a/charts/testmachinery/values.yaml
+++ b/charts/testmachinery/values.yaml
@@ -59,6 +59,8 @@ testmachinery:
   insecure: false
   disableCollector: false
   cleanWorkflowPods: false
+#  prepareImage: ""
+#  baseImage: ""
 
   locations:
     excludeDomains: [ ]


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind task

**What this PR does / why we need it**:
So far, it was not possible to specify the `baseImage` and `prepareImage` used by the testmachinery controller. Instead, it used a hard-coded default value. This PR adds an optional configuration to the helm chart addressing to resolve this.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @dguendisch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
