### PR TITLE
Cleanup `AllowPrivilegedContainers` setting 

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -65,9 +65,6 @@ const (
 	// AnnotationZone is the annotation to specify the zone of the shoot the testrun is testing
 	AnnotationZone = "metadata.testmachinery.gardener.cloud/zone"
 
-	// AnnotationAllowPrivilegedContainers is the annotation describing whether and how created shoots will have allowPrivilegedContainers configured
-	AnnotationAllowPrivilegedContainers = "metadata.testmachinery.gardener.cloud/allow-privileged-containers"
-
 	// AnnotationShootAnnotations is the annotation describing which additional shoot annotations were set (as they could impact the shoot behaviour)
 	AnnotationShootAnnotations = "metadata.testmachinery.gardener.cloud/shoot-annotations"
 

--- a/pkg/common/types_shootflavor.go
+++ b/pkg/common/types_shootflavor.go
@@ -38,9 +38,6 @@ type Shoot struct {
 	// Kubernetes versions to test
 	KubernetesVersion gardencorev1beta1.ExpirableVersion
 
-	// AllowPrivilegedContainers defines whether privileged containers will be allowed in the given shoot or not
-	AllowPrivilegedContainers *bool
-
 	// AdditionalAnnotations holds annotations to be added to created shoots
 	AdditionalAnnotations map[string]string
 
@@ -62,10 +59,6 @@ type ShootFlavor struct {
 
 	// Kubernetes versions to test
 	KubernetesVersions ShootKubernetesVersionFlavor `json:"kubernetes"`
-
-	// AllowPrivilegedContainers defines whether privileged containers will be allowed in the given shoot or not
-	// +optional
-	AllowPrivilegedContainers *bool `json:"allowPrivilegedContainers"`
 
 	// AdditionalAnnotations allows to optionally define additional annotations for the created shoot resources
 	// +optional

--- a/pkg/shootflavors/extendedflavors.go
+++ b/pkg/shootflavors/extendedflavors.go
@@ -93,13 +93,12 @@ func NewExtended(k8sClient client.Client, rawFlavors []*common.ExtendedShootFlav
 				shoots = append(shoots, &ExtendedFlavorInstance{
 					shoot: &common.ExtendedShoot{
 						Shoot: common.Shoot{
-							Description:               rawFlavor.Description,
-							AdditionalAnnotations:     rawFlavor.AdditionalAnnotations,
-							AdditionalLocations:       rawFlavor.AdditionalLocations,
-							Provider:                  rawFlavor.Provider,
-							KubernetesVersion:         k8sVersion,
-							AllowPrivilegedContainers: rawFlavor.AllowPrivilegedContainers,
-							Workers:                   pools,
+							Description:           rawFlavor.Description,
+							AdditionalAnnotations: rawFlavor.AdditionalAnnotations,
+							AdditionalLocations:   rawFlavor.AdditionalLocations,
+							Provider:              rawFlavor.Provider,
+							KubernetesVersion:     k8sVersion,
+							Workers:               pools,
 						},
 						ExtendedShootConfiguration: common.ExtendedShootConfiguration{
 							Name:                  fmt.Sprintf("%s%s", shootPrefix, util.RandomString(3)),

--- a/pkg/shootflavors/extendedflavors_test.go
+++ b/pkg/shootflavors/extendedflavors_test.go
@@ -52,11 +52,11 @@ var _ = Describe("extended flavor test", func() {
 				MachineImages: []gardencorev1beta1.MachineImage{
 					{
 						Name:     "test-os",
-						Versions: MachineImageVersions(map[string][]string{"0.0.2": []string{"amd64"}, "0.0.1": []string{"amd64"}}),
+						Versions: MachineImageVersions(map[string][]string{"0.0.2": {"amd64"}, "0.0.1": {"amd64"}}),
 					},
 					{
 						Name:     "test-os-2",
-						Versions: MachineImageVersions(map[string][]string{"0.0.4": []string{"arm64"}, "0.0.3": []string{"arm64"}}),
+						Versions: MachineImageVersions(map[string][]string{"0.0.4": {"arm64"}, "0.0.3": {"arm64"}}),
 					},
 				},
 			},
@@ -78,10 +78,9 @@ var _ = Describe("extended flavor test", func() {
 		rawFlavors := []*common.ExtendedShootFlavor{{
 			ExtendedConfiguration: defaultExtendedCfg,
 			ShootFlavor: common.ShootFlavor{
-				AllowPrivilegedContainers: ptr.To(true),
-				AdditionalAnnotations:     map[string]string{"a": "b"},
-				AdditionalLocations:       []common.AdditionalLocation{{Type: "git", Repo: "https:// github.com/gardener/gardener", Revision: "master"}},
-				Provider:                  common.CloudProviderGCP,
+				AdditionalAnnotations: map[string]string{"a": "b"},
+				AdditionalLocations:   []common.AdditionalLocation{{Type: "git", Repo: "https:// github.com/gardener/gardener", Revision: "master"}},
+				Provider:              common.CloudProviderGCP,
 				KubernetesVersions: common.ShootKubernetesVersionFlavor{
 					Versions: &[]gardencorev1beta1.ExpirableVersion{
 						{
@@ -104,12 +103,11 @@ var _ = Describe("extended flavor test", func() {
 
 		shoot := flavors.GetShoots()[0]
 		Expect(shoot.Get().Shoot).To(Equal(common.Shoot{
-			Provider:                  common.CloudProviderGCP,
-			AllowPrivilegedContainers: ptr.To(true),
-			AdditionalAnnotations:     map[string]string{"a": "b"},
-			AdditionalLocations:       []common.AdditionalLocation{{Type: "git", Repo: "https:// github.com/gardener/gardener", Revision: "master"}},
-			KubernetesVersion:         gardencorev1beta1.ExpirableVersion{Version: "1.15"},
-			Workers:                   []gardencorev1beta1.Worker{{Name: "wp1", Machine: gardencorev1beta1.Machine{Architecture: ptr.To("amd64")}}},
+			Provider:              common.CloudProviderGCP,
+			AdditionalAnnotations: map[string]string{"a": "b"},
+			AdditionalLocations:   []common.AdditionalLocation{{Type: "git", Repo: "https:// github.com/gardener/gardener", Revision: "master"}},
+			KubernetesVersion:     gardencorev1beta1.ExpirableVersion{Version: "1.15"},
+			Workers:               []gardencorev1beta1.Worker{{Name: "wp1", Machine: gardencorev1beta1.Machine{Architecture: ptr.To("amd64")}}},
 		}))
 		Expect(shoot.Get().ExtendedConfiguration).To(Equal(defaultExtendedCfg))
 	})
@@ -118,10 +116,9 @@ var _ = Describe("extended flavor test", func() {
 		rawFlavors := []*common.ExtendedShootFlavor{{
 			ExtendedConfiguration: defaultExtendedCfg,
 			ShootFlavor: common.ShootFlavor{
-				AllowPrivilegedContainers: ptr.To(true),
-				AdditionalAnnotations:     map[string]string{"a": "b"},
-				AdditionalLocations:       []common.AdditionalLocation{{Type: "git", Repo: "https:// github.com/gardener/gardener", Revision: "master"}},
-				Provider:                  common.CloudProviderGCP,
+				AdditionalAnnotations: map[string]string{"a": "b"},
+				AdditionalLocations:   []common.AdditionalLocation{{Type: "git", Repo: "https:// github.com/gardener/gardener", Revision: "master"}},
+				Provider:              common.CloudProviderGCP,
 				KubernetesVersions: common.ShootKubernetesVersionFlavor{
 					Versions: &[]gardencorev1beta1.ExpirableVersion{
 						{
@@ -144,12 +141,11 @@ var _ = Describe("extended flavor test", func() {
 
 		shoot := flavors.GetShoots()[0]
 		Expect(shoot.Get().Shoot).To(Equal(common.Shoot{
-			Provider:                  common.CloudProviderGCP,
-			AllowPrivilegedContainers: ptr.To(true),
-			AdditionalAnnotations:     map[string]string{"a": "b"},
-			AdditionalLocations:       []common.AdditionalLocation{{Type: "git", Repo: "https:// github.com/gardener/gardener", Revision: "master"}},
-			KubernetesVersion:         gardencorev1beta1.ExpirableVersion{Version: "1.15"},
-			Workers:                   []gardencorev1beta1.Worker{{Name: "wp1", Machine: gardencorev1beta1.Machine{Architecture: ptr.To("arm64")}}},
+			Provider:              common.CloudProviderGCP,
+			AdditionalAnnotations: map[string]string{"a": "b"},
+			AdditionalLocations:   []common.AdditionalLocation{{Type: "git", Repo: "https:// github.com/gardener/gardener", Revision: "master"}},
+			KubernetesVersion:     gardencorev1beta1.ExpirableVersion{Version: "1.15"},
+			Workers:               []gardencorev1beta1.Worker{{Name: "wp1", Machine: gardencorev1beta1.Machine{Architecture: ptr.To("arm64")}}},
 		}))
 		Expect(shoot.Get().ExtendedConfiguration).To(Equal(defaultExtendedCfg))
 	})
@@ -158,10 +154,9 @@ var _ = Describe("extended flavor test", func() {
 		rawFlavors := []*common.ExtendedShootFlavor{{
 			ExtendedConfiguration: defaultExtendedCfg,
 			ShootFlavor: common.ShootFlavor{
-				AllowPrivilegedContainers: ptr.To(true),
-				AdditionalAnnotations:     map[string]string{"a": "b"},
-				AdditionalLocations:       []common.AdditionalLocation{{Type: "git", Repo: "https:// github.com/gardener/gardener", Revision: "master"}},
-				Provider:                  common.CloudProviderGCP,
+				AdditionalAnnotations: map[string]string{"a": "b"},
+				AdditionalLocations:   []common.AdditionalLocation{{Type: "git", Repo: "https:// github.com/gardener/gardener", Revision: "master"}},
+				Provider:              common.CloudProviderGCP,
 				KubernetesVersions: common.ShootKubernetesVersionFlavor{
 					Versions: &[]gardencorev1beta1.ExpirableVersion{
 						{
@@ -351,10 +346,9 @@ var _ = Describe("extended flavor test", func() {
 		rawFlavors := []*common.ExtendedShootFlavor{{
 			ExtendedConfiguration: defaultExtendedCfg,
 			ShootFlavor: common.ShootFlavor{
-				AllowPrivilegedContainers: ptr.To(true),
-				AdditionalAnnotations:     map[string]string{"a": "b"},
-				AdditionalLocations:       []common.AdditionalLocation{{Type: "git", Repo: "https:// github.com/gardener/gardener", Revision: "master"}},
-				Provider:                  common.CloudProviderGCP,
+				AdditionalAnnotations: map[string]string{"a": "b"},
+				AdditionalLocations:   []common.AdditionalLocation{{Type: "git", Repo: "https:// github.com/gardener/gardener", Revision: "master"}},
+				Provider:              common.CloudProviderGCP,
 				KubernetesVersions: common.ShootKubernetesVersionFlavor{
 					Versions: &[]gardencorev1beta1.ExpirableVersion{
 						{
@@ -377,12 +371,11 @@ var _ = Describe("extended flavor test", func() {
 
 		shoot := flavors.GetShoots()[0]
 		Expect(shoot.Get().Shoot).To(Equal(common.Shoot{
-			Provider:                  common.CloudProviderGCP,
-			AllowPrivilegedContainers: ptr.To(true),
-			AdditionalAnnotations:     map[string]string{"a": "b"},
-			AdditionalLocations:       []common.AdditionalLocation{{Type: "git", Repo: "https:// github.com/gardener/gardener", Revision: "master"}},
-			KubernetesVersion:         gardencorev1beta1.ExpirableVersion{Version: "1.15"},
-			Workers:                   []gardencorev1beta1.Worker{{Name: "wp1", Machine: gardencorev1beta1.Machine{Architecture: ptr.To("amd64")}}},
+			Provider:              common.CloudProviderGCP,
+			AdditionalAnnotations: map[string]string{"a": "b"},
+			AdditionalLocations:   []common.AdditionalLocation{{Type: "git", Repo: "https:// github.com/gardener/gardener", Revision: "master"}},
+			KubernetesVersion:     gardencorev1beta1.ExpirableVersion{Version: "1.15"},
+			Workers:               []gardencorev1beta1.Worker{{Name: "wp1", Machine: gardencorev1beta1.Machine{Architecture: ptr.To("amd64")}}},
 		}))
 		Expect(shoot.Get().ExtendedConfiguration).To(Equal(defaultExtendedCfg))
 	})

--- a/pkg/shootflavors/flavors.go
+++ b/pkg/shootflavors/flavors.go
@@ -107,22 +107,20 @@ func New(rawFlavors []*common.ShootFlavor) (*Flavors, error) {
 					}
 
 					shoots = append(shoots, &common.Shoot{
-						AdditionalAnnotations:     rawFlavor.AdditionalAnnotations,
-						AdditionalLocations:       rawFlavor.AdditionalLocations,
-						Provider:                  rawFlavor.Provider,
-						KubernetesVersion:         k8sVersion,
-						AllowPrivilegedContainers: rawFlavor.AllowPrivilegedContainers,
-						Workers:                   workers.WorkerPools,
+						AdditionalAnnotations: rawFlavor.AdditionalAnnotations,
+						AdditionalLocations:   rawFlavor.AdditionalLocations,
+						Provider:              rawFlavor.Provider,
+						KubernetesVersion:     k8sVersion,
+						Workers:               workers.WorkerPools,
 					})
 				}
 				continue
 			}
 			shoots = append(shoots, &common.Shoot{
-				AdditionalAnnotations:     rawFlavor.AdditionalAnnotations,
-				AdditionalLocations:       rawFlavor.AdditionalLocations,
-				Provider:                  rawFlavor.Provider,
-				KubernetesVersion:         k8sVersion,
-				AllowPrivilegedContainers: rawFlavor.AllowPrivilegedContainers,
+				AdditionalAnnotations: rawFlavor.AdditionalAnnotations,
+				AdditionalLocations:   rawFlavor.AdditionalLocations,
+				Provider:              rawFlavor.Provider,
+				KubernetesVersion:     k8sVersion,
 			})
 		}
 	}

--- a/pkg/shootflavors/flavors_test.go
+++ b/pkg/shootflavors/flavors_test.go
@@ -256,32 +256,6 @@ var _ = Describe("flavor test", func() {
 		Expect(err).To(HaveOccurred())
 	})
 
-	It("should return one shoot with disabled allowPrivilegeContainers", func() {
-		rawFlavors := []*common.ShootFlavor{
-			{
-				Provider:                  common.CloudProviderGCP,
-				AllowPrivilegedContainers: ptr.To(false),
-				KubernetesVersions: common.ShootKubernetesVersionFlavor{
-					Versions: &[]gardencorev1beta1.ExpirableVersion{
-						{
-							Version: "1.15",
-						},
-					},
-				},
-			},
-		}
-		flavors, err := New(rawFlavors)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(flavors.GetShoots()).To(HaveLen(1))
-		Expect(flavors.GetShoots()).To(ConsistOf(
-			&common.Shoot{
-				Provider:                  common.CloudProviderGCP,
-				AllowPrivilegedContainers: ptr.To(false),
-				KubernetesVersion:         gardencorev1beta1.ExpirableVersion{Version: "1.15"},
-			},
-		))
-	})
-
 	It("should return 2 gcp shoots with the specified 2 versions", func() {
 		rawFlavors := []*common.ShootFlavor{
 			{
@@ -639,7 +613,7 @@ var _ = Describe("flavor test", func() {
 			images := flavors.GetUsedMachineImages()
 			Expect(images).To(HaveKeyWithValue(common.CloudProviderGCP, []gardencorev1beta1.MachineImage{{
 				Name:     "coreos",
-				Versions: MachineImageVersions(map[string][]string{"0.0.1": []string{"amd64"}}),
+				Versions: MachineImageVersions(map[string][]string{"0.0.1": {"amd64"}}),
 			}}))
 		})
 
@@ -667,8 +641,8 @@ var _ = Describe("flavor test", func() {
 
 			images := flavors.GetUsedMachineImages()
 			Expect(images).To(HaveKeyWithValue(common.CloudProviderGCP, []gardencorev1beta1.MachineImage{
-				{Name: "coreos", Versions: MachineImageVersions(map[string][]string{"0.0.1": []string{"amd64"}})},
-				{Name: "jeos", Versions: MachineImageVersions(map[string][]string{"0.0.2": []string{"amd64"}})},
+				{Name: "coreos", Versions: MachineImageVersions(map[string][]string{"0.0.1": {"amd64"}})},
+				{Name: "jeos", Versions: MachineImageVersions(map[string][]string{"0.0.2": {"amd64"}})},
 			}))
 		})
 
@@ -702,8 +676,8 @@ var _ = Describe("flavor test", func() {
 
 			images := flavors.GetUsedMachineImages()
 			Expect(images).To(HaveKeyWithValue(common.CloudProviderGCP, []gardencorev1beta1.MachineImage{
-				{Name: "coreos", Versions: MachineImageVersions(map[string][]string{"0.0.1": []string{"amd64"}})},
-				{Name: "jeos", Versions: MachineImageVersions(map[string][]string{"0.0.2": []string{"amd64"}})},
+				{Name: "coreos", Versions: MachineImageVersions(map[string][]string{"0.0.1": {"amd64"}})},
+				{Name: "jeos", Versions: MachineImageVersions(map[string][]string{"0.0.2": {"amd64"}})},
 			}))
 		})
 	})

--- a/pkg/testmachinery/collector/precompute.go
+++ b/pkg/testmachinery/collector/precompute.go
@@ -59,9 +59,6 @@ func PreComputeTeststepFields(phase argov1.NodePhase, meta metadata.Metadata, cl
 	if meta.FlavorDescription != "" {
 		providerEnhanced += "_" + meta.FlavorDescription
 	}
-	if meta.AllowPrivilegedContainers != nil && !*meta.AllowPrivilegedContainers {
-		providerEnhanced += "(NoPrivCtrs)"
-	}
 	if meta.ContainerRuntime != "" {
 		providerEnhanced += fmt.Sprintf("{%s}", meta.ContainerRuntime)
 	}

--- a/pkg/testmachinery/metadata/metadata.go
+++ b/pkg/testmachinery/metadata/metadata.go
@@ -29,18 +29,12 @@ func (m *Metadata) CreateAnnotations() map[string]string {
 		common.AnnotationRetries:                strconv.Itoa(m.Retries),
 		common.AnnotationShootAnnotations:       util.MarshalMap(m.Annotations),
 	}
-	if m.AllowPrivilegedContainers != nil {
-		annotations[common.AnnotationAllowPrivilegedContainers] = strconv.FormatBool(*m.AllowPrivilegedContainers)
-	}
 	return annotations
 }
 
 // GetDimensionFromMetadata returns a string describing the dimension of the metadata
 func (m *Metadata) GetDimensionFromMetadata(sep string) string {
 	d := fmt.Sprintf("%s"+sep+"%s"+sep+"%s", m.CloudProvider, m.KubernetesVersion, m.OperatingSystem)
-	if m.AllowPrivilegedContainers != nil && !*m.AllowPrivilegedContainers {
-		d = fmt.Sprintf("%s"+sep+"%s", d, "NoPrivCtrs")
-	}
 	if m.FlavorDescription != "" {
 		d = fmt.Sprintf("%s"+sep+"%s", d, m.FlavorDescription)
 	}
@@ -79,11 +73,6 @@ func FromTestrun(tr *tmv1beta1.Testrun) *Metadata {
 			StartTime:      tr.Status.StartTime,
 			ExecutionGroup: tr.Labels[common.LabelTestrunExecutionGroup],
 		},
-	}
-	if a, ok := tr.Annotations[common.AnnotationAllowPrivilegedContainers]; ok {
-		if b, err := strconv.ParseBool(a); err == nil {
-			metadata.AllowPrivilegedContainers = &b
-		}
 	}
 	return metadata
 }

--- a/pkg/testmachinery/metadata/types.go
+++ b/pkg/testmachinery/metadata/types.go
@@ -26,12 +26,11 @@ type Metadata struct {
 	Region            string `json:"region,omitempty"`
 
 	// todo: schrodit - add support to better persist multiple worker pools with multiple oss, versions and zones
-	OperatingSystem           string            `json:"operating_system,omitempty"`
-	OperatingSystemVersion    string            `json:"operating_system_version,omitempty"`
-	ContainerRuntime          string            `json:"container_runtime,omitempty"`
-	Zone                      string            `json:"zone,omitempty"`
-	AllowPrivilegedContainers *bool             `json:"allow_privileged_containers,omitempty"`
-	ShootAnnotations          map[string]string `json:"shoot_annotations,omitempty"`
+	OperatingSystem        string            `json:"operating_system,omitempty"`
+	OperatingSystemVersion string            `json:"operating_system_version,omitempty"`
+	ContainerRuntime       string            `json:"container_runtime,omitempty"`
+	Zone                   string            `json:"zone,omitempty"`
+	ShootAnnotations       map[string]string `json:"shoot_annotations,omitempty"`
 
 	// ComponentDescriptor describes the current component_descriptor of the direct landscape-setup components.
 	// It is formatted as an array of components: { name: "my_component", version: "0.0.1" }

--- a/pkg/testrunner/list.go
+++ b/pkg/testrunner/list.go
@@ -186,9 +186,6 @@ func triggerRunEvent(notifyChannels []chan *Run, run *Run) {
 
 func getDimensionFromMetadata(meta *metadata.Metadata) string {
 	d := fmt.Sprintf("%s/%s/%s", meta.CloudProvider, meta.KubernetesVersion, meta.OperatingSystem)
-	if meta.AllowPrivilegedContainers != nil && !*meta.AllowPrivilegedContainers {
-		d = fmt.Sprintf("%s [%s]", d, "NoPrivCtrs")
-	}
 	if meta.FlavorDescription != "" {
 		d = fmt.Sprintf("%s\n(%s)", d, meta.FlavorDescription)
 	}

--- a/pkg/testrunner/result/summary-poster.go
+++ b/pkg/testrunner/result/summary-poster.go
@@ -135,9 +135,6 @@ func parseTestrunsToTableItems(runs testrunner.RunList) (tableItems util.TableIt
 			}
 
 			var additionalDimensionInfo string
-			if meta.AllowPrivilegedContainers != nil && !*meta.AllowPrivilegedContainers {
-				additionalDimensionInfo = "NoPrivCtrs"
-			}
 			item := &util.TableItem{
 				Meta:         util.ItemMeta{CloudProvider: meta.CloudProvider, TestrunID: meta.Testrun.ID, OperatingSystem: meta.OperatingSystem, KubernetesVersion: meta.KubernetesVersion, FlavorDescription: meta.FlavorDescription, AdditionalDimensionInfo: additionalDimensionInfo},
 				StatusSymbol: status,

--- a/pkg/testrunner/template/shoot_template_test.go
+++ b/pkg/testrunner/template/shoot_template_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/utils/ptr"
 
 	"github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
 	"github.com/gardener/test-infra/pkg/common"
@@ -41,12 +40,11 @@ var _ = Describe("shoot templates", func() {
 		shoots = []*shootflavors.ExtendedFlavorInstance{
 			shootflavors.NewExtendedFlavorInstance(&common.ExtendedShoot{
 				Shoot: common.Shoot{
-					Provider:                  common.CloudProviderGCP,
-					KubernetesVersion:         gardencorev1beta1.ExpirableVersion{Version: "1.15.2"},
-					Workers:                   []gardencorev1beta1.Worker{{Name: "wp1", Machine: gardencorev1beta1.Machine{Image: &gardencorev1beta1.ShootMachineImage{Name: "core-os"}}}},
-					AllowPrivilegedContainers: ptr.To(false),
-					AdditionalAnnotations:     map[string]string{"a": "b"},
-					AdditionalLocations:       []common.AdditionalLocation{{Type: "git", Repo: "https://github.com/gardener/gardener", Revision: "1.2.3"}},
+					Provider:              common.CloudProviderGCP,
+					KubernetesVersion:     gardencorev1beta1.ExpirableVersion{Version: "1.15.2"},
+					Workers:               []gardencorev1beta1.Worker{{Name: "wp1", Machine: gardencorev1beta1.Machine{Image: &gardencorev1beta1.ShootMachineImage{Name: "core-os"}}}},
+					AdditionalAnnotations: map[string]string{"a": "b"},
+					AdditionalLocations:   []common.AdditionalLocation{{Type: "git", Repo: "https://github.com/gardener/gardener", Revision: "1.2.3"}},
 				},
 				ExtendedShootConfiguration: common.ExtendedShootConfiguration{
 					Name:         "test-name",
@@ -88,7 +86,6 @@ var _ = Describe("shoot templates", func() {
 			Expect(tr.Annotations).To(HaveKeyWithValue("shoot.secretBinding", "test-sb"))
 			Expect(tr.Annotations).To(HaveKeyWithValue("shoot.region", "region-1"))
 			Expect(tr.Annotations).To(HaveKeyWithValue("shoot.zone", "region-1-1"))
-			Expect(tr.Annotations).To(HaveKeyWithValue("shoot.allowPrivilegedContainers", "false"))
 			Expect(tr.Annotations).To(HaveKeyWithValue("shoot.shootAnnotations", "a=b"))
 			Expect(tr.Annotations).To(HaveKeyWithValue("shoot.k8sVersion", "1.15.2"))
 			Expect(tr.Annotations).To(HaveKeyWithValue("shoot.k8sPrevPrePatchVersion", "1.15.2"))
@@ -120,7 +117,6 @@ var _ = Describe("shoot templates", func() {
 			Expect(meta.CloudProvider).To(Equal("gcp"))
 			Expect(meta.Region).To(Equal("region-1"))
 			Expect(meta.Zone).To(Equal("region-1-1"))
-			Expect(meta.AllowPrivilegedContainers).To(Equal(ptr.To(false)))
 			Expect(meta.Annotations).To(Equal(map[string]string{"a": "b"}))
 			Expect(meta.OperatingSystem).To(Equal("core-os"))
 		})

--- a/pkg/testrunner/template/testdata/shoot/basic/templates/testrun.yaml
+++ b/pkg/testrunner/template/testdata/shoot/basic/templates/testrun.yaml
@@ -12,9 +12,6 @@ metadata:
         shoot.secretBinding: {{ required "secretBinding is required" .Values.shoot.secretBinding }}
         shoot.region: {{ required "region is required" .Values.shoot.region }}
         shoot.zone: {{ required "zone is required" .Values.shoot.zone }}
-        {{- if  hasKey .Values.shoot "allowPrivilegedContainers" }}
-        shoot.allowPrivilegedContainers: "{{ .Values.shoot.allowPrivilegedContainers }}"
-        {{- end }}
         {{- if  hasKey .Values.shoot "shootAnnotations" }}
         shoot.shootAnnotations: "{{ .Values.shoot.shootAnnotations }}"
         {{- end }}

--- a/pkg/testrunner/template/values.go
+++ b/pkg/testrunner/template/values.go
@@ -144,9 +144,6 @@ func (r *shootValueRenderer) GetValues(shoot *common.ExtendedShoot, defaultValue
 			"gardener": string(r.parameters.GardenerKubeconfig),
 		},
 	}
-	if shoot.AllowPrivilegedContainers != nil {
-		values["shoot"].(map[string]interface{})["allowPrivilegedContainers"] = shoot.AllowPrivilegedContainers
-	}
 	if shoot.AdditionalAnnotations != nil {
 		values["shoot"].(map[string]interface{})["shootAnnotations"] = util.MarshalMap(shoot.AdditionalAnnotations)
 	}
@@ -163,17 +160,16 @@ func (r *shootValueRenderer) GetMetadata(shoot *common.ExtendedShoot) (*metadata
 		containerRuntime = string(shoot.Workers[0].CRI.Name)
 	}
 	return &metadata.Metadata{
-		FlavorDescription:         shoot.Description,
-		Landscape:                 r.parameters.Landscape,
-		ComponentDescriptor:       r.parameters.ComponentDescriptor.JSON(),
-		CloudProvider:             string(shoot.Provider),
-		KubernetesVersion:         shoot.KubernetesVersion.Version,
-		Region:                    shoot.Region,
-		Zone:                      shoot.Zone,
-		AllowPrivilegedContainers: shoot.AllowPrivilegedContainers,
-		OperatingSystem:           shoot.Workers[0].Machine.Image.Name, // todo: check if there a possible multiple workerpools with different images
-		OperatingSystemVersion:    operatingsystemversion,
-		ContainerRuntime:          containerRuntime,
-		Annotations:               shoot.AdditionalAnnotations,
+		FlavorDescription:      shoot.Description,
+		Landscape:              r.parameters.Landscape,
+		ComponentDescriptor:    r.parameters.ComponentDescriptor.JSON(),
+		CloudProvider:          string(shoot.Provider),
+		KubernetesVersion:      shoot.KubernetesVersion.Version,
+		Region:                 shoot.Region,
+		Zone:                   shoot.Zone,
+		OperatingSystem:        shoot.Workers[0].Machine.Image.Name, // todo: check if there a possible multiple workerpools with different images
+		OperatingSystemVersion: operatingsystemversion,
+		ContainerRuntime:       containerRuntime,
+		Annotations:            shoot.AdditionalAnnotations,
 	}, nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind cleanup

**What this PR does / why we need it**:

Related to https://github.com/gardener/gardener/pull/8989 and https://github.com/gardener/gardener/pull/9273

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
