### PR TITLE
Set controller runtime logger for testrunner

### DIFF
--- a/cmd/testrunner/cmd/cmd.go
+++ b/cmd/testrunner/cmd/cmd.go
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/gardener/test-infra/cmd/testrunner/cmd/alert"
 	collectcmd "github.com/gardener/test-infra/cmd/testrunner/cmd/collect"
@@ -29,6 +30,7 @@ var rootCmd = &cobra.Command{
 			return err
 		}
 		logger.SetLogger(log)
+		ctrl.SetLogger(log)
 		return nil
 	},
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
A new check in the controller-runtime logging revealed, we missed to set the controller-runtime logger for the testrunner. 
Other controllers set this already ([example](https://github.com/gardener/test-infra/blob/86122f3581c04dd7ca4db51bd0f7bb96efb30e9a/cmd/tm-bot/app/options.go#L49-L50)). So I assume it was simply missed :) 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @dguendisch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
