### PR TITLE
Testrunner adds a providerconfig to any AWS worker

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.8.0
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/gardener/gardener v1.90.1
+	github.com/gardener/gardener-extension-provider-aws v1.53.1
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.4.1
 	github.com/go-logr/zapr v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -701,6 +701,8 @@ github.com/gardener/etcd-druid v0.22.0 h1:DVe+Zjrb93r9vI1uUiCTMHBffIUoMAKhNzFZNC
 github.com/gardener/etcd-druid v0.22.0/go.mod h1:FROhfVKyWBo4krlPe3R6FIhJRmOmijEWBdEeUP0CJjE=
 github.com/gardener/gardener v1.90.1 h1:GZFBnBA8BGDL07eWhqQd58jVyn7ZWFd6G1o/LN6YOZ8=
 github.com/gardener/gardener v1.90.1/go.mod h1:2oopZmb8fQbXXeypRpiY2Nj0kVcobxsMYUn7HOupX84=
+github.com/gardener/gardener-extension-provider-aws v1.53.1 h1:034uRSoQ/uSYz8smyRQEMCNdBljyCvbEHo+iAzw5xx4=
+github.com/gardener/gardener-extension-provider-aws v1.53.1/go.mod h1:N5+5++qPCNC1gQeG/Uy9xEQUEVRABU7WFNFLs3cSTaM=
 github.com/gardener/hvpa-controller/api v0.5.0 h1:f4F3O7YUrenwh4S3TgPREPiB287JjjUiUL18OqPLyAA=
 github.com/gardener/hvpa-controller/api v0.5.0/go.mod h1:QQl3ELkCaki+8RhXl0FZMfvnm0WCGwGJlGmrxJj6lvM=
 github.com/gardener/machine-controller-manager v0.52.0 h1:irhpamQ/QXixCXJpNKRL71aM3FAdNO1HxZwA54jvncI=

--- a/pkg/shootflavors/worker.go
+++ b/pkg/shootflavors/worker.go
@@ -1,7 +1,13 @@
 package shootflavors
 
 import (
+	"encoding/json"
+
+	"github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
 
 	"github.com/gardener/test-infra/pkg/common"
 	"github.com/gardener/test-infra/pkg/util"
@@ -17,6 +23,26 @@ func SetupWorker(cloudprofile gardencorev1beta1.CloudProfile, workers []gardenco
 				return nil, err
 			}
 			worker.Machine.Image.Version = &version.Version
+		}
+
+		if cloudprofile.Spec.Type == "aws" {
+			providerConfig := v1alpha1.WorkerConfig{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "WorkerConfig",
+					APIVersion: "aws.provider.extensions.gardener.cloud/v1alpha1",
+				},
+				InstanceMetadataOptions: &v1alpha1.InstanceMetadataOptions{
+					HTTPTokens:              ptr.To(v1alpha1.HTTPTokensRequired),
+					HTTPPutResponseHopLimit: ptr.To(int64(2)),
+				},
+			}
+			js, err := json.Marshal(providerConfig)
+			if err != nil {
+				return nil, err
+			}
+			worker.ProviderConfig = &runtime.RawExtension{
+				Raw: js,
+			}
 		}
 		res[i] = *worker
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind task

**What this PR does / why we need it**:
Shoots on AWS need to be created with IMDSv2 configuration by default. This can be enabled through a worker's providerConfig.
Testrunner will add a suitable proivderConfig when parsing the worker configuration from the shoot flavor to extend any AWS worker.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @dguendisch

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
