### PR TITLE
Make sure, ocm parameters can be used by the results collector

### DIFF
--- a/cmd/testrunner/cmd/run_template/options.go
+++ b/cmd/testrunner/cmd/run_template/options.go
@@ -63,6 +63,8 @@ func (o *options) Complete() error {
 
 	o.testrunnerConfig.Timeout = time.Duration(o.timeout) * time.Second
 	o.collectConfig.ComponentDescriptorPath = o.shootParameters.ComponentDescriptorPath
+	o.collectConfig.OCMConfigPath = o.shootParameters.OCMConfigPath
+	o.collectConfig.Repository = o.shootParameters.Repository
 
 	if len(o.shootParameters.FlavorConfigPath) != 0 {
 		gardenK8sClient, err := kutil.NewClientFromFile(o.testrunnerKubeconfigPath, client.Options{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind task

**What this PR does / why we need it**:
Testrunner collects results to upload them as assets to e.g. a github release. When switching to OCM, it was missed to forward the OCM parameters to the collector.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @dguendisch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
