### PR TITLE
Testrunner skips machine image versions containing a build identifier

### DIFF
--- a/pkg/util/machine_image.go
+++ b/pkg/util/machine_image.go
@@ -64,6 +64,9 @@ func getLatestMachineImageVersion(rawVersions []gardencorev1beta1.MachineImageVe
 		if err != nil {
 			return gardencorev1beta1.MachineImageVersion{}, err
 		}
+		if v.Metadata() != "" {
+			continue
+		}
 		if latestVersion == nil || v.GreaterThan(latestVersion) {
 			latestVersion = v
 			latestExpVersion = rawVersion

--- a/pkg/util/machine_image_test.go
+++ b/pkg/util/machine_image_test.go
@@ -1,0 +1,80 @@
+package util
+
+import (
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("machine image version test", func() {
+
+	var (
+		rawVersions []gardencorev1beta1.MachineImageVersion
+	)
+
+	BeforeEach(func() {
+		rawVersions = []gardencorev1beta1.MachineImageVersion{
+			gardencorev1beta1.MachineImageVersion{
+				ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+					Version: "1.2.3",
+				},
+			},
+			gardencorev1beta1.MachineImageVersion{
+				ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+					Version: "1.2.4",
+				},
+			},
+			gardencorev1beta1.MachineImageVersion{
+				ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+					Version: "1.2.4-pre-release",
+				},
+			},
+		}
+	})
+
+	It("should return the latest of two machine image versions", func() {
+		version, err := getLatestMachineImageVersion(rawVersions)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(version.Version).To(Equal("1.2.4"))
+	})
+
+	It("should consider full version higher than pre-release and build", func() {
+		rawVersions = append(rawVersions,
+			gardencorev1beta1.MachineImageVersion{
+				ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+					Version: "1.2.4+build",
+				},
+			},
+			gardencorev1beta1.MachineImageVersion{
+				ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+					Version: "1.2.4-pre+build",
+				},
+			},
+		)
+
+		version, err := getLatestMachineImageVersion(rawVersions)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(version.Version).To(Equal("1.2.4"))
+
+	})
+
+	It("should skip build versions", func() {
+		rawVersions = append(rawVersions,
+			gardencorev1beta1.MachineImageVersion{
+				ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+					Version: "1.2.5+build",
+				},
+			},
+			gardencorev1beta1.MachineImageVersion{
+				ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+					Version: "1.2.5-pre+build",
+				},
+			},
+		)
+
+		version, err := getLatestMachineImageVersion(rawVersions)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(version.Version).To(Equal("1.2.4"))
+
+	})
+})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
Skip a machine image version with a build identifier, even if its version number is the highest.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @dguendisch 
cc @MrBatschner @timuthy

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Testrunner skips machine image versions containing a build identifier
```
