### PR TITLE
Add latest-x pattern for major machine image versions

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -103,6 +103,10 @@ const (
 	PatternTwoMinorBeforeLatest   = "twoMinorBeforeLatest"
 	PatternThreeMinorBeforeLatest = "threeMinorBeforeLatest"
 	PatternFourMinorBeforeLatest  = "fourMinorBeforeLatest"
+	PatternOneMajorBeforeLatest   = "oneMajorBeforeLatest"
+	PatternTwoMajorBeforeLatest   = "twoMajorBeforeLatest"
+	PatternThreeMajorBeforeLatest = "threeMajorBeforeLatest"
+	PatternFourMajorBeforeLatest  = "fourMajorBeforeLatest"
 
 	// TM Dashboard
 	DashboardExecutionGroupParameter = "runID"

--- a/pkg/shootflavors/worker.go
+++ b/pkg/shootflavors/worker.go
@@ -17,8 +17,11 @@ func SetupWorker(cloudprofile gardencorev1beta1.CloudProfile, workers []gardenco
 	res := make([]gardencorev1beta1.Worker, len(workers))
 	for i, w := range workers {
 		worker := w.DeepCopy()
-		if worker.Machine.Image != nil && (worker.Machine.Image.Version == nil || *worker.Machine.Image.Version == common.PatternLatest) {
-			version, err := util.GetLatestMachineImageVersion(cloudprofile, worker.Machine.Image.Name, *worker.Machine.Architecture)
+		if worker.Machine.Image != nil {
+			if worker.Machine.Image.Version == nil {
+				*worker.Machine.Image.Version = common.PatternLatest
+			}
+			version, err := util.GetMachineImageVersion(cloudprofile, *worker.Machine.Image.Version, worker.Machine.Image.Name, *worker.Machine.Architecture)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/util/machine_image_test.go
+++ b/pkg/util/machine_image_test.go
@@ -1,10 +1,76 @@
 package util
 
 import (
+	"time"
+
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/gardener/test-infra/pkg/common"
 )
+
+const (
+	imageName  = "gardenlinux"
+	arch_amd64 = "amd64"
+	arch_arm64 = "arm64"
+)
+
+var _ = Describe("get machine images from a cloudprofile", func() {
+	var (
+		cloudprofile gardencorev1beta1.CloudProfile
+		expiredTime  metav1.Time
+		futureTime   metav1.Time
+	)
+
+	BeforeEach(func() {
+		expiredTime = metav1.NewTime(time.Now())
+		futureTime = metav1.NewTime(time.Now().Add(time.Hour * 24))
+		cloudprofile = gardencorev1beta1.CloudProfile{
+			Spec: gardencorev1beta1.CloudProfileSpec{
+				MachineImages: []gardencorev1beta1.MachineImage{
+					{
+						Name: imageName,
+						Versions: []gardencorev1beta1.MachineImageVersion{
+							{ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+								Version:        "3.4.5",
+								ExpirationDate: &futureTime,
+							}, Architectures: []string{arch_amd64, arch_arm64}},
+							{ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+								Version:        "2.3.4",
+								ExpirationDate: &futureTime,
+							}, Architectures: []string{arch_amd64, arch_arm64}},
+							{ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+								Version:        "4.5.6",
+								ExpirationDate: &expiredTime,
+							}, Architectures: []string{arch_amd64, arch_arm64}},
+						},
+					},
+				},
+			},
+		}
+	})
+
+	It("should return the latest, not-expired machine image version from a cloudprofile", func() {
+		version, err := GetMachineImageVersion(cloudprofile, common.PatternLatest, imageName, arch_amd64)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(version.Version).To(Equal("3.4.5"))
+	})
+
+	It("should return the latest-1, not-expired machine image version from a cloudprofile", func() {
+		version, err := GetMachineImageVersion(cloudprofile, common.PatternOneMajorBeforeLatest, imageName, arch_amd64)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(version.Version).To(Equal("2.3.4"))
+	})
+	It("should return the version string parsed from the flavor", func() {
+		versionInput := "1.2.3"
+		version, err := GetMachineImageVersion(cloudprofile, versionInput, imageName, arch_amd64)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(version.Version).To(Equal(versionInput))
+	})
+
+})
 
 var _ = Describe("machine image version test", func() {
 
@@ -16,45 +82,73 @@ var _ = Describe("machine image version test", func() {
 		rawVersions = []gardencorev1beta1.MachineImageVersion{
 			gardencorev1beta1.MachineImageVersion{
 				ExpirableVersion: gardencorev1beta1.ExpirableVersion{
-					Version: "1.2.3",
+					Version: "1.3.4",
 				},
 			},
 			gardencorev1beta1.MachineImageVersion{
 				ExpirableVersion: gardencorev1beta1.ExpirableVersion{
-					Version: "1.2.4",
+					Version: "3.2.4",
 				},
 			},
 			gardencorev1beta1.MachineImageVersion{
 				ExpirableVersion: gardencorev1beta1.ExpirableVersion{
-					Version: "1.2.4-pre-release",
+					Version: "2.3.4",
+				},
+			},
+			gardencorev1beta1.MachineImageVersion{
+				ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+					Version: "3.2.3",
+				},
+			},
+			gardencorev1beta1.MachineImageVersion{
+				ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+					Version: "3.2.4-pre-release",
 				},
 			},
 		}
 	})
 
-	It("should return the latest of two machine image versions", func() {
-		version, err := getLatestMachineImageVersion(rawVersions)
+	It("should return the latest of several machine image versions", func() {
+		version, err := getXMajorsBeforeLatestMachineImageVersion(rawVersions, 0)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(version.Version).To(Equal("1.2.4"))
+		Expect(version.Version).To(Equal("3.2.4"))
+	})
+
+	It("should return the latest-1 of several machine image versions", func() {
+		version, err := getXMajorsBeforeLatestMachineImageVersion(rawVersions, 1)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(version.Version).To(Equal("2.3.4"))
+	})
+
+	It("should return the latest-2 of several machine image versions", func() {
+		version, err := getXMajorsBeforeLatestMachineImageVersion(rawVersions, 2)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(version.Version).To(Equal("1.3.4"))
+	})
+
+	It("should return an error if no matching version is found for latest-x", func() {
+		_, err := getXMajorsBeforeLatestMachineImageVersion(rawVersions, 3)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal("no machine image version matching the pattern latest-3 found"))
 	})
 
 	It("should consider full version higher than pre-release and build", func() {
 		rawVersions = append(rawVersions,
 			gardencorev1beta1.MachineImageVersion{
 				ExpirableVersion: gardencorev1beta1.ExpirableVersion{
-					Version: "1.2.4+build",
+					Version: "3.2.4+build",
 				},
 			},
 			gardencorev1beta1.MachineImageVersion{
 				ExpirableVersion: gardencorev1beta1.ExpirableVersion{
-					Version: "1.2.4-pre+build",
+					Version: "3.2.4-pre+build",
 				},
 			},
 		)
 
-		version, err := getLatestMachineImageVersion(rawVersions)
+		version, err := getXMajorsBeforeLatestMachineImageVersion(rawVersions, 0)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(version.Version).To(Equal("1.2.4"))
+		Expect(version.Version).To(Equal("3.2.4"))
 
 	})
 
@@ -62,19 +156,19 @@ var _ = Describe("machine image version test", func() {
 		rawVersions = append(rawVersions,
 			gardencorev1beta1.MachineImageVersion{
 				ExpirableVersion: gardencorev1beta1.ExpirableVersion{
-					Version: "1.2.5+build",
+					Version: "3.2.5+build",
 				},
 			},
 			gardencorev1beta1.MachineImageVersion{
 				ExpirableVersion: gardencorev1beta1.ExpirableVersion{
-					Version: "1.2.5-pre+build",
+					Version: "3.2.5-pre+build",
 				},
 			},
 		)
 
-		version, err := getLatestMachineImageVersion(rawVersions)
+		version, err := getXMajorsBeforeLatestMachineImageVersion(rawVersions, 0)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(version.Version).To(Equal("1.2.4"))
+		Expect(version.Version).To(Equal("3.2.4"))
 
 	})
 })

--- a/pkg/util/machine_image_test.go
+++ b/pkg/util/machine_image_test.go
@@ -38,6 +38,10 @@ var _ = Describe("get machine images from a cloudprofile", func() {
 								ExpirationDate: &futureTime,
 							}, Architectures: []string{arch_amd64, arch_arm64}},
 							{ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+								Version:        "2.3.3",
+								ExpirationDate: &futureTime,
+							}, Architectures: []string{arch_amd64, arch_arm64}},
+							{ExpirableVersion: gardencorev1beta1.ExpirableVersion{
 								Version:        "2.3.4",
 								ExpirationDate: &futureTime,
 							}, Architectures: []string{arch_amd64, arch_arm64}},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
Testrunner can parse latest-x pattern for major machine image and fetch the correct version from a cloudprofile. It respects expiration dates and architecture. Build versions continue to be ignored.

In case the pattern is not recognized , the version will be interpreted as string and validation is delegated to the respective garden cluster during shoot creation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @dguendisch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Latest-x pattern can be used for machine image versions in testrun flavors
```
