### PR TITLE
Replace deprecated ginkgo flags with ginkgo@v2 alternatives

### DIFF
--- a/integration-tests/e2e/kubetest/kubetest_runner.go
+++ b/integration-tests/e2e/kubetest/kubetest_runner.go
@@ -124,7 +124,7 @@ func createKubetestArgs(ginkgoFocus string, parallel, dryRun bool, flakeAttempts
 func runKubetest(args KubetestArgs, logToStd bool) {
 	//  -clean-start
 	//    	If true, purge all namespaces except default and system before running tests. This serves to Cleanup test namespaces from failed/interrupted e2e runs in a long-lived cluster.
-	ginkgoArgs := fmt.Sprintf("--test_args=--ginkgo.flakeAttempts=%o --ginkgo.dryRun=%t --minStartupPods=1 %s", args.FlakeAttempts, args.DryRun, args.GinkgoFocus)
+	ginkgoArgs := fmt.Sprintf("--test_args=--ginkgo.flake-attempts=%o --ginkgo.dry-run=%t --minStartupPods=1 %s", args.FlakeAttempts, args.DryRun, args.GinkgoFocus)
 	cmd := exec.Command("kubetest", "--provider=skeleton", "--deployment=local", "--test", "--check-version-skew=false", args.GinkgoParallel, ginkgoArgs, fmt.Sprintf("--dump=%s", args.LogDir))
 	cmd.Dir = config.KubernetesPath
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
Running conformance tests locally following the steps in https://github.com/gardener/test-infra/tree/master/integration-tests/e2e#run-conformance-tests-or-single-tests-directly-without-gardeners-test-automation results in many warnings of type:
```
You're using deprecated Ginkgo functionality:
=============================================
  --ginkgo.dryRun is deprecated, use --ginkgo.dry-run instead
  Learn more at: https://onsi.github.io/ginkgo/MIGRATING_TO_V2#changed-command-line-flags
  --ginkgo.flakeAttempts is deprecated, use --ginkgo.flake-attempts instead
  Learn more at: https://onsi.github.io/ginkgo/MIGRATING_TO_V2#changed-command-line-flags

To silence deprecations that can be silenced set the following environment variable:
  ACK_GINKGO_DEPRECATIONS=2.19.0
```

This PR replaces ginkgo@v1 flags with their ginkgo@v2 alternatives.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
