### PR TITLE
Introduce `gosec` for Static Application Security Testing (SAST)

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -62,6 +62,9 @@ test-infra:
       steps:
         <<: *default_steps
     release:
+      steps:
+          check:
+            image: 'golang:1.23'
       traits:
         version:
           preprocess: 'finalize'
@@ -69,6 +72,16 @@ test-infra:
           ocm_repository: europe-docker.pkg.dev/gardener-project/releases
         release:
           nextversion: 'bump_minor'
+          assets:
+            - type: build-step-log
+              step_name: check
+              purposes:
+                - lint
+                - sast
+                - gosec
+              comment: |
+                we use gosec (linter) for SAST scans
+                see: https://github.com/securego/gosec
         slack:
           default_channel: 'internal_ti_workspace'
           channel_cfgs:
@@ -95,20 +108,3 @@ test-infra:
             tm-prepare-image:
               <<: *prepare_image
               image: europe-docker.pkg.dev/gardener-project/releases/testmachinery/prepare-step
-
-    #####################
-    #      Images       #
-    #####################
-    tm-golang-image:
-      repo:
-        trigger: false
-      traits:
-        version:
-          preprocess: 'finalize'
-        publish:
-          dockerimages:
-            tm-golang-image:
-              image: europe-docker.pkg.dev/gardener-project/releases/testmachinery/golang
-              dockerfile: 'Dockerfile'
-              dir: 'hack/images/golang'
-              tag_as_latest: true

--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,8 @@ assets
 
 **/*.coverprofile
 
+# openapi-gen
 **/*.report
+
+# gosec
+gosec-report.sarif

--- a/Makefile
+++ b/Makefile
@@ -61,11 +61,19 @@ format: $(GOIMPORTS) $(GOIMPORTSREVISER)
 .PHONY: check
 check: $(GOIMPORTS) $(GOLANGCI_LINT)
 	@REPO_ROOT=$(REPO_ROOT) bash $(GARDENER_HACK_DIR)/check.sh --golangci-lint-config=./.golangci.yaml ./cmd/... ./pkg/... ./test/... ./conformance-tests/...
+	$(MAKE) sast-report
 
 .PHONY: test
 test:
 	KUBEBUILDER_ASSETS="$(shell setup-envtest use -p path ${ENVTEST_K8S_VERSION})" go test -mod=mod ./cmd/... ./pkg/...
 
+.PHONY: sast
+sast: $(GOSEC)
+	@bash $(GARDENER_HACK_DIR)/sast.sh
+
+.PHONY: sast-report
+sast-report: $(GOSEC)
+	@bash $(GARDENER_HACK_DIR)/sast.sh --gosec-report true
 
 .PHONY: install
 install:

--- a/cmd/logging/main.go
+++ b/cmd/logging/main.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/hashicorp/go-multierror"
@@ -69,7 +70,7 @@ func run(ctx context.Context) error {
 		return fmt.Errorf("host kubeconfig at %s does not exists", kubeconfigPath)
 	}
 
-	kubeconfigBytes, err := os.ReadFile(kubeconfigPath)
+	kubeconfigBytes, err := os.ReadFile(filepath.Clean(kubeconfigPath))
 	if err != nil {
 		return fmt.Errorf("unable to read host kubeconfig: %w", err)
 	}
@@ -143,10 +144,10 @@ func writePodLogs(podName, outputPath string, logs []byte) error {
 	if outputPath == "" {
 		return nil
 	}
-	if err := os.MkdirAll(outputPath, os.ModePerm); err != nil {
+	if err := os.MkdirAll(outputPath, 0750); err != nil {
 		return err
 	}
 	fileName := fmt.Sprintf("%s.log", podName)
 
-	return os.WriteFile(path.Join(outputPath, fileName), logs, os.ModePerm)
+	return os.WriteFile(path.Join(outputPath, fileName), logs, 0600)
 }

--- a/cmd/prepare/prepare.go
+++ b/cmd/prepare/prepare.go
@@ -75,13 +75,13 @@ func createTMKubeconfigFile(log logr.Logger) error {
 	}
 
 	log.Info("Write TestMachinery kubeconfig to file", "file", tmFilePath)
-	return os.WriteFile(tmFilePath, kubeconfig, os.ModePerm)
+	return os.WriteFile(tmFilePath, kubeconfig, 0600)
 }
 
 func createDirectories(log logr.Logger, directories []string) error {
 	for _, dir := range directories {
 		log.Info("create directory", "dir", dir)
-		if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+		if err := os.MkdirAll(dir, 0750); err != nil {
 			return err
 		}
 	}
@@ -132,7 +132,7 @@ func cloneRepository(log logr.Logger, repo *prepare.Repository, repoBasePath str
 }
 
 func readConfigFile(file string) (*prepare.Config, error) {
-	data, err := os.ReadFile(file)
+	data, err := os.ReadFile(filepath.Clean(file))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/testrunner/cmd/docs/docs.go
+++ b/cmd/testrunner/cmd/docs/docs.go
@@ -43,7 +43,7 @@ var docsCmd = &cobra.Command{
 			}
 			return
 		}
-		err := os.MkdirAll(outputDir, os.ModePerm)
+		err := os.MkdirAll(outputDir, 0750)
 		if err != nil {
 			logger.Log.Error(err, "cannot create directories")
 			os.Exit(1)

--- a/cmd/testrunner/cmd/run_template/options.go
+++ b/cmd/testrunner/cmd/run_template/options.go
@@ -7,6 +7,7 @@ package run_template
 import (
 	"errors"
 	"os"
+	"path/filepath"
 	"time"
 
 	pkgerrors "github.com/pkg/errors"
@@ -87,7 +88,7 @@ func (o *options) Complete() error {
 
 func GetShootFlavors(cfgPath string, k8sClient client.Client, shootPrefix string, filterPatchVersions bool) (*shootflavors.ExtendedFlavors, error) {
 	// read and parse test shoot configuration
-	dat, err := os.ReadFile(cfgPath)
+	dat, err := os.ReadFile(filepath.Clean(cfgPath))
 	if err != nil {
 		return nil, pkgerrors.Wrapf(err, "unable to read test shoot configuration file from %s", cfgPath)
 	}

--- a/conformance-tests/publish/parse_junit.go
+++ b/conformance-tests/publish/parse_junit.go
@@ -8,6 +8,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 )
 
@@ -48,7 +49,7 @@ func (ts *timestamp) UnmarshalXMLAttr(attr xml.Attr) error {
 }
 
 func parseJunit(junitFilePath string) (startTime, finishTime time.Time, err error) {
-	data, err := os.ReadFile(junitFilePath)
+	data, err := os.ReadFile(filepath.Clean(junitFilePath))
 	if err != nil {
 		return
 	}

--- a/conformance-tests/publish/publish.go
+++ b/conformance-tests/publish/publish.go
@@ -52,14 +52,14 @@ func createMetadataFiles(log logr.Logger) error {
 	}
 
 	startedContent := []byte(fmt.Sprintf("{\"timestamp\": %d}", testsuiteStartTime.Unix()))
-	err = os.WriteFile(filepath.Join(config.ExportPath, startedFileName), startedContent, 06444)
+	err = os.WriteFile(filepath.Join(config.ExportPath, startedFileName), startedContent, 0600)
 	if err != nil {
 		log.Error(err, "Failed to write started.json file")
 		return err
 	}
 
 	finishedContent := []byte(fmt.Sprintf("{\"timestamp\": %d, \"result\": \"SUCCESS\", \"metadata\": {\"shoot-k8s-release\": \"%s\", \"gardener\": \"%s\"}}", testsuiteFinishTime.Unix(), config.K8sRelease, config.GardenerVersion))
-	err = os.WriteFile(filepath.Join(config.ExportPath, finishedFileName), finishedContent, 06444)
+	err = os.WriteFile(filepath.Join(config.ExportPath, finishedFileName), finishedContent, 0600)
 	if err != nil {
 		log.Error(err, "Failed to write finished.json file")
 		return err
@@ -107,7 +107,7 @@ func uploadResultsToBucket(log logr.Logger, files []string, k8sReleaseMajorMinor
 
 func upload(client *storage.Client, bucket, sourcePath, targetPath string) error {
 	ctx := context.Background()
-	f, err := os.Open(sourcePath)
+	f, err := os.Open(filepath.Clean(sourcePath))
 	if err != nil {
 		return err
 	}

--- a/pkg/apis/config/config_testmachinery.go
+++ b/pkg/apis/config/config_testmachinery.go
@@ -66,7 +66,7 @@ type GitHub struct {
 // GitHubCache is the github cache configuration
 type GitHubCache struct {
 	CacheDir        string `json:"cacheDir,omitempty"`
-	CacheDiskSizeGB int    `json:"cacheDiskSizeGB,omitempty"`
+	CacheDiskSizeGB uint64 `json:"cacheDiskSizeGB,omitempty"`
 	MaxAgeSeconds   int    `json:"maxAgeSeconds,omitempty"`
 }
 

--- a/pkg/apis/config/constants.go
+++ b/pkg/apis/config/constants.go
@@ -12,7 +12,7 @@ import (
 var ChartsPath = filepath.Join("charts", "internal")
 
 // GitHubSecretKeyName is the name of the secret key that contains the github secrets
-const GitHubSecretKeyName = "config.yaml"
+const GitHubSecretKeyName = "config.yaml" // #nosec G101 -- No credential.
 
 // S3SecretName is the name of the secret containing the s3 credentials
 const S3SecretName = "s3-secret"

--- a/pkg/apis/config/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/config/v1beta1/zz_generated.conversion.go
@@ -457,7 +457,15 @@ func Convert_config_ElasticSearch_To_v1beta1_ElasticSearch(in *config.ElasticSea
 }
 
 func autoConvert_v1beta1_GitHub_To_config_GitHub(in *GitHub, out *config.GitHub, s conversion.Scope) error {
-	out.Cache = (*config.GitHubCache)(unsafe.Pointer(in.Cache))
+	if in.Cache != nil {
+		in, out := &in.Cache, &out.Cache
+		*out = new(config.GitHubCache)
+		if err := Convert_v1beta1_GitHubCache_To_config_GitHubCache(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.Cache = nil
+	}
 	out.SecretsPath = in.SecretsPath
 	return nil
 }
@@ -468,7 +476,15 @@ func Convert_v1beta1_GitHub_To_config_GitHub(in *GitHub, out *config.GitHub, s c
 }
 
 func autoConvert_config_GitHub_To_v1beta1_GitHub(in *config.GitHub, out *GitHub, s conversion.Scope) error {
-	out.Cache = (*GitHubCache)(unsafe.Pointer(in.Cache))
+	if in.Cache != nil {
+		in, out := &in.Cache, &out.Cache
+		*out = new(GitHubCache)
+		if err := Convert_config_GitHubCache_To_v1beta1_GitHubCache(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.Cache = nil
+	}
 	out.SecretsPath = in.SecretsPath
 	return nil
 }
@@ -542,7 +558,7 @@ func Convert_config_GitHubBot_To_v1beta1_GitHubBot(in *config.GitHubBot, out *Gi
 
 func autoConvert_v1beta1_GitHubCache_To_config_GitHubCache(in *GitHubCache, out *config.GitHubCache, s conversion.Scope) error {
 	out.CacheDir = in.CacheDir
-	out.CacheDiskSizeGB = in.CacheDiskSizeGB
+	out.CacheDiskSizeGB = uint64(in.CacheDiskSizeGB)
 	out.MaxAgeSeconds = in.MaxAgeSeconds
 	return nil
 }
@@ -554,7 +570,7 @@ func Convert_v1beta1_GitHubCache_To_config_GitHubCache(in *GitHubCache, out *con
 
 func autoConvert_config_GitHubCache_To_v1beta1_GitHubCache(in *config.GitHubCache, out *GitHubCache, s conversion.Scope) error {
 	out.CacheDir = in.CacheDir
-	out.CacheDiskSizeGB = in.CacheDiskSizeGB
+	out.CacheDiskSizeGB = int(in.CacheDiskSizeGB)
 	out.MaxAgeSeconds = in.MaxAgeSeconds
 	return nil
 }

--- a/pkg/logger/config.go
+++ b/pkg/logger/config.go
@@ -17,7 +17,7 @@ type Config struct {
 
 	Development       bool
 	Cli               bool
-	Verbosity         int
+	Verbosity         int8
 	DisableStacktrace bool
 	DisableCaller     bool
 	DisableTimestamp  bool
@@ -31,7 +31,7 @@ func InitFlags(flagset *flag.FlagSet) {
 
 	fs.BoolVar(&configFromFlags.Development, "dev", false, "enable development logging which result in console encoding, enabled stacktrace and enabled caller")
 	fs.BoolVar(&configFromFlags.Cli, "cli", util.GetenvBool("CLI", false), "logger runs as cli logger. enables cli logging")
-	fs.IntVarP(&configFromFlags.Verbosity, "verbosity", "v", 1, "number for the log level verbosity")
+	fs.Int8VarP(&configFromFlags.Verbosity, "verbosity", "v", 1, "number for the log level verbosity")
 	fs.BoolVar(&configFromFlags.DisableStacktrace, "disable-stacktrace", true, "disable the stacktrace of error logs")
 	fs.BoolVar(&configFromFlags.DisableCaller, "disable-caller", true, "disable the caller of logs")
 	fs.BoolVar(&configFromFlags.DisableTimestamp, "disable-timestamp", true, "disable timestamp output")

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -83,7 +83,7 @@ func New(config *Config) (logr.Logger, error) {
 	}
 	zapCfg := determineZapConfig(config)
 
-	level := int8(0 - config.Verbosity)
+	level := 0 - config.Verbosity
 	zapCfg.Level = zap.NewAtomicLevelAt(zapcore.Level(level))
 
 	zapLog, err := zapCfg.Build(zap.AddCallerSkip(1))

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -607,7 +607,7 @@ func schema_test_infra_pkg_apis_config_GitHubCache(ref common.ReferenceCallback)
 					"cacheDiskSizeGB": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"integer"},
-							Format: "int32",
+							Format: "int64",
 						},
 					},
 					"maxAgeSeconds": {

--- a/pkg/testmachinery/collector/helper.go
+++ b/pkg/testmachinery/collector/helper.go
@@ -16,14 +16,14 @@ import (
 func writeBulks(path string, bufs [][]byte) error {
 	// check if directory exists and create of not
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		err := os.MkdirAll(path, os.ModePerm)
+		err := os.MkdirAll(path, 0750)
 		if err != nil {
 			return err
 		}
 	}
 	for _, buf := range bufs {
 		file := filepath.Join(path, fmt.Sprintf("res-%s", util.RandomString(5)))
-		if err := os.WriteFile(file, buf, 0644); err != nil {
+		if err := os.WriteFile(file, buf, 0600); err != nil {
 			return err
 		}
 	}

--- a/pkg/testmachinery/ghcache/ghcache.go
+++ b/pkg/testmachinery/ghcache/ghcache.go
@@ -66,7 +66,7 @@ func InitGitHubCache(cfg *config.GitHubCache) {
 			return
 		}
 
-		if err := os.MkdirAll(cfg.CacheDir, os.ModePerm); err != nil {
+		if err := os.MkdirAll(cfg.CacheDir, 0750); err != nil {
 			panic(err)
 		}
 		if cfg.CacheDiskSizeGB == 0 {
@@ -77,7 +77,7 @@ func InitGitHubCache(cfg *config.GitHubCache) {
 			diskv.New(diskv.Options{
 				BasePath:     path.Join(cfg.CacheDir, "data"),
 				TempDir:      path.Join(cfg.CacheDir, "temp"),
-				CacheSizeMax: uint64(cfg.CacheDiskSizeGB) * uint64(1000000000), // GB to B
+				CacheSizeMax: cfg.CacheDiskSizeGB * uint64(1000000000), // GB to B
 			}))
 	})
 }
@@ -97,7 +97,7 @@ func AddFlags(flagset *flag.FlagSet) *config.GitHubCache {
 	internalConfig = &config.GitHubCache{}
 	flagset.StringVar(&internalConfig.CacheDir, "github-cache-dir", "",
 		"Path directory that should be used to cache github requests")
-	flagset.IntVar(&internalConfig.CacheDiskSizeGB, "github-cache-size", 1,
+	flagset.Uint64Var(&internalConfig.CacheDiskSizeGB, "github-cache-size", 1,
 		"Size of the github cache in GB")
 	flagset.IntVar(&internalConfig.MaxAgeSeconds, "github-cache-max-age", 3600,
 		"Maximum age of a failed github response in seconds")

--- a/pkg/testmachinery/locations/location/gitlocation.go
+++ b/pkg/testmachinery/locations/location/gitlocation.go
@@ -170,7 +170,10 @@ func (l *GitLocation) getGitHubClient() (*github.Client, *http.Client, error) {
 func (l *GitLocation) getHTTPClient() (*http.Client, error) {
 	if l.config != nil {
 		trp, err := ghcache.WithRateLimitControlCache(l.log.WithName("ghCache"), &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: l.config.SkipTls},
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: l.config.SkipTls, // #nosec G402 -- option defaults to false, otherwise it is a user's conscious decision.
+				MinVersion:         tls.VersionTLS12,
+			},
 		})
 		if err != nil {
 			return nil, err
@@ -185,9 +188,12 @@ func (l *GitLocation) getHTTPClient() (*http.Client, error) {
 		return basicAuth.Client(), nil
 	}
 
-	l.log.V(3).Info("insecure and unauthenticated git connection is used")
+	l.log.V(3).Info("unauthenticated git connection is used")
 	trp, err := ghcache.WithRateLimitControlCache(l.log.WithName("ghCache"), &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: false,
+			MinVersion:         tls.VersionTLS12,
+		},
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/testmachinery/testmachinery.go
+++ b/pkg/testmachinery/testmachinery.go
@@ -7,6 +7,7 @@ package testmachinery
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/pkg/errors"
@@ -144,7 +145,7 @@ func readSecretsFromFile(path string) ([]GitHubInstanceConfig, error) {
 	if _, err := os.Stat(path); err != nil {
 		return nil, errors.Wrapf(err, "file %s does not exist", path)
 	}
-	rawSecrets, err := os.ReadFile(path)
+	rawSecrets, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to read file from %s", path)
 	}

--- a/pkg/testmachinery/util.go
+++ b/pkg/testmachinery/util.go
@@ -2,6 +2,7 @@ package testmachinery
 
 import (
 	"os"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -11,12 +12,13 @@ import (
 
 var decoder runtime.Decoder
 
-// ParseTestrunFromFile reads a testrun.yaml file from filePath and parses the yaml.
-func ParseTestrunFromFile(filePath string) (*v1beta1.Testrun, error) {
-	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+// ParseTestrunFromFile reads a testrun.yaml file from file and parses the yaml.
+func ParseTestrunFromFile(file string) (*v1beta1.Testrun, error) {
+	f := filepath.Clean(file)
+	if _, err := os.Stat(f); os.IsNotExist(err) {
 		return nil, err
 	}
-	data, err := os.ReadFile(filePath)
+	data, err := os.ReadFile(f)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/testrunner/componentdescriptor/componentdescriptor.go
+++ b/pkg/testrunner/componentdescriptor/componentdescriptor.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -50,7 +51,7 @@ func GetComponents(ctx context.Context, log logr.Logger, cdPath string, repoRef 
 	if cdPath == "" {
 		return make([]*Component, 0), nil
 	}
-	data, err := os.ReadFile(cdPath)
+	data, err := os.ReadFile(filepath.Clean(cdPath))
 	if err != nil {
 		return nil, fmt.Errorf("cannot read component descriptor file %s: %s", cdPath, err.Error())
 	}

--- a/pkg/testrunner/result/notification.go
+++ b/pkg/testrunner/result/notification.go
@@ -27,7 +27,7 @@ func GenerateNotificationConfigForAlerting(tr []*tmv1beta1.Testrun, concourseOnE
 	}
 
 	notifyConfigFilePath := fmt.Sprintf("%s/notify.cfg", concourseOnErrorDir)
-	if err := os.WriteFile(notifyConfigFilePath, notifyConfig, 0777); err != nil {
+	if err := os.WriteFile(notifyConfigFilePath, notifyConfig, 0600); err != nil {
 		log.Warnf("Cannot write file email notification config to %s: %s", notifyConfigFilePath, err.Error())
 		return
 	}

--- a/pkg/testrunner/template/helper.go
+++ b/pkg/testrunner/template/helper.go
@@ -42,7 +42,7 @@ func readFileValues(files []string) (map[string]interface{}, error) {
 	values := make(map[string]interface{})
 	for _, file := range files {
 		var newValues map[string]interface{}
-		data, err := os.ReadFile(file)
+		data, err := os.ReadFile(filepath.Clean(file))
 		if err != nil {
 			return nil, errors.Wrapf(err, "unable to read file %s", file)
 		}

--- a/pkg/tm-bot/plugins/xkcd/xkcd.go
+++ b/pkg/tm-bot/plugins/xkcd/xkcd.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net/http"
 	"net/url"
 	"path"
@@ -86,7 +86,7 @@ func (x *xkcd) Run(flagset *pflag.FlagSet, client github.Client, event *github.G
 			return pluginerr.New(fmt.Sprintf("xkcd %d does not exist. The maximum number is currently %d", x.num, max), "")
 		}
 	} else {
-		x.num = rand.Intn(max)
+		x.num = rand.IntN(max) // #nosec: G404 -- No cryptographic context.
 	}
 
 	info, err := x.GetImage(x.num)

--- a/pkg/tm-bot/server.go
+++ b/pkg/tm-bot/server.go
@@ -65,8 +65,8 @@ func Serve(ctx context.Context, log logr.Logger, restConfig *rest.Config, cfg *c
 
 func (o *options) startWebserver(router *mux.Router, stop <-chan struct{}) error {
 	cfg := o.cfg.Webserver
-	serverHTTP := &http.Server{Addr: fmt.Sprintf(":%d", cfg.HTTPPort), Handler: router}
-	serverHTTPS := &http.Server{Addr: fmt.Sprintf(":%d", cfg.HTTPSPort), Handler: router}
+	serverHTTP := &http.Server{Addr: fmt.Sprintf(":%d", cfg.HTTPPort), Handler: router, ReadHeaderTimeout: 10 * time.Second, WriteTimeout: 10 * time.Second, ReadTimeout: 10 * time.Second}
+	serverHTTPS := &http.Server{Addr: fmt.Sprintf(":%d", cfg.HTTPSPort), Handler: router, ReadHeaderTimeout: 10 * time.Second, WriteTimeout: 10 * time.Second, ReadTimeout: 10 * time.Second}
 	go func() {
 		o.log.Info("starting HTTP server", "port", cfg.HTTPPort)
 		if err := serverHTTP.ListenAndServe(); err != nil && err != http.ErrServerClosed {

--- a/pkg/tm-bot/tests/status.go
+++ b/pkg/tm-bot/tests/status.go
@@ -7,7 +7,7 @@ package tests
 import (
 	"bytes"
 	"context"
-	"crypto/sha1"
+	"crypto/sha256"
 	"fmt"
 	"strings"
 
@@ -109,7 +109,7 @@ func (u *StatusUpdater) UpdateComment(comment string) error {
 	if u.commentID == 0 {
 		return nil
 	}
-	h := sha1.New()
+	h := sha256.New()
 	if _, err := h.Write([]byte(comment)); err != nil {
 		return err
 	}

--- a/pkg/util/elasticsearch/elasticsearch.go
+++ b/pkg/util/elasticsearch/elasticsearch.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"path/filepath"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
@@ -129,7 +130,7 @@ func (c *client) Bulk(data []byte) error {
 }
 
 func (c *client) BulkFromFile(file string) error {
-	data, err := os.ReadFile(file)
+	data, err := os.ReadFile(filepath.Clean(file))
 	if err != nil {
 		return err
 	}

--- a/pkg/util/kubernetes/health.go
+++ b/pkg/util/kubernetes/health.go
@@ -185,12 +185,12 @@ func daemonSetMaxUnavailable(daemonSet *appsv1.DaemonSet) int32 {
 		return 0
 	}
 
-	maxUnavailable, err := intstr.GetValueFromIntOrPercent(rollingUpdate.MaxUnavailable, int(daemonSet.Status.DesiredNumberScheduled), false)
+	maxUnavailable, err := intstr.GetScaledValueFromIntOrPercent(rollingUpdate.MaxUnavailable, int(daemonSet.Status.DesiredNumberScheduled), false)
 	if err != nil {
 		return 0
 	}
 
-	return int32(maxUnavailable)
+	return int32(maxUnavailable) // #nosec G115 -- maxUnavailable is derived from IntOrString, which internally uses an int32 representation or a percentage value derived from a total stored as int32
 }
 
 func getNodeCondition(conditions []corev1.NodeCondition, conditionType corev1.NodeConditionType) *corev1.NodeCondition {

--- a/pkg/util/kubernetes/kubernetes.go
+++ b/pkg/util/kubernetes/kubernetes.go
@@ -7,6 +7,7 @@ package kubernetes
 import (
 	"context"
 	"os"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -40,7 +41,7 @@ func NewClientFromSecretObject(secret *corev1.Secret, opts client.Options) (clie
 
 // NewClientFromFile creates a new Client struct from a kubconfig file.
 func NewClientFromFile(kubeconfigPath string, opts client.Options) (client.Client, error) {
-	data, err := os.ReadFile(kubeconfigPath)
+	data, err := os.ReadFile(filepath.Clean(kubeconfigPath))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/s3/mocks/object.go
+++ b/pkg/util/s3/mocks/object.go
@@ -7,6 +7,7 @@ package mock_s3
 import (
 	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/minio/minio-go"
 
@@ -28,12 +29,12 @@ func (o *mockObject) Close() error { return nil }
 
 // CreateS3ObjectFromFile creates a mock S§ Object from a file
 func CreateS3ObjectFromFile(file string) (s3.Object, error) {
-	fileInfo, err := os.Stat(file)
+	fileInfo, err := os.Stat(filepath.Clean(file))
 	if os.IsExist(err) {
 		return nil, err
 	}
 
-	f, err := os.Open(file)
+	f, err := os.Open(filepath.Clean(file))
 	if err != nil {
 		return nil, err
 	}

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"time"
@@ -218,7 +219,7 @@ func HTTPGet(url string) (*http.Response, error) {
 
 // ReadJSONFile reads a file and deserializes the json into the given object
 func ReadJSONFile(path string, obj interface{}) error {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {
 		return err
 	}
@@ -227,7 +228,7 @@ func ReadJSONFile(path string, obj interface{}) error {
 
 // ReadYAMLFile reads a file and deserializes the yaml into the given object
 func ReadYAMLFile(path string, obj interface{}) error {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind task

**What this PR does / why we need it**:

This PR introduces gosec for Static Application Security Testing for the test-infra repo.

It uses the default ruleset of gosec with two exceptions.

Scanning generated code is disabled. The Kubernetes code-gen creates hundreds of low priority findings for unsafe pointers (G103). The generated code has proven that it is working and it is not possible to address those findings.
The ./hack folder is excluded, because `gosec` does not support nested go modules (like logcheck) and there is no productive code in this folder anyway.
All findings based on these settings have been mitigated in this PR.

There are two new make targets.

- `make sast` runs the linter and logs all finding to console and fails in case of errors.
- `make sast-report` can be used in build pipelines. It fails on errors too. Additionally, it creates a report in sarif format to /gosec-report.sarif file. This report also tracks suppressed findings.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @dguendisch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add `gosec` linter
```
