### PR TITLE
`prepare` clones with `--filter=blob:none`

### DIFF
--- a/cmd/prepare/prepare.go
+++ b/cmd/prepare/prepare.go
@@ -46,6 +46,8 @@ import (
 	"github.com/gardener/test-infra/pkg/util"
 )
 
+const bloblessClone = "--filter=blob:none"
+
 func runPrepare(log logr.Logger, cfg *prepare.Config, repoBasePath string) error {
 	fmt.Printf("\n%s\n\n", util.PrettyPrintStruct(cfg))
 
@@ -96,7 +98,7 @@ func cloneRepository(log logr.Logger, repo *prepare.Repository, repoBasePath str
 	repoPath := path.Join(repoBasePath, repo.Name)
 	log.Info("Clone repo", "repo", repo.URL, "revision", repo.Revision, "path", repoPath)
 
-	if err := runCommand(log, cwd, "git", "clone", "-v", repo.URL, repoPath); err != nil {
+	if err := runCommand(log, cwd, "git", "clone", bloblessClone, "-v", repo.URL, repoPath); err != nil {
 		// do some checks to diagnose why git clone fails
 		if addrs, e := net.LookupHost("github.com"); e == nil {
 			fmt.Printf("LookupHost github.com: %v\n", addrs)
@@ -112,7 +114,7 @@ func cloneRepository(log logr.Logger, repo *prepare.Repository, repoBasePath str
 		_ = runCommand(log, cwd, "nslookup", "kubernetes.default.svc.cluster.local")
 		// for whatever reason, git clone sometimes fails to resolve github.com => workaround by retrying
 		log.Info("git clone failed => retrying once")
-		if err := runCommand(log, cwd, "git", "clone", "-v", repo.URL, repoPath); err != nil {
+		if err := runCommand(log, cwd, "git", "clone", bloblessClone, "-v", repo.URL, repoPath); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:

Currently, the `prepare` step clones full repositories. To fetch less data, the `--filter=blob:none` can be used. While `--filter=tree:0` would be an alternative, it might have issues with submodules. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/invite @dguendisch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`prepare` clones with `--filter=blob:none`
```
