### PR TITLE
Make tm-controller resource requests configurable

### DIFF
--- a/charts/testmachinery/templates/deployment-tm-controller.yaml
+++ b/charts/testmachinery/templates/deployment-tm-controller.yaml
@@ -67,6 +67,10 @@ spec:
           initialDelaySeconds: 3
           periodSeconds: 30
           failureThreshold: 5
+        resources:
+          requests:
+            cpu: {{ .Values.controller.resources.requests.cpu | quote }}
+            memory: {{ .Values.controller.resources.requests.memory | quote }}
         volumeMounts:
         - name: config
           mountPath: /etc/testmachinery/config

--- a/charts/testmachinery/values.yaml
+++ b/charts/testmachinery/values.yaml
@@ -21,6 +21,11 @@ controller:
 
   serviceAccountName: testmachinery-controller
 
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+
   healthEndpointPort: 8081
   metricsEndpointPort: 8080
   enableLeaderElection: false


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind task

**What this PR does / why we need it**:

Make tm-controller resource requests configurable.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @dguendisch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Requests for tm-controller can be specified now. 
```
