### PR TITLE
Enable `ipFamilies` to be set by testrunner

### DIFF
--- a/pkg/common/types_shootflavor.go
+++ b/pkg/common/types_shootflavor.go
@@ -110,6 +110,7 @@ type ExtendedConfiguration struct {
 	LoadbalancerProvider string `json:"loadbalancerProvider"`
 
 	NetworkingType string `json:"networkingType"`
+	IpFamilies     string `json:"ipFamilies"`
 
 	ControlPlaneFailureTolerance string `json:"controlPlaneFailureTolerance"`
 

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -3661,6 +3661,13 @@ func schema_pkg_apis_meta_v1_DeleteOptions(ref common.ReferenceCallback) common.
 							},
 						},
 					},
+					"ignoreStoreReadErrorWithClusterBreakingPotential": {
+						SchemaProps: spec.SchemaProps{
+							Description: "if set to true, it will trigger an unsafe deletion of the resource in case the normal deletion flow fails with a corrupt object error. A resource is considered corrupt if it can not be retrieved from the underlying storage successfully because of a) its data can not be transformed e.g. decryption failure, or b) it fails to decode into an object. NOTE: unsafe deletion ignores finalizer constraints, skips precondition checks, and removes the object from the storage. WARNING: This may potentially break the cluster if the workload associated with the resource being unsafe-deleted relies on normal deletion flow. Use only if you REALLY know what you are doing. The default value is false, and the user must opt in to enable it",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/shootflavors/extendedflavors_test.go
+++ b/pkg/shootflavors/extendedflavors_test.go
@@ -440,7 +440,7 @@ var _ = Describe("extended flavor test", func() {
 	})
 
 	It("should generate a shoot with the correct ipFamilies set", func() {
-		defaultExtendedCfg.IpFamilies = "ipv4"
+		defaultExtendedCfg.IpFamilies = "IPv4"
 		rawFlavors := []*common.ExtendedShootFlavor{{
 			ExtendedConfiguration: defaultExtendedCfg,
 			ShootFlavor: common.ShootFlavor{

--- a/pkg/testrunner/template/values.go
+++ b/pkg/testrunner/template/values.go
@@ -132,6 +132,7 @@ func (r *shootValueRenderer) GetValues(shoot *common.ExtendedShoot, defaultValue
 			"controlPlaneFailureTolerance": shoot.ControlPlaneFailureTolerance,
 			"floatingPoolName":             shoot.FloatingPoolName,
 			"networkingType":               shoot.NetworkingType,
+			"ipFamilies":                   shoot.IpFamilies,
 			"loadbalancerProvider":         shoot.LoadbalancerProvider,
 			"infrastructureConfig":         infrastructure,
 			"networkingConfig":             networkingConfig,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind task

**What this PR does / why we need it**:

Expand the configuration options available to a flavor by adding an `ipFamilies` field.
This will allow writing tests using the newly introduced flag to the shoot creation framework (https://github.com/gardener/gardener/pull/11135).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @dguendisch 

cc @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Enable `ipFamilies` to be set by testrunner
```
