### PR TITLE
deploy logging stack to correct namespace

### DIFF
--- a/charts/testmachinery/charts/logging/charts/vali/templates/NOTES.txt
+++ b/charts/testmachinery/charts/logging/charts/vali/templates/NOTES.txt
@@ -1,3 +1,3 @@
 Verify the application is working by running these commands:
-  kubectl --namespace {{ .Release.Namespace }} port-forward service/{{ include "vali.fullname" . }} {{ .Values.service.port }}
+  kubectl --namespace {{ .Values.global.loggingNamespace }} port-forward service/{{ include "vali.fullname" . }} {{ .Values.service.port }}
   curl http://127.0.0.1:{{ .Values.service.port }}/api/prom/label

--- a/charts/testmachinery/charts/logging/charts/vali/templates/configmap-alert.yaml
+++ b/charts/testmachinery/charts/logging/charts/vali/templates/configmap-alert.yaml
@@ -1,10 +1,11 @@
+{{- if .Values.global.loggingEnabled }}
 {{- if gt (len .Values.alerting_groups) 0 }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "vali.fullname" . }}-alerting-rules
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.global.loggingNamespace }}
   labels:
     app: {{ template "vali.name" . }}
     chart: {{ template "vali.chart" . }}
@@ -14,4 +15,5 @@ data:
   {{ template "vali.fullname" . }}-alerting-rules.yaml: |-
     groups:
     {{- toYaml .Values.alerting_groups | nindent 6 }}
+{{- end }}
 {{- end }}

--- a/charts/testmachinery/charts/logging/charts/vali/templates/ingress.yaml
+++ b/charts/testmachinery/charts/logging/charts/vali/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.loggingEnabled }}
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "vali.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
@@ -9,7 +10,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.global.loggingNamespace }}
   labels:
     app: {{ template "vali.name" . }}
     chart: {{ template "vali.chart" . }}
@@ -42,4 +43,5 @@ spec:
               servicePort: {{ $svcPort }}
         {{- end }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/testmachinery/charts/logging/charts/vali/templates/networkpolicy.yaml
+++ b/charts/testmachinery/charts/logging/charts/vali/templates/networkpolicy.yaml
@@ -1,9 +1,10 @@
+{{- if .Values.global.loggingEnabled }}
 {{- if .Values.networkPolicy.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ template "vali.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.global.loggingNamespace }}
   labels:
     app: {{ template "vali.name" . }}
     chart: {{ template "vali.chart" . }}
@@ -23,4 +24,5 @@ spec:
             release: {{ .Release.Name }}
     - ports:
       - port: {{ .Values.service.port }}
+{{- end }}
 {{- end }}

--- a/charts/testmachinery/charts/logging/charts/vali/templates/pdb.yaml
+++ b/charts/testmachinery/charts/logging/charts/vali/templates/pdb.yaml
@@ -1,9 +1,10 @@
+{{- if .Values.global.loggingEnabled }}
 {{- if .Values.podDisruptionBudget -}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "vali.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.global.loggingNamespace }}
   labels:
     app: {{ template "vali.name" . }}
     heritage: {{ .Release.Service }}
@@ -14,4 +15,5 @@ spec:
     matchLabels:
       app: {{ template "vali.name" . }}
 {{ toYaml .Values.podDisruptionBudget | indent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/testmachinery/charts/logging/charts/vali/templates/role.yaml
+++ b/charts/testmachinery/charts/logging/charts/vali/templates/role.yaml
@@ -1,13 +1,14 @@
+{{- if .Values.global.loggingEnabled }}
 {{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "vali.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.global.loggingNamespace }}
   labels:
     app: {{ template "vali.name" . }}
     chart: {{ template "vali.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 {{- end }}
-
+{{- end }}

--- a/charts/testmachinery/charts/logging/charts/vali/templates/rolebinding.yaml
+++ b/charts/testmachinery/charts/logging/charts/vali/templates/rolebinding.yaml
@@ -1,9 +1,10 @@
+{{- if .Values.global.loggingEnabled }}
 {{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "vali.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.global.loggingNamespace }}
   labels:
     app: {{ template "vali.name" . }}
     chart: {{ template "vali.chart" . }}
@@ -17,4 +18,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "vali.serviceAccountName" . }}
 {{- end }}
-
+{{- end }}

--- a/charts/testmachinery/charts/logging/charts/vali/templates/secret.yaml
+++ b/charts/testmachinery/charts/logging/charts/vali/templates/secret.yaml
@@ -1,8 +1,9 @@
+{{- if .Values.global.loggingEnabled }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "vali.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.global.loggingNamespace }}
   labels:
     app: {{ template "vali.name" . }}
     chart: {{ template "vali.chart" . }}
@@ -10,3 +11,4 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   vali.yaml: {{ tpl (toYaml .Values.config) . | b64enc}}
+  {{- end }}

--- a/charts/testmachinery/charts/logging/charts/vali/templates/service-headless.yaml
+++ b/charts/testmachinery/charts/logging/charts/vali/templates/service-headless.yaml
@@ -1,8 +1,9 @@
+{{- if .Values.global.loggingEnabled }}
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "vali.fullname" . }}-headless
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.global.loggingNamespace }}
   labels:
     app: {{ template "vali.name" . }}
     chart: {{ template "vali.chart" . }}
@@ -22,3 +23,4 @@ spec:
   selector:
     app: {{ template "vali.name" . }}
     release: {{ .Release.Name }}
+{{- end }}

--- a/charts/testmachinery/charts/logging/charts/vali/templates/service.yaml
+++ b/charts/testmachinery/charts/logging/charts/vali/templates/service.yaml
@@ -1,8 +1,9 @@
+{{- if .Values.global.loggingEnabled }}
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "vali.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.global.loggingNamespace }}
   labels:
     app: {{ template "vali.name" . }}
     chart: {{ template "vali.chart" . }}
@@ -41,3 +42,4 @@ spec:
   selector:
     app: {{ template "vali.name" . }}
     release: {{ .Release.Name }}
+{{- end }}

--- a/charts/testmachinery/charts/logging/charts/vali/templates/serviceaccount.yaml
+++ b/charts/testmachinery/charts/logging/charts/vali/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.loggingEnabled }}
 {{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
@@ -10,6 +11,6 @@ metadata:
   annotations:
     {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
   name: {{ template "vali.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.global.loggingNamespace }}
 {{- end }}
-
+{{- end }}

--- a/charts/testmachinery/charts/logging/charts/vali/templates/statefulset.yaml
+++ b/charts/testmachinery/charts/logging/charts/vali/templates/statefulset.yaml
@@ -1,8 +1,9 @@
+{{- if .Values.global.loggingEnabled }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "vali.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.global.loggingNamespace }}
   labels:
     app: {{ template "vali.name" . }}
     chart: {{ template "vali.chart" . }}
@@ -142,3 +143,4 @@ spec:
         {{- toYaml .Values.persistence.selector | nindent 8 }}
       {{- end }}
   {{- end }}
+{{- end }}

--- a/charts/testmachinery/charts/logging/charts/valitail/templates/NOTES.txt
+++ b/charts/testmachinery/charts/logging/charts/valitail/templates/NOTES.txt
@@ -1,3 +1,3 @@
 Verify the application is working by running these commands:
-  kubectl --namespace {{ .Release.Namespace }} port-forward daemonset/{{ include "valitail.fullname" . }} {{ .Values.config.server.http_listen_port }}
+  kubectl --namespace {{ .Values.global.loggingNamespace }} port-forward daemonset/{{ include "valitail.fullname" . }} {{ .Values.config.server.http_listen_port }}
   curl http://127.0.0.1:{{ .Values.config.server.http_listen_port }}/metrics

--- a/charts/testmachinery/charts/logging/charts/valitail/templates/clusterrole.yaml
+++ b/charts/testmachinery/charts/logging/charts/valitail/templates/clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.loggingEnabled }}
 {{- if .Values.rbac.create }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -17,4 +18,5 @@ rules:
   - endpoints
   - pods
   verbs: ["get", "watch", "list"]
+{{- end }}
 {{- end }}

--- a/charts/testmachinery/charts/logging/charts/valitail/templates/clusterrolebinding.yaml
+++ b/charts/testmachinery/charts/logging/charts/valitail/templates/clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.loggingEnabled }}
 {{- if .Values.rbac.create }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -11,9 +12,10 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ template "valitail.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Values.global.loggingNamespace }}
 roleRef:
   kind: ClusterRole
   name: {{ template "valitail.fullname" . }}-clusterrole
   apiGroup: rbac.authorization.k8s.io
+{{- end }}
 {{- end }}

--- a/charts/testmachinery/charts/logging/charts/valitail/templates/configmap.yaml
+++ b/charts/testmachinery/charts/logging/charts/valitail/templates/configmap.yaml
@@ -1,8 +1,9 @@
+{{- if .Values.global.loggingEnabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "valitail.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.global.loggingNamespace }}
   labels:
     app: {{ template "valitail.name" . }}
     chart: {{ template "valitail.chart" . }}
@@ -265,3 +266,4 @@ data:
     {{- if .Values.extraScrapeConfigs }}
     {{- toYaml .Values.extraScrapeConfigs | nindent 4 }}
     {{- end }}
+{{- end }}

--- a/charts/testmachinery/charts/logging/charts/valitail/templates/daemonset.yaml
+++ b/charts/testmachinery/charts/logging/charts/valitail/templates/daemonset.yaml
@@ -1,8 +1,9 @@
+{{- if .Values.global.loggingEnabled }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "valitail.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.global.loggingNamespace }}
   labels:
     app: {{ template "valitail.name" . }}
     chart: {{ template "valitail.chart" . }}
@@ -127,3 +128,4 @@ spec:
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+{{- end }}

--- a/charts/testmachinery/charts/logging/charts/valitail/templates/role.yaml
+++ b/charts/testmachinery/charts/logging/charts/valitail/templates/role.yaml
@@ -1,12 +1,14 @@
+{{- if .Values.global.loggingEnabled }}
 {{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "valitail.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.global.loggingNamespace }}
   labels:
     app: {{ template "valitail.name" . }}
     chart: {{ template "valitail.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+{{- end }}
 {{- end }}

--- a/charts/testmachinery/charts/logging/charts/valitail/templates/rolebinding.yaml
+++ b/charts/testmachinery/charts/logging/charts/valitail/templates/rolebinding.yaml
@@ -1,9 +1,10 @@
+{{- if .Values.global.loggingEnabled }}
 {{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "valitail.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.global.loggingNamespace }}
   labels:
     app: {{ template "valitail.name" . }}
     chart: {{ template "valitail.chart" . }}
@@ -17,4 +18,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "valitail.serviceAccountName" . }}
 {{- end }}
-
+{{- end }}

--- a/charts/testmachinery/charts/logging/charts/valitail/templates/service-syslog.yaml
+++ b/charts/testmachinery/charts/logging/charts/valitail/templates/service-syslog.yaml
@@ -1,9 +1,10 @@
+{{- if .Values.global.loggingEnabled }}
 {{- if .Values.syslogService.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "valitail.fullname" . }}-syslog
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.global.loggingNamespace }}
   labels:
     app: {{ template "valitail.name" . }}
     chart: {{ template "valitail.chart" . }}
@@ -47,4 +48,5 @@ spec:
   selector:
     app: {{ template "valitail.name" . }}
     release: {{ .Release.Name }}
+{{- end }}
 {{- end }}

--- a/charts/testmachinery/charts/logging/charts/valitail/templates/serviceaccount.yaml
+++ b/charts/testmachinery/charts/logging/charts/valitail/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.loggingEnabled }}
 {{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
@@ -8,6 +9,6 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "valitail.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.global.loggingNamespace }}
 {{- end }}
-
+{{- end }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:

https://github.com/gardener/test-infra/pull/611 dropped the namespace redirection for the logging chart. Instead of deploying to the namespace defined in the helm values, it was deployed to the top-level `Release` namespace.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @dguendisch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
