### PR TITLE
Configure security context for vali/valitail and reserve-capacity

### DIFF
--- a/charts/testmachinery/charts/logging/charts/vali/templates/statefulset.yaml
+++ b/charts/testmachinery/charts/logging/charts/vali/templates/statefulset.yaml
@@ -86,6 +86,7 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           securityContext:
             readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
           env:
             {{- if .Values.env }}
               {{- toYaml .Values.env | nindent 12 }}

--- a/charts/testmachinery/charts/logging/charts/valitail/values.yaml
+++ b/charts/testmachinery/charts/logging/charts/valitail/values.yaml
@@ -84,6 +84,7 @@ extraScrapeConfigs: []
 
 securityContext:
   readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
   runAsGroup: 0
   runAsUser: 0
 

--- a/charts/testmachinery/charts/reserve-excess-capacity/templates/reserve-excess-capacity.yaml
+++ b/charts/testmachinery/charts/reserve-excess-capacity/templates/reserve-excess-capacity.yaml
@@ -57,5 +57,10 @@ spec:
           limits:
             cpu: {{ .Values.resources.limits.cpu }}
             memory: {{ .Values.resources.limits.memory }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1001
       priorityClassName: tm-reserve-excess-capacity
 {{- end }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind task

**What this PR does / why we need it**:

Configure the security context for vali, valitail and the reserve-capacity deployment to be more restrictive.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @dguendisch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
