### PR TITLE
Allow configuration of global workflow defaults

### DIFF
--- a/charts/testmachinery/charts/argo/templates/config.yaml
+++ b/charts/testmachinery/charts/argo/templates/config.yaml
@@ -9,6 +9,10 @@ metadata:
   namespace: {{.Release.Namespace}}
 data:
   config: |
+    {{- if .Values.workflowDefaults }}
+    workflowDefaults: |
+    {{- toYaml .Values.workflowDefaults | nindent 6 }}
+    {{- end }}
     mainContainer:
       securityContext: {{- toYaml .Values.argo.mainContainer.securityContext | nindent 8 }}
     executor:

--- a/charts/testmachinery/charts/argo/values.yaml
+++ b/charts/testmachinery/charts/argo/values.yaml
@@ -58,3 +58,10 @@ objectStorage:
   keyPrefix: "testmachinery"
   secret:
     name: "s3-secret"
+
+workflowDefaults: {}
+  # metadata:
+  #   labels:
+  #     foo: bar
+  # spec:
+  #   ...

--- a/charts/testmachinery/values.yaml
+++ b/charts/testmachinery/values.yaml
@@ -163,6 +163,13 @@ argo:
     secret:
       name: "s3-secret"
 
+  workflowDefaults: {}
+    # metadata:
+    #   labels:
+    #     foo: bar
+    # spec:
+    #   ...
+
 logging:
   global:
     loggingNamespace: logging


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind task

**What this PR does / why we need it**:

Argo allows the configuration of global workflow defaults per controller ([ref](https://argo-workflows.readthedocs.io/en/latest/default-workflow-specs/)). With this PR the generated controller configmap accepts workflow defaults to customize the installation further.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @dguendisch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Allow configuration of global workflow defaults.
```
