### PR TITLE
Add simple elasticsearch/opensearch ingest command

### DIFF
--- a/cmd/elasticsearch/cmd/cmd.go
+++ b/cmd/elasticsearch/cmd/cmd.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/gardener/test-infra/cmd/elasticsearch/cmd/ingest"
 	"github.com/gardener/test-infra/cmd/elasticsearch/cmd/precompute"
 	"github.com/gardener/test-infra/pkg/logger"
 )
@@ -54,4 +55,5 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&RootFlags.Password, "password", "", "Elasticsearch basic auth password")
 
 	precompute.AddCommand(rootCmd)
+	ingest.AddCommand(rootCmd)
 }

--- a/cmd/elasticsearch/cmd/ingest/ingest.go
+++ b/cmd/elasticsearch/cmd/ingest/ingest.go
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ingest
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/gardener/test-infra/pkg/apis/config"
+	"github.com/gardener/test-infra/pkg/logger"
+	"github.com/gardener/test-infra/pkg/util/elasticsearch"
+)
+
+var (
+	// only touch ES when true, dry-run otherwise
+	updateES bool
+	filepath string
+)
+
+// AddCommand adds the ingest subcommand to another command.
+func AddCommand(cmd *cobra.Command) {
+	cmd.AddCommand(ingestCmd)
+}
+
+var ingestCmd = &cobra.Command{
+	Use:   "ingest",
+	Short: "Verifies that ingestion of testrun metadata into elasticsearch/opensearch works.",
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if updateES {
+			logger.Log.Info("Starting 'elasticsearch ingest' in update mode", "elasticsearch endpoint", cmd.Flag("endpoint").Value, "elasticsearch user", cmd.Flag("user").Value)
+		} else {
+			logger.Log.Info("Starting 'elasticsearch ingest' in dry-run mode")
+		}
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := run(cmd); err != nil {
+			logger.Log.Error(err, "error during execution")
+			return err
+		}
+		return nil
+	},
+	PostRun: func(cmd *cobra.Command, args []string) {
+		logger.Log.Info("Finished 'elasticsearch ingest'")
+	},
+}
+
+// package init defines the flags for the ingest command
+func init() {
+	ingestCmd.Flags().StringVar(&filepath, "file", "", "path to a bulk ingestion file")
+}
+
+func run(cmd *cobra.Command) error {
+	esClient, err := elasticsearch.NewClient(config.ElasticSearch{
+		Endpoint: cmd.Flag("endpoint").Value.String(),
+		Username: cmd.Flag("user").Value.String(),
+		Password: cmd.Flag("password").Value.String(),
+	})
+	if err != nil {
+		return err
+	}
+	err = esClient.BulkFromFile(cmd.Flag("file").Value.String())
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/elasticsearch/testdata/bulkfile-es.ndjson
+++ b/cmd/elasticsearch/testdata/bulkfile-es.ndjson
@@ -1,0 +1,8 @@
+{"index":{"_index":"testmachinery","_type":"_doc"}}
+{"tm":{"tr":{"id":"test","startTime":"2025-03-27T08:43:31Z"},"annotations":{"testmachinery.garden.cloud/collect":"true"}},"type":"testrun","startTime":"2025-03-27T08:43:31Z","testsRun":2}
+{"index":{"_index":"testmachinery","_type":"_doc"}}
+{"tm":{"tr":{"id":"test","startTime":"2025-03-27T08:43:31Z"},"annotations":{"testmachinery.garden.cloud/collect":"true"},"stepName":"create-shoot-create-testflow","testdefinition":"ccreate-shoot"},"type":"teststep","name":"ccreate-shoot","stepName":"create","phase":"Succeeded","startTime":"2020-02-25T09:00:54Z","duration":643,"pre":{"phaseNum":100}}
+{"index":{"_index":"testmachinery","_type":"_doc"}}
+{"tm":{"tr":{"id":"test","startTime":"2025-03-27T08:43:31Z"},"annotations":{"testmachinery.garden.cloud/collect":"true"},"stepName":"delete-shoot-delete-testflow","testdefinition":"delete-shoot"},"type":"teststep","name":"delete-shoot","stepName":"delete","phase":"Succeeded","startTime":"2020-02-25T09:05:54Z","duration":643,"pre":{"phaseNum":100}}
+{"index":{"_index":"tm-delete-shoot","_type":"_doc"}}
+{"name":"test-export","tm":{"tr":{"id":"test","startTime":"2025-03-27T08:43:31Z"},"annotations":{"testmachinery.garden.cloud/collect":"true"},"stepName":"delete-shoot-delete-testflow","testdefinition":"delete-shoot","phase":"Succeeded","startTime":"2020-02-25T09:05:54Z","duration":643,"podName":"test-zl5wr-wf-4048348902"}}

--- a/cmd/elasticsearch/testdata/bulkfile-os.ndjson
+++ b/cmd/elasticsearch/testdata/bulkfile-os.ndjson
@@ -1,0 +1,8 @@
+{"index":{"_index":"testmachinery"}
+{"tm":{"tr":{"id":"test","startTime":"2025-03-27T08:43:31Z"},"annotations":{"testmachinery.garden.cloud/collect":"true"}},"type":"testrun","startTime":"2025-03-27T08:43:31Z","testsRun":2}
+{"index":{"_index":"testmachinery"}
+{"tm":{"tr":{"id":"test","startTime":"2025-03-27T08:43:31Z"},"annotations":{"testmachinery.garden.cloud/collect":"true"},"stepName":"create-shoot-create-testflow","testdefinition":"create-shoot"},"type":"teststep","name":"create-shoot","stepName":"create","phase":"Succeeded","startTime":"2025-03-27T09:00:54Z","duration":643,"pre":{"phaseNum":100}}
+{"index":{"_index":"testmachinery"}
+{"tm":{"tr":{"id":"test","startTime":"2025-03-27T08:43:31Z"},"annotations":{"testmachinery.garden.cloud/collect":"true"},"stepName":"delete-shoot-delete-testflow","testdefinition":"delete-shoot"},"type":"teststep","name":"delete-shoot","stepName":"delete","phase":"Succeeded","startTime":"2025-03-27T09:05:54Z","duration":643,"pre":{"phaseNum":100}}
+{"index":{"_index":"tm-delete-shoot"}
+{"name":"test-export","tm":{"tr":{"id":"test","startTime":"2025-03-27T08:43:31Z"},"annotations":{"testmachinery.garden.cloud/collect":"true"},"stepName":"delete-shoot-delete-testflow","testdefinition":"delete-shoot","phase":"Succeeded","startTime":"2025-03-27T09:05:54Z","duration":643,"podName":"test-zl5wr-wf-4048348902"}}


### PR DESCRIPTION
**How to categorize this PR?**

/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Adds a simple subcommand `ingest` to the `elasticsearch` command to ingest bulk (ndjson) files into elasticsearch/opensearch.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
