### PR TITLE
fix: Pass github_api to GitHubRepositoryHelper

### DIFF
--- a/.ci/it-prepare.py
+++ b/.ci/it-prepare.py
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+
+import ccc.github
 import ctx
 from gitutil import (
     GitHelper
@@ -34,7 +36,7 @@ pull_request_number=git_helper.repo.git.config("--get", "pullrequest.id")
 github_helper = GitHubRepositoryHelper(
     owner=github_repository_owner,
     name=github_repository_name,
-    github_cfg=github_cfg,
+    github_api=ccc.github.github_api(github_cfg),
 )
 
 pull_request = github_helper.repository.pull_request(pull_request_number)

--- a/cmd/cncf-conformance-pr-creator/create_pr_k8s_conformance.py
+++ b/cmd/cncf-conformance-pr-creator/create_pr_k8s_conformance.py
@@ -36,7 +36,7 @@ gh = github.util.GitHubRepositoryHelper(
 repo = gh.repository
 
 script_dir = os.path.dirname(os.path.realpath(__file__))
-temlate_dir = script_dir + '/'
+template_dir = script_dir + '/'
 gs_bucket_name = 'k8s-conformance-gardener'
 conformance_tests_passed_string = "0 Failed | 0 Pending"
 
@@ -201,7 +201,7 @@ def modify_files_for_product(gardener_version, product_name, provider, k8s_versi
         print("Was not able to open " + f)
 
     # create readme
-    shutil.copyfile(temlate_dir + '/gardener_readme.txt', 'README.md')
+    shutil.copyfile(template_dir + '/gardener_readme.txt', 'README.md')
 
     # download e2e.log and junit_01.xml
     downloadingE2eLogFileSuccessful = download_files_from_gcloud_storage(provider, k8s_version)

--- a/cmd/cncf-conformance-pr-creator/create_pr_k8s_conformance.py
+++ b/cmd/cncf-conformance-pr-creator/create_pr_k8s_conformance.py
@@ -9,6 +9,7 @@ import string
 import subprocess
 import sys
 
+import ccc.github
 import google.cloud.storage
 from google.cloud.exceptions import NotFound
 import semver.version
@@ -26,10 +27,11 @@ repo_path = os.environ['FORK_OWNER'] + '/' + repo_name
 upstream_repo = 'https://github.com/cncf/k8s-conformance'
 cfg_factory = ctx.cfg_factory()
 github_cfg = cfg_factory.github('github_com')
+github_api = ccc.github.github_api(github_cfg)
 gh = github.util.GitHubRepositoryHelper(
     owner='cncf',
     name=repo_name,
-    github_cfg=github_cfg,
+    github_api=github_api,
 )
 repo = gh.repository
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:

Invoking https://github.com/gardener/test-infra/blob/24bc7ec97d7df66a5ec3e0a438384efb93fc16a9/cmd/cncf-conformance-pr-creator/create_pr_k8s_conformance.py#L29-L33 fails due to:
```terminal
Traceback (most recent call last):
  File "cmd/cncf-conformance-pr-creator/create_pr_k8s_conformance.py", line 29, in <module>
    gh = github.util.GitHubRepositoryHelper(
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: RepositoryHelperBase.__init__() got an unexpected keyword argument 'github_cfg'
```

I mimicked the usage of `ccc.github.github_api(github_cfg)` from other repositories and applied it here as well.

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @hendrikKahl 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
