### PR TITLE
fix: Initialize repo_url in github_cfg

### DIFF
--- a/cmd/cncf-conformance-pr-creator/README.md
+++ b/cmd/cncf-conformance-pr-creator/README.md
@@ -15,7 +15,7 @@
 ## How to use
 Invoke the script as shown below. This will create a new branch on your k8s-conformance fork, which contains files for not yet k8s certified gardener provider versions.
 
-    export FORK_ONWER=yourForkName
+    export FORK_OWNER=yourForkName
     python3 create_pr_k8s_conformance.py
 
-Afterwards check the changes in your branch manually. If the changes are fine, create a pull request to the upstream repository https://github.com/cncf/k8s-conformance .
+Afterward, check the changes in your branch manually. If the changes are fine, create a pull request to the upstream repository https://github.com/cncf/k8s-conformance .

--- a/cmd/cncf-conformance-pr-creator/create_pr_k8s_conformance.py
+++ b/cmd/cncf-conformance-pr-creator/create_pr_k8s_conformance.py
@@ -27,11 +27,11 @@ repo_path = os.environ['FORK_OWNER'] + '/' + repo_name
 upstream_repo = 'https://github.com/cncf/k8s-conformance'
 cfg_factory = ctx.cfg_factory()
 github_cfg = cfg_factory.github('github_com')
-github_api = ccc.github.github_api(github_cfg)
+github_cfg.repo_url = f'cncf/{repo_name}'
 gh = github.util.GitHubRepositoryHelper(
     owner='cncf',
     name=repo_name,
-    github_api=github_api,
+    github_api=(ccc.github.github_api(github_cfg)),
 )
 repo = gh.repository
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:

Second attempt at fixing `create-pr-k8s-conformance.py`:

```terminal
Traceback (most recent call last):
  File "cmd/cncf-conformance-pr-creator/create_pr_k8s_conformance.py", line 332, in <module>
    gitHelper = cloneForkedRepo()
                ^^^^^^^^^^^^^^^^^
  File "cmd/cncf-conformance-pr-creator/create_pr_k8s_conformance.py", line 97, in cloneForkedRepo
    gitHelper = gitutil.GitHelper.clone_into(repo_name, github_cfg, repo_path)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/gitutil.py", line 100, in clone_into
    if not git_cfg.repo_url:
           ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/model/base.py", line 128, in __getattr__
    raise AttributeError(name)
AttributeError: repo_url. Did you mean: 'repo_urls'?
```

Unfortunately, I don't know how to run the script locally to verify my changes.

**Which issue(s) this PR fixes**:

Follow-up to: https://github.com/gardener/test-infra/pull/650

**Special notes for your reviewer**:

/cc @hendrikKahl 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
