### PR TITLE
fix: Call clone_into() correctly

### DIFF
--- a/cmd/cncf-conformance-pr-creator/create_pr_k8s_conformance.py
+++ b/cmd/cncf-conformance-pr-creator/create_pr_k8s_conformance.py
@@ -27,7 +27,6 @@ repo_path = os.environ['FORK_OWNER'] + '/' + repo_name
 upstream_repo = 'https://github.com/cncf/k8s-conformance'
 cfg_factory = ctx.cfg_factory()
 github_cfg = cfg_factory.github('github_com')
-github_cfg.repo_url = f'cncf/{repo_name}'
 gh = github.util.GitHubRepositoryHelper(
     owner='cncf',
     name=repo_name,
@@ -94,7 +93,13 @@ def id_generator(size=4, chars=string.ascii_uppercase + string.digits):
 
 
 def cloneForkedRepo():
-    gitHelper = gitutil.GitHelper.clone_into(repo_name, github_cfg, repo_path)
+    github_cfg = ccc.github.github_cfg_for_repo_url(upstream_repo)
+    gitHelper = gitutil.GitHelper.clone_into(
+        target_directory=repo_name,
+        git_cfg=github_cfg.git_cfg(
+            repo_path=repo_path
+        ),
+    )
     print('INFO: Cloned ' + repo_path + ' repository into ' + repo_name + ' directory')
     return gitHelper
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:

Attempts to fix the `create_pr_k8s_conformance.py` script.

```terminal
Traceback (most recent call last):
  File "cmd/cncf-conformance-pr-creator/create_pr_k8s_conformance.py", line 332, in <module>
    gitHelper = cloneForkedRepo()
                ^^^^^^^^^^^^^^^^^
  File "cmd/cncf-conformance-pr-creator/create_pr_k8s_conformance.py", line 97, in cloneForkedRepo
    gitHelper = gitutil.GitHelper.clone_into(repo_name, github_cfg, repo_path)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/gitutil.py", line 103, in clone_into
    auth_type = git_cfg.auth_type
                ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/model/base.py", line 128, in __getattr__
    raise AttributeError(name)
AttributeError: auth_type
```

Trying to mimick the usage of `clone_into()`:
* https://github.com/gardener/cc-utils/blob/ce64553ce37028ed1f99a0acb8a77c668481e5ad/cli/gardener_ci/_release_notes.py#L83-L88
* https://github.com/gardener/cc-utils/blob/ce64553ce37028ed1f99a0acb8a77c668481e5ad/concourse/steps/update_component_deps.py#L693-L698

**Which issue(s) this PR fixes**:

Follow-up to: https://github.com/gardener/test-infra/pull/651

**Special notes for your reviewer**:

/cc @hendrikKahl 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
