### PR TITLE
Support credentialsBinding with testrunner

### DIFF
--- a/pkg/common/types_shootflavor.go
+++ b/pkg/common/types_shootflavor.go
@@ -100,11 +100,12 @@ type ShootWorkerFlavor struct {
 
 // ExtendedConfiguration specifies extended configuration for shoot flavors that are deployed into a preexisting landscape
 type ExtendedConfiguration struct {
-	ProjectName      string `json:"projectName"`
-	CloudprofileName string `json:"cloudprofile"`
-	SecretBinding    string `json:"secretBinding"`
-	Region           string `json:"region"`
-	Zone             string `json:"zone"`
+	ProjectName        string `json:"projectName"`
+	CloudprofileName   string `json:"cloudprofile"`
+	SecretBinding      string `json:"secretBinding"`
+	CredentialsBinding string `json:"credentialsBinding"`
+	Region             string `json:"region"`
+	Zone               string `json:"zone"`
 
 	FloatingPoolName     string `json:"floatingPoolName"`
 	LoadbalancerProvider string `json:"loadbalancerProvider"`

--- a/pkg/shootflavors/extendedflavors.go
+++ b/pkg/shootflavors/extendedflavors.go
@@ -31,8 +31,11 @@ func ValidateExtendedFlavor(identifier string, flavor *common.ExtendedShootFlavo
 	if flavor.ProjectName == "" {
 		allErrs = multierror.Append(allErrs, fmt.Errorf("%s.projectName: value has to be defined", identifier))
 	}
-	if flavor.SecretBinding == "" {
-		allErrs = multierror.Append(allErrs, fmt.Errorf("%s.secretBinding: value has to be defined", identifier))
+	if flavor.SecretBinding == "" && flavor.CredentialsBinding == "" {
+		allErrs = multierror.Append(allErrs, fmt.Errorf("%s.secretBinding/credentialsBinding: value for one of these has to be defined", identifier))
+	}
+	if flavor.SecretBinding != "" && flavor.CredentialsBinding != "" {
+		allErrs = multierror.Append(allErrs, fmt.Errorf("%s.secretBinding/credentialsBinding: use either/or but not both at the same time", identifier))
 	}
 	if flavor.Region == "" {
 		allErrs = multierror.Append(allErrs, fmt.Errorf("%s.region: value has to be defined", identifier))

--- a/pkg/testrunner/template/testdata/shoot/basic/templates/testrun.yaml
+++ b/pkg/testrunner/template/testdata/shoot/basic/templates/testrun.yaml
@@ -9,7 +9,11 @@ metadata:
         shoot.projectNamespace: {{ required "projectNamespace is required" .Values.shoot.projectNamespace }}
         shoot.cloudprovider: {{ required "cloudprovider is required" .Values.shoot.cloudprovider }}
         shoot.cloudprofile: {{ required "cloudprofile is required" .Values.shoot.cloudprofile }}
+        {{- if .Values.shoot.credentialsBinding }}
+        shoot.credentialsBinding: {{ .Values.shoot.credentialsBinding }}
+        {{- else }}
         shoot.secretBinding: {{ required "secretBinding is required" .Values.shoot.secretBinding }}
+        {{- end }}
         shoot.region: {{ required "region is required" .Values.shoot.region }}
         shoot.zone: {{ required "zone is required" .Values.shoot.zone }}
         {{- if  hasKey .Values.shoot "shootAnnotations" }}

--- a/pkg/testrunner/template/values.go
+++ b/pkg/testrunner/template/values.go
@@ -123,6 +123,7 @@ func (r *shootValueRenderer) GetValues(shoot *common.ExtendedShoot, defaultValue
 			"cloudprovider":                shoot.Provider,
 			"cloudprofile":                 shoot.CloudprofileName,
 			"secretBinding":                shoot.SecretBinding,
+			"credentialsBinding":           shoot.CredentialsBinding,
 			"region":                       shoot.Region,
 			"zone":                         shoot.Zone,
 			"workers":                      workers,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind test

**What this PR does / why we need it**:

Enhance testrunner to support specifying `credentialsBinding` through flavor resources.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/invite @dguendisch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Support credentialsBinding with testrunner
```
