### PR TITLE
Adapt alerter endpoint for opensearch bulk inserts

### DIFF
--- a/pkg/alert/alert.go
+++ b/pkg/alert/alert.go
@@ -380,7 +380,7 @@ func (alerter *Alert) elasticRequest(urlAttributes, httpMethod, payloadFormated 
 // filePostedAlerts posts test contexts to elasticsearch
 func (alerter *Alert) filePostedAlerts(tests map[string]TestDetails) error {
 	payload := alerter.generatePostedAlertsPayload(tests)
-	if err := alerter.elasticRequest("/tm-alerter/_doc/_bulk", http.MethodPost, payload, nil); err != nil {
+	if err := alerter.elasticRequest("/tm-alerter/_bulk", http.MethodPost, payload, nil); err != nil {
 		return errors.Wrap(err, "failed to store alerted tests in elasticsearch")
 	}
 	alerter.log.V(3).Info(fmt.Sprintf("filed %d tests as alerted in elasticsearch", len(tests)))

--- a/pkg/testmachinery/collector/summary.go
+++ b/pkg/testmachinery/collector/summary.go
@@ -19,6 +19,7 @@ import (
 )
 
 // collectSummaryAndExports takes a completed testrun status and writes the results to elastic search bulk json files.
+// it also adds bulk json files that were potentially written/exported by other teststeps.
 func (c *collector) collectSummaryAndExports(path string, tr *tmv1beta1.Testrun, meta *metadata.Metadata) error {
 	meta.Testrun.StartTime = tr.Status.StartTime
 	meta.Annotations = tr.Annotations


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind technical-debt

**What this PR does / why we need it**:
The alerting component for failed tests used an outdated bulk insert API endpoint that is not available anymore and thus fails with recent opensearch versions.

/invite @hendrikKahl 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fixed the slack alerting component to use current opensearch bulk insert endpoints.
```
