### PR TITLE
Add in-place update support for machine image selection

### DIFF
--- a/pkg/shootflavors/worker.go
+++ b/pkg/shootflavors/worker.go
@@ -21,7 +21,7 @@ func SetupWorker(cloudprofile gardencorev1beta1.CloudProfile, workers []gardenco
 			if worker.Machine.Image.Version == nil {
 				*worker.Machine.Image.Version = common.PatternLatest
 			}
-			version, err := util.GetMachineImageVersion(cloudprofile, *worker.Machine.Image.Version, worker.Machine.Image.Name, *worker.Machine.Architecture)
+			version, err := util.GetMachineImageVersion(cloudprofile, worker)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
This PR adds logic to filter machine image versions that support in-place updates based on the worker's update strategy. 

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/10219

**Special notes for your reviewer**:
/invite @hendrikKahl @dguendisch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
