### PR TITLE
Add functionality to support machine image update tests

### DIFF
--- a/pkg/shootflavors/extendedflavors.go
+++ b/pkg/shootflavors/extendedflavors.go
@@ -10,6 +10,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/hashicorp/go-multierror"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/strings/slices"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -56,6 +57,10 @@ func ValidateExtendedFlavor(identifier string, flavor *common.ExtendedShootFlavo
 		for j, worker := range pool.WorkerPools {
 			if worker.Machine.Architecture != nil && !slices.Contains(v1beta1constants.ValidArchitectures, *worker.Machine.Architecture) {
 				allErrs = multierror.Append(allErrs, fmt.Errorf("%s[%d].machine.architecture: value is invalid", identifier, j))
+			}
+			if worker.UpdateStrategy != nil &&
+				!sets.New(gardencorev1beta1.AutoRollingUpdate, gardencorev1beta1.AutoInPlaceUpdate, gardencorev1beta1.ManualInPlaceUpdate).Has(*worker.UpdateStrategy) {
+				allErrs = multierror.Append(allErrs, fmt.Errorf("%s[%d].updateStrategy: value is invalid", identifier, j))
 			}
 		}
 	}

--- a/pkg/shootflavors/extendedflavors_test.go
+++ b/pkg/shootflavors/extendedflavors_test.go
@@ -245,6 +245,33 @@ var _ = Describe("extended flavor test", func() {
 		Expect(err).To(HaveOccurred())
 	})
 
+	It("should fail with invalid update strategy of worker pool", func() {
+		rawFlavors := []*common.ExtendedShootFlavor{{
+			ExtendedConfiguration: defaultExtendedCfg,
+			ShootFlavor: common.ShootFlavor{
+				AdditionalAnnotations: map[string]string{"a": "b"},
+				AdditionalLocations:   []common.AdditionalLocation{{Type: "git", Repo: "https:// github.com/gardener/gardener", Revision: "master"}},
+				Provider:              common.CloudProviderGCP,
+				KubernetesVersions: common.ShootKubernetesVersionFlavor{
+					Versions: &[]gardencorev1beta1.ExpirableVersion{
+						{
+							Version: "1.15",
+						},
+					},
+				},
+				Workers: []common.ShootWorkerFlavor{
+					{
+						WorkerPools: []gardencorev1beta1.Worker{{Name: "wp1", Machine: gardencorev1beta1.Machine{Architecture: ptr.To("arm64")}, UpdateStrategy: ptr.To[gardencorev1beta1.MachineUpdateStrategy]("foo")}},
+					},
+				},
+			},
+		}}
+
+		_, err := NewExtended(c, rawFlavors, "test-pref", false)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("Flavors.0[0].updateStrategy: value is invalid"))
+	})
+
 	It("should select the correct 3 versions", func() {
 		versionPattern := ">=1.14 <= 1.15"
 		rawFlavors := []*common.ExtendedShootFlavor{{

--- a/pkg/util/machine_image_test.go
+++ b/pkg/util/machine_image_test.go
@@ -18,182 +18,253 @@ const (
 	arch_arm64 = "arm64"
 )
 
-var _ = Describe("get machine images from a cloudprofile", func() {
+var _ = Describe("machine image version", func() {
 	var (
 		cloudprofile gardencorev1beta1.CloudProfile
 		worker       *gardencorev1beta1.Worker
 		expiredTime  metav1.Time
 		futureTime   metav1.Time
+		rawVersions  []gardencorev1beta1.MachineImageVersion
+		currentImage gardencorev1beta1.ShootMachineImage
+		arch         string
 	)
 
-	BeforeEach(func() {
-		expiredTime = metav1.NewTime(time.Now())
-		futureTime = metav1.NewTime(time.Now().Add(time.Hour * 24))
-		cloudprofile = gardencorev1beta1.CloudProfile{
-			Spec: gardencorev1beta1.CloudProfileSpec{
-				MachineImages: []gardencorev1beta1.MachineImage{
-					{
-						Name: imageName,
-						Versions: []gardencorev1beta1.MachineImageVersion{
-							{ExpirableVersion: gardencorev1beta1.ExpirableVersion{
-								Version:        "3.4.5",
-								ExpirationDate: &futureTime,
-							}, Architectures: []string{arch_amd64, arch_arm64}, InPlaceUpdates: &gardencorev1beta1.InPlaceUpdates{Supported: true}},
-							{ExpirableVersion: gardencorev1beta1.ExpirableVersion{
-								Version:        "2.3.3",
-								ExpirationDate: &futureTime,
-							}, Architectures: []string{arch_amd64, arch_arm64}},
-							{ExpirableVersion: gardencorev1beta1.ExpirableVersion{
-								Version:        "2.3.4",
-								ExpirationDate: &futureTime,
-							}, Architectures: []string{arch_amd64, arch_arm64}},
-							{ExpirableVersion: gardencorev1beta1.ExpirableVersion{
-								Version:        "4.5.6",
-								ExpirationDate: &expiredTime,
-							}, Architectures: []string{arch_amd64, arch_arm64}},
+	Describe("#GetMachineImageVersion", func() {
+		BeforeEach(func() {
+			expiredTime = metav1.NewTime(time.Now())
+			futureTime = metav1.NewTime(time.Now().Add(time.Hour * 24))
+			cloudprofile = gardencorev1beta1.CloudProfile{
+				Spec: gardencorev1beta1.CloudProfileSpec{
+					MachineImages: []gardencorev1beta1.MachineImage{
+						{
+							Name: imageName,
+							Versions: []gardencorev1beta1.MachineImageVersion{
+								{ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+									Version:        "3.4.5",
+									ExpirationDate: &futureTime,
+								}, Architectures: []string{arch_amd64, arch_arm64}, InPlaceUpdates: &gardencorev1beta1.InPlaceUpdates{Supported: true}},
+								{ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+									Version:        "2.3.3",
+									ExpirationDate: &futureTime,
+								}, Architectures: []string{arch_amd64, arch_arm64}},
+								{ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+									Version:        "2.3.4",
+									ExpirationDate: &futureTime,
+								}, Architectures: []string{arch_amd64, arch_arm64}},
+								{ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+									Version:        "4.5.6",
+									ExpirationDate: &expiredTime,
+								}, Architectures: []string{arch_amd64, arch_arm64}},
+							},
 						},
 					},
 				},
-			},
-		}
+			}
 
-		worker = &gardencorev1beta1.Worker{
-			Machine: gardencorev1beta1.Machine{
-				Image: &gardencorev1beta1.ShootMachineImage{
-					Name:    imageName,
-					Version: ptr.To(common.PatternLatest),
+			worker = &gardencorev1beta1.Worker{
+				Machine: gardencorev1beta1.Machine{
+					Image: &gardencorev1beta1.ShootMachineImage{
+						Name:    imageName,
+						Version: ptr.To(common.PatternLatest),
+					},
+					Architecture: ptr.To(arch_amd64),
 				},
-				Architecture: ptr.To(arch_amd64),
-			},
-		}
+			}
+		})
+
+		It("should return the latest, not-expired machine image version from a cloudprofile", func() {
+			version, err := GetMachineImageVersion(cloudprofile, worker)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(version.Version).To(Equal("3.4.5"))
+		})
+
+		It("should return the latest, not-expired, inplace supported machine image version from a cloudprofile", func() {
+			worker.UpdateStrategy = ptr.To(gardencorev1beta1.AutoInPlaceUpdate)
+			version, err := GetMachineImageVersion(cloudprofile, worker)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(version.Version).To(Equal("3.4.5"))
+		})
+
+		It("should return the latest-1, not-expired machine image version from a cloudprofile", func() {
+			worker.Machine.Image.Version = ptr.To(common.PatternOneMajorBeforeLatest)
+			version, err := GetMachineImageVersion(cloudprofile, worker)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(version.Version).To(Equal("2.3.4"))
+		})
+
+		It("should return the version string parsed from the flavor", func() {
+			worker.Machine.Image.Version = ptr.To("1.2.3")
+			version, err := GetMachineImageVersion(cloudprofile, worker)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(version.Version).To(Equal("1.2.3"))
+		})
 	})
 
-	It("should return the latest, not-expired machine image version from a cloudprofile", func() {
-		version, err := GetMachineImageVersion(cloudprofile, worker)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(version.Version).To(Equal("3.4.5"))
-	})
-
-	It("should return the latest, not-expired, inplace supported machine image version from a cloudprofile", func() {
-		worker.UpdateStrategy = ptr.To(gardencorev1beta1.AutoInPlaceUpdate)
-		version, err := GetMachineImageVersion(cloudprofile, worker)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(version.Version).To(Equal("3.4.5"))
-	})
-
-	It("should return the latest-1, not-expired machine image version from a cloudprofile", func() {
-		worker.Machine.Image.Version = ptr.To(common.PatternOneMajorBeforeLatest)
-		version, err := GetMachineImageVersion(cloudprofile, worker)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(version.Version).To(Equal("2.3.4"))
-	})
-
-	It("should return the version string parsed from the flavor", func() {
-		worker.Machine.Image.Version = ptr.To("1.2.3")
-		version, err := GetMachineImageVersion(cloudprofile, worker)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(version.Version).To(Equal("1.2.3"))
-	})
-
-})
-
-var _ = Describe("machine image version test", func() {
-
-	var (
-		rawVersions []gardencorev1beta1.MachineImageVersion
-	)
-
-	BeforeEach(func() {
-		rawVersions = []gardencorev1beta1.MachineImageVersion{
-			{
-				ExpirableVersion: gardencorev1beta1.ExpirableVersion{
-					Version: "1.3.4",
+	Describe("#getXMajorsBeforeLatestMachineImageVersion", func() {
+		BeforeEach(func() {
+			rawVersions = []gardencorev1beta1.MachineImageVersion{
+				{
+					ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+						Version: "1.3.4",
+					},
 				},
-			},
-			{
-				ExpirableVersion: gardencorev1beta1.ExpirableVersion{
-					Version: "3.2.4",
+				{
+					ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+						Version: "3.2.4",
+					},
 				},
-			},
-			{
-				ExpirableVersion: gardencorev1beta1.ExpirableVersion{
-					Version: "2.3.4",
+				{
+					ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+						Version: "2.3.4",
+					},
 				},
-			},
-			{
-				ExpirableVersion: gardencorev1beta1.ExpirableVersion{
-					Version: "3.2.3",
+				{
+					ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+						Version: "3.2.3",
+					},
 				},
-			},
-			{
-				ExpirableVersion: gardencorev1beta1.ExpirableVersion{
-					Version: "3.2.4-pre-release",
+				{
+					ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+						Version: "3.2.4-pre-release",
+					},
 				},
-			},
-		}
+			}
+		})
+
+		It("should return the latest of several machine image versions", func() {
+			version, err := getXMajorsBeforeLatestMachineImageVersion(rawVersions, 0)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(version.Version).To(Equal("3.2.4"))
+		})
+
+		It("should return the latest-1 of several machine image versions", func() {
+			version, err := getXMajorsBeforeLatestMachineImageVersion(rawVersions, 1)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(version.Version).To(Equal("2.3.4"))
+		})
+
+		It("should return the latest-2 of several machine image versions", func() {
+			version, err := getXMajorsBeforeLatestMachineImageVersion(rawVersions, 2)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(version.Version).To(Equal("1.3.4"))
+		})
+
+		It("should return an error if no matching version is found for latest-x", func() {
+			_, err := getXMajorsBeforeLatestMachineImageVersion(rawVersions, 3)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("no machine image version matching the pattern latest-3 found"))
+		})
+
+		It("should consider full version higher than pre-release and build", func() {
+			rawVersions = append(rawVersions,
+				gardencorev1beta1.MachineImageVersion{
+					ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+						Version: "3.2.4+build",
+					},
+				},
+				gardencorev1beta1.MachineImageVersion{
+					ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+						Version: "3.2.4-pre+build",
+					},
+				},
+			)
+
+			version, err := getXMajorsBeforeLatestMachineImageVersion(rawVersions, 0)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(version.Version).To(Equal("3.2.4"))
+
+		})
+
+		It("should skip build versions", func() {
+			rawVersions = append(rawVersions,
+				gardencorev1beta1.MachineImageVersion{
+					ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+						Version: "3.2.5+build",
+					},
+				},
+				gardencorev1beta1.MachineImageVersion{
+					ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+						Version: "3.2.5-pre+build",
+					},
+				},
+			)
+
+			version, err := getXMajorsBeforeLatestMachineImageVersion(rawVersions, 0)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(version.Version).To(Equal("3.2.4"))
+
+		})
 	})
 
-	It("should return the latest of several machine image versions", func() {
-		version, err := getXMajorsBeforeLatestMachineImageVersion(rawVersions, 0)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(version.Version).To(Equal("3.2.4"))
-	})
-
-	It("should return the latest-1 of several machine image versions", func() {
-		version, err := getXMajorsBeforeLatestMachineImageVersion(rawVersions, 1)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(version.Version).To(Equal("2.3.4"))
-	})
-
-	It("should return the latest-2 of several machine image versions", func() {
-		version, err := getXMajorsBeforeLatestMachineImageVersion(rawVersions, 2)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(version.Version).To(Equal("1.3.4"))
-	})
-
-	It("should return an error if no matching version is found for latest-x", func() {
-		_, err := getXMajorsBeforeLatestMachineImageVersion(rawVersions, 3)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal("no machine image version matching the pattern latest-3 found"))
-	})
-
-	It("should consider full version higher than pre-release and build", func() {
-		rawVersions = append(rawVersions,
-			gardencorev1beta1.MachineImageVersion{
-				ExpirableVersion: gardencorev1beta1.ExpirableVersion{
-					Version: "3.2.4+build",
+	Describe("#GetLatestPreviousVersionForInPlaceUpdate", func() {
+		BeforeEach(func() {
+			cloudprofile = gardencorev1beta1.CloudProfile{
+				Spec: gardencorev1beta1.CloudProfileSpec{
+					MachineImages: []gardencorev1beta1.MachineImage{
+						{
+							Name: imageName,
+							Versions: []gardencorev1beta1.MachineImageVersion{
+								{ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+									Version:        "3.4.5",
+									ExpirationDate: &futureTime,
+								}, Architectures: []string{arch_amd64}, InPlaceUpdates: &gardencorev1beta1.InPlaceUpdates{Supported: true, MinVersionForUpdate: ptr.To("2.3.0")}},
+								{ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+									Version:        "3.4.0",
+									ExpirationDate: &futureTime,
+								}, Architectures: []string{arch_amd64}, InPlaceUpdates: &gardencorev1beta1.InPlaceUpdates{Supported: true}},
+								{ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+									Version:        "2.3.3",
+									ExpirationDate: &futureTime,
+								}, Architectures: []string{arch_amd64}, InPlaceUpdates: &gardencorev1beta1.InPlaceUpdates{Supported: true, MinVersionForUpdate: ptr.To("2.3.0")}},
+								{ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+									Version:        "4.5.6",
+									ExpirationDate: &expiredTime,
+								}, Architectures: []string{arch_amd64}, InPlaceUpdates: &gardencorev1beta1.InPlaceUpdates{Supported: true}},
+							},
+						},
+					},
 				},
-			},
-			gardencorev1beta1.MachineImageVersion{
-				ExpirableVersion: gardencorev1beta1.ExpirableVersion{
-					Version: "3.2.4-pre+build",
-				},
-			},
-		)
+			}
 
-		version, err := getXMajorsBeforeLatestMachineImageVersion(rawVersions, 0)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(version.Version).To(Equal("3.2.4"))
+			currentImage = gardencorev1beta1.ShootMachineImage{
+				Name:    imageName,
+				Version: ptr.To("3.4.5"),
+			}
+			arch = arch_amd64
+		})
 
-	})
+		It("should return the latest previous version that supports in-place updates", func() {
+			version, err := GetLatestPreviousVersionForInPlaceUpdate(cloudprofile, currentImage, arch)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(version).To(Equal("3.4.0"))
+		})
 
-	It("should skip build versions", func() {
-		rawVersions = append(rawVersions,
-			gardencorev1beta1.MachineImageVersion{
-				ExpirableVersion: gardencorev1beta1.ExpirableVersion{
-					Version: "3.2.5+build",
-				},
-			},
-			gardencorev1beta1.MachineImageVersion{
-				ExpirableVersion: gardencorev1beta1.ExpirableVersion{
-					Version: "3.2.5-pre+build",
-				},
-			},
-		)
+		It("should return an error if no previous version supports in-place updates", func() {
+			currentImage.Version = ptr.To("2.3.3")
+			_, err := GetLatestPreviousVersionForInPlaceUpdate(cloudprofile, currentImage, arch)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("no machine image versions found that can be in-place updated to the current version"))
+		})
 
-		version, err := getXMajorsBeforeLatestMachineImageVersion(rawVersions, 0)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(version.Version).To(Equal("3.2.4"))
+		It("should return an error if the current version does not support in-place updates", func() {
+			currentImage.Version = ptr.To("4.5.6")
+			_, err := GetLatestPreviousVersionForInPlaceUpdate(cloudprofile, currentImage, arch)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("specified machine image version is not found in the cloudprofile or does not support in-place updates"))
+		})
 
+		It("should return an error if the current version does not have a minimum version for in-place updates", func() {
+			cloudprofile.Spec.MachineImages[0].Versions[0].InPlaceUpdates.MinVersionForUpdate = nil
+			_, err := GetLatestPreviousVersionForInPlaceUpdate(cloudprofile, currentImage, arch)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("current machine image version does not have a minimum version for in-place updates"))
+		})
+
+		It("should return an error if no machine image versions are found", func() {
+			cloudprofile.Spec.MachineImages[0].Versions = []gardencorev1beta1.MachineImageVersion{}
+			_, err := GetLatestPreviousVersionForInPlaceUpdate(cloudprofile, currentImage, arch)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("no machine image versions found in cloudprofile " + cloudprofile.GetName()))
+		})
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
This PR adds functionality to support machine image update tests, which are only relevant only if shoot has worker pool with an in-place update strategy.
This PR introduces a new value `machineImagePrevVersion`, which is the latest previous version from which a machine image can be in-place updated to the current machine image version.
It also sets the value `shoot.machine.imageversion`, which is the version the machine image will be updated to from the `machineImagePrevVersion` version.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/10219

**Special notes for your reviewer**:
/invite @hendrikKahl @dguendisch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
