### PR TITLE
Use ASCII style for tables

### DIFF
--- a/pkg/alert/alert.go
+++ b/pkg/alert/alert.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/olekukonko/tablewriter"
+	"github.com/olekukonko/tablewriter/renderer"
 	"github.com/olekukonko/tablewriter/tw"
 	"github.com/pkg/errors"
 
@@ -267,6 +268,11 @@ func createAlertMessage(failedTests map[string]TestDetails, alert *Alert) string
 		tablewriter.WithHeader([]string{"Test", "Landscape", "Provider", "K8s Ver", "OS", "Success", "Alert Reason", "Last failure"}),
 		tablewriter.WithHeaderAlignment(tw.AlignCenter),
 		tablewriter.WithRowAlignment(tw.AlignCenter),
+		tablewriter.WithRenderer(renderer.NewBlueprint()),
+		tablewriter.WithRendition(tw.Rendition{
+			Symbols: tw.NewSymbols(tw.StyleASCII),
+			Borders: tw.Border{Top: tw.On, Bottom: tw.On, Left: tw.On, Right: tw.On},
+		}),
 	)
 	if err := table.Bulk(content); err != nil {
 		return fmt.Errorf("unable to add table content: %w", err).Error()
@@ -334,6 +340,11 @@ func createRecoverMessage(recoveredTests map[string]TestDetails) string {
 		tablewriter.WithHeader([]string{"Test", "Landscape", "Provider", "K8s Ver", "OS"}),
 		tablewriter.WithHeaderAlignment(tw.AlignCenter),
 		tablewriter.WithRowAlignment(tw.AlignCenter),
+		tablewriter.WithRenderer(renderer.NewBlueprint()),
+		tablewriter.WithRendition(tw.Rendition{
+			Symbols: tw.NewSymbols(tw.StyleASCII),
+			Borders: tw.Border{Top: tw.On, Bottom: tw.On, Left: tw.On, Right: tw.On},
+		}),
 	)
 
 	if err := table.Bulk(content); err != nil {

--- a/pkg/testrunner/list.go
+++ b/pkg/testrunner/list.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/go-multierror"
 	"github.com/olekukonko/tablewriter"
+	"github.com/olekukonko/tablewriter/renderer"
 	"github.com/olekukonko/tablewriter/tw"
 
 	tmv1beta1 "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
@@ -140,6 +141,11 @@ func (rl RunList) RenderTable() string {
 		tablewriter.WithHeader([]string{"Dimension", "Testrun", "Test Name", "Step", "Phase", "Duration"}),
 		tablewriter.WithHeaderAutoWrap(tw.WrapNone),
 		tablewriter.WithRowAutoWrap(tw.WrapNone),
+		tablewriter.WithRenderer(renderer.NewBlueprint()),
+		tablewriter.WithRendition(tw.Rendition{
+			Symbols: tw.NewSymbols(tw.StyleASCII),
+			Borders: tw.Border{Top: tw.On, Bottom: tw.On, Left: tw.On, Right: tw.On},
+		}),
 	)
 
 	dimensions := make(map[string][][]string)

--- a/pkg/util/output/table.go
+++ b/pkg/util/output/table.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/olekukonko/tablewriter"
+	"github.com/olekukonko/tablewriter/renderer"
 	"github.com/olekukonko/tablewriter/tw"
 
 	tmv1beta1 "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
@@ -24,8 +25,10 @@ func RenderTestflowTable(writer io.Writer, flow tmv1beta1.TestFlow) {
 		tablewriter.WithHeader([]string{"Step", "Definition", "Dependencies"}),
 		tablewriter.WithHeaderAutoWrap(tw.WrapNormal),
 		tablewriter.WithRowAutoWrap(tw.WrapNormal),
+		tablewriter.WithRenderer(renderer.NewBlueprint()),
 		tablewriter.WithRendition(tw.Rendition{
-			Symbols: tw.NewSymbolCustom("custom").WithRow("-"),
+			Symbols: tw.NewSymbols(tw.StyleASCII),
+			Borders: tw.Border{Top: tw.On, Bottom: tw.On, Left: tw.On, Right: tw.On},
 			Settings: tw.Settings{
 				Separators: tw.Separators{
 					BetweenRows: tw.On,
@@ -59,6 +62,11 @@ func RenderStatusTable(writer io.Writer, steps []*tmv1beta1.StepStatus) {
 
 	table := tablewriter.NewTable(writer,
 		tablewriter.WithHeader([]string{"Name", "Step", "Phase", "Duration"}),
+		tablewriter.WithRenderer(renderer.NewBlueprint()),
+		tablewriter.WithRendition(tw.Rendition{
+			Symbols: tw.NewSymbols(tw.StyleASCII),
+			Borders: tw.Border{Top: tw.On, Bottom: tw.On, Left: tw.On, Right: tw.On},
+		}),
 	)
 	if err := table.Bulk(GetStatusTableRows(steps)); err != nil {
 		fmt.Fprintf(os.Stderr, "Could not append rows to status table: %v", err)

--- a/pkg/util/slack-table-post.go
+++ b/pkg/util/slack-table-post.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/go-logr/logr"
 	"github.com/olekukonko/tablewriter"
+	"github.com/olekukonko/tablewriter/renderer"
 	"github.com/olekukonko/tablewriter/tw"
 )
 
@@ -91,6 +92,11 @@ func RenderTableForSlack(log logr.Logger, items TableItems) (string, error) {
 		tablewriter.WithHeaderAlignment(tw.AlignCenter),
 		tablewriter.WithRowAutoWrap(tw.WrapNone),
 		tablewriter.WithRowAlignment(tw.AlignLeft),
+		tablewriter.WithRenderer(renderer.NewBlueprint()),
+		tablewriter.WithRendition(tw.Rendition{
+			Symbols: tw.NewSymbols(tw.StyleASCII),
+			Borders: tw.Border{Top: tw.On, Bottom: tw.On, Left: tw.On, Right: tw.On},
+		}),
 	)
 	if err := table.Bulk(res.GetContent()); err != nil {
 		return "", fmt.Errorf("unable to add table content: %w", err)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind test

**What this PR does / why we need it**:

Not all environments where `testrunner` is executed support modern terminal output. Thus this PR pins the output style to ASCII.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/invite @dguendisch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
