### PR TITLE
Testruner posts to GitHub actions step summary file

### DIFF
--- a/cmd/testrunner/cmd/run_template/options.go
+++ b/cmd/testrunner/cmd/run_template/options.go
@@ -43,6 +43,7 @@ type options struct {
 	filterPatchVersions      bool
 	failOnError              bool
 	timeout                  int64
+	postToGitHubStepSummary  string
 }
 
 // NewOptions creates a new options struct.
@@ -174,6 +175,8 @@ func (o *options) AddFlags(fs *pflag.FlagSet) error {
 
 	fs.StringArrayVar(&o.shootParameters.SetValues, "set", make([]string, 0), "sets additional helm values")
 	fs.StringArrayVarP(&o.shootParameters.FileValues, "values", "f", make([]string, 0), "yaml value files to override template values")
+
+	fs.StringVar(&o.postToGitHubStepSummary, "post-to-github-step-summary", "", "Path to the GitHub Actions Step Summary file. If set, the testrun summary will be appended to this file.")
 
 	// DEPRECATED FLAGS
 	// is now handled by the testmachinery

--- a/cmd/testrunner/cmd/run_template/run_template.go
+++ b/cmd/testrunner/cmd/run_template/run_template.go
@@ -63,6 +63,8 @@ func NewRunTemplateCommand() (*cobra.Command, error) {
 func (o *options) run(ctx context.Context) error {
 	logger.Log.Info("Start testmachinery testrunner")
 
+	logger.SetupGitHubStepSummary(o.postToGitHubStepSummary)
+
 	runs, err := testrunnerTemplate.RenderTestruns(ctx, logger.Log.WithName("Render"), &o.shootParameters, o.shootFlavors)
 	if err != nil {
 		return errors.Wrap(err, "unable to render testrun")

--- a/cmd/testrunner/cmd/run_testrun/options.go
+++ b/cmd/testrunner/cmd/run_testrun/options.go
@@ -26,6 +26,8 @@ type options struct {
 	testrunFlakeAttempts int
 
 	timeout time.Duration
+
+	postToGitHubStepSummary string
 }
 
 // NewOptions creates a new options struct.
@@ -70,6 +72,8 @@ func (o *options) AddFlags(fs *pflag.FlagSet) error {
 	fs.IntVar(&o.testrunnerConfig.BackoffBucket, "backoff-bucket", 0, "Number of parallel created testruns per backoff period")
 	fs.DurationVar(&o.testrunnerConfig.BackoffPeriod, "backoff-period", 0, "Time to wait between the creation of testrun buckets")
 	fs.DurationVar(o.watchOptions.PollInterval, "poll-interval", time.Minute, "poll interval of the underlaying watch")
+
+	fs.StringVar(&o.postToGitHubStepSummary, "post-to-github-step-summary", "", "Path to the GitHub Actions Step Summary file. If set, the testrun summary will be appended to this file.")
 
 	// DEPRECATED FLAGS
 	// is now handled by the testmachinery

--- a/cmd/testrunner/cmd/run_testrun/run_testrun.go
+++ b/cmd/testrunner/cmd/run_testrun/run_testrun.go
@@ -54,6 +54,8 @@ func NewRunTestrunCommand() (*cobra.Command, error) {
 func (o *options) run(ctx context.Context) error {
 	logger.Log.Info("start testmachinery testrunner")
 
+	logger.SetupGitHubStepSummary(o.postToGitHubStepSummary)
+
 	watcher, err := watch.NewFromFile(logger.Log, o.tmKubeconfigPath, &o.watchOptions)
 	if err != nil {
 		logger.Log.Error(err, "unable to start testrun watch controller")

--- a/pkg/logger/helper.go
+++ b/pkg/logger/helper.go
@@ -6,9 +6,58 @@ package logger
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
 )
 
 func Logf(logFunc func(msg string, keysAndValues ...interface{}), format string, a ...interface{}) {
 	message := fmt.Sprintf(format, a...)
 	logFunc(message)
+}
+
+var (
+	ghaSummaryFileName   string
+	ghaSummaryFileExists bool
+	fileWriterMutex      sync.Mutex
+	setupOnce            sync.Once
+)
+
+func SetupGitHubStepSummary(file string) {
+	onceFunc := func() {
+		if file != "" {
+			ghaSummaryFileExists = true
+			ghaSummaryFileName = filepath.Clean(file)
+		}
+	}
+	setupOnce.Do(onceFunc)
+}
+
+func PostToGitHubStepSummary(message string, append bool) error {
+	if ghaSummaryFileExists {
+		fileWriterMutex.Lock()
+		defer fileWriterMutex.Unlock()
+
+		var flags int
+		if append {
+			flags = os.O_CREATE | os.O_WRONLY | os.O_APPEND
+		} else {
+			flags = os.O_CREATE | os.O_WRONLY | os.O_TRUNC
+		}
+		file, err := os.OpenFile(ghaSummaryFileName, flags, 0600) // #nosec G304 -- input is derived form a user's input
+		defer func(file *os.File) {
+			err := file.Close()
+			if err != nil {
+				fmt.Printf("Could not close file %s: %v\n", ghaSummaryFileName, err)
+			}
+		}(file)
+		if err != nil {
+			return err
+		}
+
+		log := []byte(message + "\n")
+		_, err = file.Write(log)
+		return err
+	}
+	return nil
 }

--- a/pkg/testrunner/result/collect.go
+++ b/pkg/testrunner/result/collect.go
@@ -11,11 +11,13 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/hashicorp/go-multierror"
+	"github.com/olekukonko/tablewriter/tw"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	tmv1beta1 "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
 	trerrors "github.com/gardener/test-infra/pkg/common/error"
+	"github.com/gardener/test-infra/pkg/logger"
 	"github.com/gardener/test-infra/pkg/testrunner"
 	"github.com/gardener/test-infra/pkg/testrunner/componentdescriptor"
 	"github.com/gardener/test-infra/pkg/util"
@@ -54,6 +56,9 @@ func (c *Collector) Collect(ctx context.Context, log logr.Logger, tmClient clien
 		log.Error(err, "error while posting notification on slack")
 	}
 	fmt.Println(runs.RenderTable())
+	if err := logger.PostToGitHubStepSummary(runs.RenderTableWithSymbols(tw.StyleMarkdown), true); err != nil {
+		log.Error(err, "unable to post summary to github step summary")
+	}
 
 	return testrunsFailed, util.ReturnMultiError(result)
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind task

**What this PR does / why we need it**:

Testrunner has a new flag to make it post updates to a GitHub Actions step summary file.
During an action run it will post:
- a link to the execution group
- links to each testrun
- result of each testrun

When all tests have finished, it will post:
- a link to the execution group
- results of all testruns

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @dguendisch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Testruner posts to GitHub actions step summary file
```
