### PR TITLE
use more generic naming for summary write up

### DIFF
--- a/cmd/testrunner/cmd/run_template/options.go
+++ b/cmd/testrunner/cmd/run_template/options.go
@@ -43,7 +43,7 @@ type options struct {
 	filterPatchVersions      bool
 	failOnError              bool
 	timeout                  int64
-	postToGitHubStepSummary  string
+	summaryFilePath          string
 }
 
 // NewOptions creates a new options struct.
@@ -131,7 +131,7 @@ func (o *options) AddFlags(fs *pflag.FlagSet) error {
 
 	fs.StringVar(&o.tmKubeconfigPath, "tm-kubeconfig-path", "", "Path to the testmachinery cluster kubeconfig")
 	fs.StringVar(&o.testrunNamePrefix, "testrun-prefix", "default-", "Testrun name prefix which is used to generate a unique testrun name.")
-	fs.StringVarP(&o.testrunnerConfig.Namespace, "namespace", "n", "default", "Namesapce where the testrun should be deployed.")
+	fs.StringVarP(&o.testrunnerConfig.Namespace, "namespace", "n", "default", "Namespace where the testrun should be deployed.")
 	fs.Int64Var(&o.timeout, "timeout", 3600, "Timout in seconds of the testrunner to wait for the complete testrun to finish.")
 	fs.IntVar(&o.testrunnerConfig.FlakeAttempts, "testrun-flake-attempts", 0, "Max number of testruns until testrun is successful")
 	fs.BoolVar(&o.failOnError, "fail-on-error", true, "Testrunners exits with 1 if one testruns failed.")
@@ -176,7 +176,7 @@ func (o *options) AddFlags(fs *pflag.FlagSet) error {
 	fs.StringArrayVar(&o.shootParameters.SetValues, "set", make([]string, 0), "sets additional helm values")
 	fs.StringArrayVarP(&o.shootParameters.FileValues, "values", "f", make([]string, 0), "yaml value files to override template values")
 
-	fs.StringVar(&o.postToGitHubStepSummary, "post-to-github-step-summary", "", "Path to the GitHub Actions Step Summary file. If set, the testrun summary will be appended to this file.")
+	fs.StringVar(&o.summaryFilePath, "summary-file-path", "", "Path to a summary file. If set, the testrun summary will be appended to this file.")
 
 	// DEPRECATED FLAGS
 	// is now handled by the testmachinery

--- a/cmd/testrunner/cmd/run_template/run_template.go
+++ b/cmd/testrunner/cmd/run_template/run_template.go
@@ -63,7 +63,7 @@ func NewRunTemplateCommand() (*cobra.Command, error) {
 func (o *options) run(ctx context.Context) error {
 	logger.Log.Info("Start testmachinery testrunner")
 
-	logger.SetupGitHubStepSummary(o.postToGitHubStepSummary)
+	logger.InitializeSummarySetup(o.summaryFilePath)
 
 	runs, err := testrunnerTemplate.RenderTestruns(ctx, logger.Log.WithName("Render"), &o.shootParameters, o.shootFlavors)
 	if err != nil {

--- a/cmd/testrunner/cmd/run_testrun/options.go
+++ b/cmd/testrunner/cmd/run_testrun/options.go
@@ -24,10 +24,8 @@ type options struct {
 	tmKubeconfigPath     string
 	testrunPath          string
 	testrunFlakeAttempts int
-
-	timeout time.Duration
-
-	postToGitHubStepSummary string
+	timeout              time.Duration
+	summaryFilePath      string
 }
 
 // NewOptions creates a new options struct.
@@ -62,7 +60,7 @@ func (o *options) AddFlags(fs *pflag.FlagSet) error {
 
 	fs.StringVar(&o.tmKubeconfigPath, "tm-kubeconfig-path", "", "Path to the testmachinery cluster kubeconfig")
 	fs.StringVar(&o.testrunNamePrefix, "testrun-prefix", "default-", "Testrun name prefix which is used to generate a unique testrun name.")
-	fs.StringVarP(&o.testrunnerConfig.Namespace, "namespace", "n", "default", "Namesapce where the testrun should be deployed.")
+	fs.StringVarP(&o.testrunnerConfig.Namespace, "namespace", "n", "default", "Namespace where the testrun should be deployed.")
 	fs.DurationVar(&o.timeout, "timeout", 1*time.Hour, "Timout in seconds of the testrunner to wait for the complete testrun to finish.")
 	fs.IntVar(&o.testrunFlakeAttempts, "testrun-flake-attempts", 0, "Max number of testruns until testrun is successful")
 	fs.BoolVar(&o.testrunnerConfig.NoExecutionGroup, "no-execution-group", false, "do not inject a execution group id into testruns")
@@ -73,7 +71,7 @@ func (o *options) AddFlags(fs *pflag.FlagSet) error {
 	fs.DurationVar(&o.testrunnerConfig.BackoffPeriod, "backoff-period", 0, "Time to wait between the creation of testrun buckets")
 	fs.DurationVar(o.watchOptions.PollInterval, "poll-interval", time.Minute, "poll interval of the underlaying watch")
 
-	fs.StringVar(&o.postToGitHubStepSummary, "post-to-github-step-summary", "", "Path to the GitHub Actions Step Summary file. If set, the testrun summary will be appended to this file.")
+	fs.StringVar(&o.summaryFilePath, "summary-file-path", "", "Path to a summary file. If set, the testrun summary will be appended to this file.")
 
 	// DEPRECATED FLAGS
 	// is now handled by the testmachinery

--- a/cmd/testrunner/cmd/run_testrun/run_testrun.go
+++ b/cmd/testrunner/cmd/run_testrun/run_testrun.go
@@ -54,7 +54,7 @@ func NewRunTestrunCommand() (*cobra.Command, error) {
 func (o *options) run(ctx context.Context) error {
 	logger.Log.Info("start testmachinery testrunner")
 
-	logger.SetupGitHubStepSummary(o.postToGitHubStepSummary)
+	logger.InitializeSummarySetup(o.summaryFilePath)
 
 	watcher, err := watch.NewFromFile(logger.Log, o.tmKubeconfigPath, &o.watchOptions)
 	if err != nil {

--- a/pkg/logger/helper.go
+++ b/pkg/logger/helper.go
@@ -17,24 +17,24 @@ func Logf(logFunc func(msg string, keysAndValues ...interface{}), format string,
 }
 
 var (
-	ghaSummaryFileName   string
-	ghaSummaryFileExists bool
-	fileWriterMutex      sync.Mutex
-	setupOnce            sync.Once
+	summaryFileName   string
+	summaryFileExists bool
+	fileWriterMutex   sync.Mutex
+	setupOnce         sync.Once
 )
 
-func SetupGitHubStepSummary(file string) {
+func InitializeSummarySetup(file string) {
 	onceFunc := func() {
 		if file != "" {
-			ghaSummaryFileExists = true
-			ghaSummaryFileName = filepath.Clean(file)
+			summaryFileExists = true
+			summaryFileName = filepath.Clean(file)
 		}
 	}
 	setupOnce.Do(onceFunc)
 }
 
-func PostToGitHubStepSummary(message string, append bool) error {
-	if ghaSummaryFileExists {
+func PostToSummaryFile(message string, append bool) error {
+	if summaryFileExists {
 		fileWriterMutex.Lock()
 		defer fileWriterMutex.Unlock()
 
@@ -44,11 +44,11 @@ func PostToGitHubStepSummary(message string, append bool) error {
 		} else {
 			flags = os.O_CREATE | os.O_WRONLY | os.O_TRUNC
 		}
-		file, err := os.OpenFile(ghaSummaryFileName, flags, 0600) // #nosec G304 -- input is derived form a user's input
+		file, err := os.OpenFile(summaryFileName, flags, 0600) // #nosec G304 -- input is derived form a user's input
 		defer func(file *os.File) {
 			err := file.Close()
 			if err != nil {
-				fmt.Printf("Could not close file %s: %v\n", ghaSummaryFileName, err)
+				fmt.Printf("Could not close file %s: %v\n", summaryFileName, err)
 			}
 		}(file)
 		if err != nil {

--- a/pkg/testrunner/list.go
+++ b/pkg/testrunner/list.go
@@ -72,8 +72,8 @@ func (rl RunList) Run(log logr.Logger, config *Config, testrunNamePrefix string,
 		} else {
 			tmDashboardURL = GetTmDashboardURLFromHostForExecutionGroup(TMDashboardHost, executiongroupID)
 			log.Info(fmt.Sprintf("TestMachinery Dashboard: %s", tmDashboardURL))
-			if err := logger.PostToGitHubStepSummary(fmt.Sprintf("## [TestMachinery dashboard for execution group %s](%s)", executiongroupID, tmDashboardURL), true); err != nil {
-				log.Error(err, "unable to post TestMachinery Dashboard URL to GitHub Step Summary")
+			if err := logger.PostToSummaryFile(fmt.Sprintf("## [TestMachinery dashboard for execution group %s](%s)", executiongroupID, tmDashboardURL), true); err != nil {
+				log.Error(err, "unable to post TestMachinery Dashboard URL to the Summary File")
 			}
 		}
 	}
@@ -139,8 +139,8 @@ func (rl RunList) Run(log logr.Logger, config *Config, testrunNamePrefix string,
 	log.Info("All testruns completed.")
 
 	if tmDashboardURL != "" && executiongroupID != "" {
-		if err := logger.PostToGitHubStepSummary(fmt.Sprintf("## [TestMachinery dashboard for execution group %s](%s)", executiongroupID, tmDashboardURL), false); err != nil {
-			log.Error(err, "unable to post TestMachinery Dashboard URL to GitHub Step Summary")
+		if err := logger.PostToSummaryFile(fmt.Sprintf("## [TestMachinery dashboard for execution group %s](%s)", executiongroupID, tmDashboardURL), false); err != nil {
+			log.Error(err, "unable to post TestMachinery Dashboard URL to the Summary File")
 		}
 	}
 

--- a/pkg/testrunner/result/collect.go
+++ b/pkg/testrunner/result/collect.go
@@ -56,7 +56,7 @@ func (c *Collector) Collect(ctx context.Context, log logr.Logger, tmClient clien
 		log.Error(err, "error while posting notification on slack")
 	}
 	fmt.Println(runs.RenderTable())
-	if err := logger.PostToGitHubStepSummary(runs.RenderTableWithSymbols(tw.StyleMarkdown), true); err != nil {
+	if err := logger.PostToSummaryFile(runs.RenderTableWithSymbols(tw.StyleMarkdown), true); err != nil {
 		log.Error(err, "unable to post summary to github step summary")
 	}
 

--- a/pkg/testrunner/run.go
+++ b/pkg/testrunner/run.go
@@ -74,8 +74,8 @@ func (r *Run) Exec(log logr.Logger, config *Config, prefix string) {
 
 	if TMDashboardHost, err := GetTMDashboardHost(config.Watch.Client()); err == nil {
 		log.Info(fmt.Sprintf("TestMachinery Dashboard for Testrun %s: %s", r.Testrun.Name, GetTmDashboardURLFromHostForTestrun(TMDashboardHost, r.Testrun)))
-		if err := logger.PostToGitHubStepSummary(fmt.Sprintf("[TestMachinery Dashboard for Testrun %s](%s)", r.Testrun.Name, GetTmDashboardURLFromHostForTestrun(TMDashboardHost, r.Testrun)), true); err != nil {
-			log.Error(err, "unable to post TestMachinery Dashboard URL to GitHub Step Summary")
+		if err := logger.PostToSummaryFile(fmt.Sprintf("[TestMachinery Dashboard for Testrun %s](%s)", r.Testrun.Name, GetTmDashboardURLFromHostForTestrun(TMDashboardHost, r.Testrun)), true); err != nil {
+			log.Error(err, "unable to post TestMachinery Dashboard URL to the Summary file")
 		}
 	}
 	if argoUrl, err := GetArgoURL(ctx, config.Watch.Client(), r.Testrun); err == nil {
@@ -99,7 +99,7 @@ func (r *Run) Exec(log logr.Logger, config *Config, prefix string) {
 	}
 
 	fmt.Println(RunList{r}.RenderTable())
-	if err := logger.PostToGitHubStepSummary(RunList{r}.RenderTableWithSymbols(tw.StyleMarkdown), true); err != nil {
-		log.Error(err, "unable to post testrun result to GitHub Step Summary")
+	if err := logger.PostToSummaryFile(RunList{r}.RenderTableWithSymbols(tw.StyleMarkdown), true); err != nil {
+		log.Error(err, "unable to post testrun result to the Summary file")
 	}
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind task

**What this PR does / why we need it**:
The flag in Testrunner that point to a summary file (needed to write updates to a GitHub Actions step summary file) has been renamed to use a more generic language.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
