### PR TITLE
Updated OCM mappings for helm charts

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -99,11 +99,23 @@ jobs:
               attribute: tm.images.prepare.repository
             - ref: ocm-resource:tm-prepare-image.tag
               attribute: tm.images.prepare.tag
+            - ref: ocm-resource:valitail.repository
+              attribute: logging.valitail.image.repository
+            - ref: ocm-resource:valitail.tag
+              attribute: logging.valitail.image.tag
+            - ref: ocm-resource:vali.repository
+              attribute: logging.vali.image.repository
+            - ref: ocm-resource:vali.tag
+              attribute: logging.vali.image.tag
 
           - name: testmachinery-bot
             dir: charts/tm-bot
             oci-repository: testmachinery/charts
-            ocm-mappings: []
+            ocm-mappings:
+            - ref: ocm-resource:tm-bot.repository
+              attribute: bot.image
+            - ref: ocm-resource:tm-bot.tag
+              attribute: bot.tag
 
     with:
       name: ${{ matrix.args.name }}

--- a/.ocm/resources.yaml
+++ b/.ocm/resources.yaml
@@ -7,3 +7,9 @@
 - name: argo-server
   imageReference: quay.io/argoproj/argocli:v3.6.12
   version: v3.6.12
+- name: vali
+  imageReference: europe-docker.pkg.dev/gardener-project/releases/3rd/credativ/vali:v2.2.28
+  version: v2.2.28
+- name: valitail
+  imageReference: europe-docker.pkg.dev/gardener-project/releases/3rd/credativ/valitail:v2.2.28
+  version: v2.2.28

--- a/charts/testmachinery/values.yaml
+++ b/charts/testmachinery/values.yaml
@@ -183,10 +183,10 @@ logging:
   valitail:
     image:
       repository: europe-docker.pkg.dev/gardener-project/releases/3rd/credativ/valitail
-      tag: v2.2.21
+      tag: v2.2.28
   vali:
     image:
       repository: europe-docker.pkg.dev/gardener-project/releases/3rd/credativ/vali
-      tag: v2.2.21
+      tag: v2.2.28
     persistence:
       storageClassName: default


### PR DESCRIPTION


**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind task

**What this PR does / why we need it**:

Includes an updated OCM mapping for the testmachinery bot chart and add vali/valitail as resources.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/invite @zkdev @IndritFejza @dguendisch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
