### PR TITLE
Build / test from trusted PRs

### DIFF
--- a/.github/workflows/non-release.yaml
+++ b/.github/workflows/non-release.yaml
@@ -2,9 +2,13 @@ name: Build
 on:
   push:
   pull_request:
+  pull_request_target:
+    types:
+      - labeled
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request_target' || (github.event_name == 'pull_request_target' && github.event.label.name == 'reviewed/ok-to-test') }}
     uses: ./.github/workflows/build.yaml
     with:
       mode: snapshot
@@ -13,8 +17,10 @@ jobs:
       contents: write
       packages: write
       id-token: write
+      pull-requests: write
 
   component-descriptor:
+    if: ${{ github.event_name != 'pull_request_target' || (github.event_name == 'pull_request_target' && github.event.label.name == 'reviewed/ok-to-test') }}
     uses: gardener/cc-utils/.github/workflows/post-build.yaml@master
     needs:
       - build

--- a/.github/workflows/pullrequest-trust-helper.yaml.yml
+++ b/.github/workflows/pullrequest-trust-helper.yaml.yml
@@ -1,0 +1,16 @@
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+jobs:
+  pullrequest-trusted-helper:
+    permissions:
+      pull-requests: write
+    secrets: inherit # access to `GitHub-Actions`-App is needed to read teams
+    uses: gardener/cc-utils/.github/workflows/pullrequest-trust-helper.yaml@master
+    with:
+      trusted-teams: 'test-infra-maintainers'


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind task

**What this PR does / why we need it**:

The migration from concourse to GHA dropped support for testing/building artefacts for trusted PRs.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @zkdev @dguendisch @IndritFejza 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
