### PR TITLE
Correct `renovate` `non-gardener` dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -48,7 +48,7 @@
       "groupName": "non-gardener-dependencies",
       "matchPackagePatterns": [".*"],
       "excludePackagePatterns": [
-        "^github\\.com/gardener/gardener/gardener",
+        "^github\\.com/gardener/.+",
         "^github\\.com/argoproj/argo-workflows",
         "^ocm\\.software/ocm",
         "^sigs\\.k8s\\.io/controller-runtime"


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Correct `renovate` `non-gardener` dependencies

**Which issue(s) this PR fixes**:
Currently, renovate also brings in updates to gardener modules.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
