### PR TITLE
add ingressClassName to Argo + TM-bot ingress templates

### DIFF
--- a/charts/testmachinery/charts/argo/templates/ingress.yaml
+++ b/charts/testmachinery/charts/argo/templates/ingress.yaml
@@ -25,6 +25,7 @@ metadata:
   name: {{ .Values.argoserver.ingress.name }}
   namespace: {{ .Release.Namespace }}
 spec:
+  ingressClassName: {{ default "nginx" .Values.argoserver.ingress.ingressClassName }}
   rules:
     - host: {{ .Values.argoserver.ingress.host }}
       http:

--- a/charts/testmachinery/charts/argo/values.yaml
+++ b/charts/testmachinery/charts/argo/values.yaml
@@ -58,6 +58,7 @@ argoserver:
     host: ""
     annotations: { }
     labels: { }
+    ingressClassName: "nginx"
   serviceType: ClusterIP
 
 objectStorage:

--- a/charts/testmachinery/charts/logging/charts/vali/templates/ingress.yaml
+++ b/charts/testmachinery/charts/logging/charts/vali/templates/ingress.yaml
@@ -21,6 +21,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  ingressClassName: {{ default "nginx" .Values.ingress.ingressClassName }}
 {{- if .Values.ingress.tls }}
   tls:
   {{- range .Values.ingress.tls }}

--- a/charts/testmachinery/charts/logging/charts/vali/values.yaml
+++ b/charts/testmachinery/charts/logging/charts/vali/values.yaml
@@ -25,6 +25,7 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
+  ingressClassName: "nginx"
 
 ## Affinity for pod assignment
 ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity

--- a/charts/tm-bot/templates/ingress.yaml
+++ b/charts/tm-bot/templates/ingress.yaml
@@ -17,6 +17,7 @@ metadata:
     {{ $key }}: {{ $value }}
     {{- end }}
 spec:
+  ingressClassName: {{ default "nginx" .Values.ingress.ingressClassName }}
   tls:
   - hosts:
     - {{ .Values.ingress.host }}

--- a/charts/tm-bot/values.yaml
+++ b/charts/tm-bot/values.yaml
@@ -5,6 +5,7 @@
 ingress:
   host: tm-bot.example.com
   labels: {}
+  ingressClassName: "nginx"
 
 bot:
   image: europe-docker.pkg.dev/gardener-project/releases/testmachinery/bot


### PR DESCRIPTION
We might need to specify directly in the ingress spec what ingress class is used.

If we have 2 ingress controllers in a cluster, the ingress resources needs to have it specifies which controller is responsible for them.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind task

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
