### PR TITLE
Bug fixes

### DIFF
--- a/pkg/tm-bot/github/authorization.go
+++ b/pkg/tm-bot/github/authorization.go
@@ -75,7 +75,7 @@ func (c *client) isInRequestedTeam(ctx context.Context, event *GenericRequestEve
 			c.log.V(3).Info(err.Error(), "team", c.defaultTeam.GetName())
 			return false
 		}
-		if MembershipStatus(membership.GetState()) != MembershipStatusActive {
+		if MembershipStatus(membership.GetState()) == MembershipStatusActive {
 			return true
 		}
 		return false

--- a/pkg/tm-bot/ui/auth/dummyauth.go
+++ b/pkg/tm-bot/ui/auth/dummyauth.go
@@ -27,6 +27,7 @@ func (a *dummyAuth) Protect(handler http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if !a.loggedIn {
 			http.Redirect(w, r, "/404", http.StatusTemporaryRedirect)
+			return
 		}
 		handler(w, r)
 	}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug

**What this PR does / why we need it**:

- Fix a bug with the GH app's commands 
- Add a missing return to the dummy auth provider used in local testing.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/invite @IndritFejza 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
