### PR TITLE
add support for machineCapabilities in CloudProfile spec

### DIFF
--- a/pkg/util/machine_image.go
+++ b/pkg/util/machine_image.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
 	"github.com/pkg/errors"
 	"k8s.io/utils/ptr"
@@ -60,7 +61,7 @@ func GetXMajorsBeforeLatestMachineImageVersion(cloudprofile gardencorev1beta1.Cl
 		return gardencorev1beta1.MachineImageVersion{}, fmt.Errorf("no machine image versions found for cloudprofle %s", cloudprofile.GetName())
 	}
 
-	machineVersions = FilterExpiredMachineImageVersions(FilterArchSpecificMachineImage(machineVersions, arch))
+	machineVersions = FilterExpiredMachineImageVersions(FilterArchSpecificMachineImage(machineVersions, arch, cloudprofile.Spec.MachineCapabilities))
 	if inPlace {
 		machineVersions = FilterInPlaceMachineImageVersions(machineVersions)
 	}
@@ -117,8 +118,17 @@ func GetLatestMachineImageVersion(cloudprofile gardencorev1beta1.CloudProfile, i
 	return GetXMajorsBeforeLatestMachineImageVersion(cloudprofile, imageName, arch, 0, inPlace)
 }
 
-// FilterArchSpecificMachineImage removes all version which doesn't support given architecture.
-func FilterArchSpecificMachineImage(versions []gardencorev1beta1.MachineImageVersion, architecture string) []gardencorev1beta1.MachineImageVersion {
+// FilterArchSpecificMachineImage removes all versions which don't support the given architecture.
+// It first checks whether the CloudProfile declares a global architecture capability via
+// machineCapabilities. If the requested architecture is covered there, all versions are considered
+// compatible (the per-version Architectures field is not used).
+// If no matching machineCapabilities entry exists, the per-version Architectures field is used as before.
+func FilterArchSpecificMachineImage(versions []gardencorev1beta1.MachineImageVersion, architecture string, machineCapabilities []gardencorev1beta1.CapabilityDefinition) []gardencorev1beta1.MachineImageVersion {
+	for _, cap := range machineCapabilities {
+		if cap.Name == v1beta1constants.ArchitectureName && slices.Contains([]string(cap.Values), architecture) {
+			return slices.Clone(versions)
+		}
+	}
 	filtered := make([]gardencorev1beta1.MachineImageVersion, 0)
 	for _, v := range versions {
 		if slices.Contains(v.Architectures, architecture) {
@@ -175,7 +185,7 @@ func GetLatestPreviousVersionForInPlaceUpdate(cloudprofile gardencorev1beta1.Clo
 
 	machineVersions = FilterExpiredMachineImageVersions(
 		FilterInPlaceMachineImageVersions(
-			FilterArchSpecificMachineImage(machineVersions, arch),
+			FilterArchSpecificMachineImage(machineVersions, arch, cloudprofile.Spec.MachineCapabilities),
 		),
 	)
 	if len(machineVersions) == 0 {

--- a/pkg/util/machine_image_test.go
+++ b/pkg/util/machine_image_test.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -97,6 +98,39 @@ var _ = Describe("machine image version", func() {
 			version, err := GetMachineImageVersion(cloudprofile, worker)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(version.Version).To(Equal("1.2.3"))
+		})
+
+		It("should resolve latest version when architectures are declared via machineCapabilities (no per-version architectures field)", func() {
+			// Simulate the AWS CloudProfile format where architectures are declared globally
+			// via spec.machineCapabilities instead of per machine image version.
+			cloudprofile.Spec.MachineCapabilities = []gardencorev1beta1.CapabilityDefinition{
+				{
+					Name:   v1beta1constants.ArchitectureName,
+					Values: gardencorev1beta1.CapabilityValues{arch_amd64, arch_arm64},
+				},
+			}
+			for i := range cloudprofile.Spec.MachineImages[0].Versions {
+				cloudprofile.Spec.MachineImages[0].Versions[i].Architectures = nil
+			}
+			version, err := GetMachineImageVersion(cloudprofile, worker)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(version.Version).To(Equal("3.4.5"))
+		})
+
+		It("should fail to resolve when machineCapabilities does not list the requested architecture", func() {
+			cloudprofile.Spec.MachineCapabilities = []gardencorev1beta1.CapabilityDefinition{
+				{
+					Name:   v1beta1constants.ArchitectureName,
+					Values: gardencorev1beta1.CapabilityValues{arch_amd64},
+				},
+			}
+			for i := range cloudprofile.Spec.MachineImages[0].Versions {
+				cloudprofile.Spec.MachineImages[0].Versions[i].Architectures = nil
+			}
+			worker.Machine.Architecture = ptr.To(arch_arm64)
+			_, err := GetMachineImageVersion(cloudprofile, worker)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no machine image versions found"))
 		})
 	})
 
@@ -193,6 +227,75 @@ var _ = Describe("machine image version", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(version.Version).To(Equal("3.2.4"))
 
+		})
+	})
+
+	Describe("#FilterArchSpecificMachineImage", func() {
+		var versions []gardencorev1beta1.MachineImageVersion
+
+		BeforeEach(func() {
+			versions = []gardencorev1beta1.MachineImageVersion{
+				{ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "1.0.0"}, Architectures: []string{arch_amd64}},
+				{ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "2.0.0"}, Architectures: []string{arch_amd64, arch_arm64}},
+				{ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "3.0.0"}, Architectures: []string{arch_arm64}},
+			}
+		})
+
+		It("should filter versions by per-version architectures when machineCapabilities is nil", func() {
+			result := FilterArchSpecificMachineImage(versions, arch_amd64, nil)
+			Expect(result).To(HaveLen(2))
+			Expect(result[0].Version).To(Equal("1.0.0"))
+			Expect(result[1].Version).To(Equal("2.0.0"))
+		})
+
+		It("should return all versions when machineCapabilities declares the requested architecture", func() {
+			caps := []gardencorev1beta1.CapabilityDefinition{
+				{
+					Name:   v1beta1constants.ArchitectureName,
+					Values: gardencorev1beta1.CapabilityValues{arch_amd64, arch_arm64},
+				},
+			}
+			// Versions have no per-version architectures (AWS-style)
+			for i := range versions {
+				versions[i].Architectures = nil
+			}
+			result := FilterArchSpecificMachineImage(versions, arch_amd64, caps)
+			Expect(result).To(HaveLen(3))
+		})
+
+		It("should return a new slice when machineCapabilities match, not the original", func() {
+			caps := []gardencorev1beta1.CapabilityDefinition{
+				{
+					Name:   v1beta1constants.ArchitectureName,
+					Values: gardencorev1beta1.CapabilityValues{arch_amd64},
+				},
+			}
+			for i := range versions {
+				versions[i].Architectures = nil
+			}
+			result := FilterArchSpecificMachineImage(versions, arch_amd64, caps)
+			Expect(&result[0]).ToNot(BeIdenticalTo(&versions[0]))
+		})
+
+		It("should fall through to per-version filter when machineCapabilities does not list the requested architecture", func() {
+			caps := []gardencorev1beta1.CapabilityDefinition{
+				{
+					Name:   v1beta1constants.ArchitectureName,
+					Values: gardencorev1beta1.CapabilityValues{arch_amd64},
+				},
+			}
+			result := FilterArchSpecificMachineImage(versions, arch_arm64, caps)
+			Expect(result).To(HaveLen(2))
+			Expect(result[0].Version).To(Equal("2.0.0"))
+			Expect(result[1].Version).To(Equal("3.0.0"))
+		})
+
+		It("should return empty when no versions match the architecture and machineCapabilities is nil", func() {
+			for i := range versions {
+				versions[i].Architectures = nil
+			}
+			result := FilterArchSpecificMachineImage(versions, arch_amd64, nil)
+			Expect(result).To(BeEmpty())
 		})
 	})
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->
Based on GEP33: https://github.com/gardener/gardener/issues/11301 /  https://github.com/gardener/gardener-extension-provider-aws/pull/1645 we need to add support here so the architecture can be parsed correctly.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add parsing support fro architecture from cp.spec.machineCapabilities
```

/kind task