### PR TITLE
remove wrapper fx GetLatestMachineImageVersion

### DIFF
--- a/pkg/util/machine_image.go
+++ b/pkg/util/machine_image.go
@@ -34,8 +34,8 @@ func GetMachineImageVersion(cloudprofile gardencorev1beta1.CloudProfile, worker 
 				Version: version,
 			},
 		}
-	case common.PatternLatest:
-		machineImageVersion, err = GetLatestMachineImageVersion(cloudprofile, imageName, arch, inPlace)
+	case common.PatternLatest: // get the latest available machine image version from the cloudprofile
+		machineImageVersion, err = GetXMajorsBeforeLatestMachineImageVersion(cloudprofile, imageName, arch, 0, inPlace)
 	case common.PatternOneMajorBeforeLatest:
 		machineImageVersion, err = GetXMajorsBeforeLatestMachineImageVersion(cloudprofile, imageName, arch, 1, inPlace)
 	case common.PatternTwoMajorBeforeLatest:
@@ -110,11 +110,6 @@ func getXMajorsBeforeLatestMachineImageVersion(rawVersions []gardencorev1beta1.M
 		}
 	}
 	return gardencorev1beta1.MachineImageVersion{}, errors.New(fmt.Sprintf("no machine image version matching the pattern latest-%d found", x))
-}
-
-// GetLatestMachineImageVersion returns the latest available machine image version from the cloudprofile
-func GetLatestMachineImageVersion(cloudprofile gardencorev1beta1.CloudProfile, imageName, arch string, inPlace bool) (gardencorev1beta1.MachineImageVersion, error) {
-	return GetXMajorsBeforeLatestMachineImageVersion(cloudprofile, imageName, arch, 0, inPlace)
 }
 
 // FilterArchSpecificMachineImage removes all version which doesn't support given architecture.


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->
remove GetLatestMachineImageVersion wrapper function as its not adding value

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind task

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
GetLatestMachineImageVersion is no longer supported from util pkg
```
