### PR TITLE
Derive machine image architectures from cloudprofile providerConfig

### DIFF
--- a/pkg/shootflavors/extendedflavors_test.go
+++ b/pkg/shootflavors/extendedflavors_test.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/test-infra/pkg/common"
+	"github.com/gardener/test-infra/pkg/util"
 )
 
 var _ = Describe("extended flavor test", func() {
@@ -64,6 +65,10 @@ var _ = Describe("extended flavor test", func() {
 						Versions: MachineImageVersions(map[string][]string{"0.0.4": {"arm64"}, "0.0.3": {"arm64"}}),
 					},
 				},
+				ProviderConfig: util.BuildCapabilityProviderConfig(util.ArchsByImage{
+					"test-os":   {"0.0.2": {"amd64"}, "0.0.1": {"amd64"}},
+					"test-os-2": {"0.0.4": {"arm64"}, "0.0.3": {"arm64"}},
+				}),
 			},
 		}
 	})

--- a/pkg/util/machine_image.go
+++ b/pkg/util/machine_image.go
@@ -1,8 +1,8 @@
 package util
 
 import (
+	"encoding/json"
 	"fmt"
-	"slices"
 	"sort"
 	"time"
 
@@ -10,10 +10,149 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
 	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 
 	"github.com/gardener/test-infra/pkg/common"
 )
+
+// providerConfigMachineImages models the subset of
+// cloudprofile.Spec.ProviderConfig that carries machine-image architecture
+// info. The capabilities format is the target schema; the region and flat
+// formats are legacy and can be dropped once all providers have migrated.
+type providerConfigMachineImages struct {
+	MachineImages []providerConfigMachineImage `json:"machineImages"`
+}
+
+type providerConfigMachineImage struct {
+	Name     string                              `json:"name"`
+	Versions []providerConfigMachineImageVersion `json:"versions"`
+}
+
+type providerConfigMachineImageVersion struct {
+	Version string `json:"version"`
+
+	// Capabilities format (target schema):
+	//   versions[].capabilityFlavors[].capabilities.architecture
+	CapabilityFlavors []providerConfigCapabilityFlavor `json:"capabilityFlavors,omitempty"`
+
+	// --- Legacy formats: remove once migration to capability flavors is complete. ---
+	// Flat format:   versions[].architecture (singular; version may repeat per arch)
+	Architecture string `json:"architecture,omitempty"`
+	// Region format: versions[].regions[].architecture
+	Regions []providerConfigRegion `json:"regions,omitempty"`
+	// --- End legacy formats. ---
+}
+
+type providerConfigRegion struct {
+	Architecture string `json:"architecture"`
+}
+
+type providerConfigCapabilityFlavor struct {
+	Capabilities providerConfigCapabilities `json:"capabilities"`
+}
+
+type providerConfigCapabilities struct {
+	Architecture []string `json:"architecture"`
+}
+
+// FilterMachineImageVersionsByArch returns versions of imageName that support
+// the given architecture, based on cloudprofile.Spec.ProviderConfig. If
+// cloudprofile.Spec.MachineCapabilities defines "architecture" with exactly
+// one value, every version is considered to support that single arch and the
+// providerConfig is not consulted.
+func FilterMachineImageVersionsByArch(cloudprofile gardencorev1beta1.CloudProfile, imageName string, versions []gardencorev1beta1.MachineImageVersion, architecture string) []gardencorev1beta1.MachineImageVersion {
+	if implicitArch := singleValuedArchitectureCapability(cloudprofile); implicitArch != "" {
+		if implicitArch != architecture {
+			return []gardencorev1beta1.MachineImageVersion{}
+		}
+		filtered := make([]gardencorev1beta1.MachineImageVersion, len(versions))
+		copy(filtered, versions)
+		return filtered
+	}
+
+	supportedVersions := supportedArchsByVersion(cloudprofile, imageName)
+	filtered := make([]gardencorev1beta1.MachineImageVersion, 0, len(versions))
+	for _, v := range versions {
+		if archs, ok := supportedVersions[v.Version]; ok && archs.Has(architecture) {
+			filtered = append(filtered, v)
+		}
+	}
+	return filtered
+}
+
+// supportedArchsByVersion returns version -> supported archs for imageName,
+// decoded from cloudprofile.Spec.ProviderConfig.
+func supportedArchsByVersion(cloudprofile gardencorev1beta1.CloudProfile, imageName string) map[string]sets.Set[string] {
+	lookup := make(map[string]sets.Set[string])
+
+	if cloudprofile.Spec.ProviderConfig == nil || len(cloudprofile.Spec.ProviderConfig.Raw) == 0 {
+		return lookup
+	}
+
+	var decoded providerConfigMachineImages
+	if err := json.Unmarshal(cloudprofile.Spec.ProviderConfig.Raw, &decoded); err != nil {
+		return lookup
+	}
+
+	for _, image := range decoded.MachineImages {
+		if image.Name != imageName {
+			continue
+		}
+		for _, v := range image.Versions {
+			archs, ok := lookup[v.Version]
+			if !ok {
+				archs = sets.New[string]()
+			}
+			archs.Insert(archsFromCapabilityFlavors(v)...)
+			archs.Insert(archsFromLegacyFormats(v)...)
+			if archs.Len() > 0 {
+				lookup[v.Version] = archs
+			}
+		}
+	}
+	return lookup
+}
+
+// archsFromCapabilityFlavors extracts architectures from the capability-flavor
+// (target) format on a single providerConfig version entry.
+func archsFromCapabilityFlavors(v providerConfigMachineImageVersion) []string {
+	archs := make([]string, 0)
+	for _, flavor := range v.CapabilityFlavors {
+		archs = append(archs, flavor.Capabilities.Architecture...)
+	}
+	return archs
+}
+
+// archsFromLegacyFormats extracts architectures from the legacy region and
+// flat formats on a single providerConfig version entry. Remove this function
+// (and its call site) once all providers have migrated to capability flavors.
+func archsFromLegacyFormats(v providerConfigMachineImageVersion) []string {
+	archs := make([]string, 0)
+	for _, region := range v.Regions {
+		archs = append(archs, region.Architecture)
+	}
+	if v.Architecture != "" {
+		archs = append(archs, v.Architecture)
+	}
+	return archs
+}
+
+// singleValuedArchitectureCapability returns the sole value of the
+// "architecture" entry in cloudprofile.Spec.MachineCapabilities, or "" if it
+// is missing or has zero/multiple values.
+func singleValuedArchitectureCapability(cloudprofile gardencorev1beta1.CloudProfile) string {
+	for _, def := range cloudprofile.Spec.MachineCapabilities {
+		if def.Name != "architecture" {
+			continue
+		}
+		if len(def.Values) == 1 {
+			return def.Values[0]
+		}
+		return ""
+	}
+	return ""
+}
 
 // GetMachineImageVersion returns a version identified by a pattern or defaults to the version string handed over
 func GetMachineImageVersion(cloudprofile gardencorev1beta1.CloudProfile, worker *gardencorev1beta1.Worker) (gardencorev1beta1.MachineImageVersion, error) {
@@ -60,7 +199,7 @@ func GetXMajorsBeforeLatestMachineImageVersion(cloudprofile gardencorev1beta1.Cl
 		return gardencorev1beta1.MachineImageVersion{}, fmt.Errorf("no machine image versions found for cloudprofle %s", cloudprofile.GetName())
 	}
 
-	machineVersions = FilterExpiredMachineImageVersions(FilterArchSpecificMachineImage(machineVersions, arch))
+	machineVersions = FilterExpiredMachineImageVersions(FilterMachineImageVersionsByArch(cloudprofile, imageName, machineVersions, arch))
 	if inPlace {
 		machineVersions = FilterInPlaceMachineImageVersions(machineVersions)
 	}
@@ -117,17 +256,6 @@ func GetLatestMachineImageVersion(cloudprofile gardencorev1beta1.CloudProfile, i
 	return GetXMajorsBeforeLatestMachineImageVersion(cloudprofile, imageName, arch, 0, inPlace)
 }
 
-// FilterArchSpecificMachineImage removes all version which doesn't support given architecture.
-func FilterArchSpecificMachineImage(versions []gardencorev1beta1.MachineImageVersion, architecture string) []gardencorev1beta1.MachineImageVersion {
-	filtered := make([]gardencorev1beta1.MachineImageVersion, 0)
-	for _, v := range versions {
-		if slices.Contains(v.Architectures, architecture) {
-			filtered = append(filtered, v)
-		}
-	}
-	return filtered
-}
-
 // FilterInPlaceMachineImageVersions filters the machine image versions to only include those that support in-place updates.
 func FilterInPlaceMachineImageVersions(versions []gardencorev1beta1.MachineImageVersion) []gardencorev1beta1.MachineImageVersion {
 	filtered := make([]gardencorev1beta1.MachineImageVersion, 0)
@@ -175,7 +303,7 @@ func GetLatestPreviousVersionForInPlaceUpdate(cloudprofile gardencorev1beta1.Clo
 
 	machineVersions = FilterExpiredMachineImageVersions(
 		FilterInPlaceMachineImageVersions(
-			FilterArchSpecificMachineImage(machineVersions, arch),
+			FilterMachineImageVersionsByArch(cloudprofile, currentMachineImage.Name, machineVersions, arch),
 		),
 	)
 	if len(machineVersions) == 0 {

--- a/pkg/util/machine_image.go
+++ b/pkg/util/machine_image.go
@@ -127,9 +127,15 @@ func archsFromCapabilityFlavors(v providerConfigMachineImageVersion) []string {
 // archsFromLegacyFormats extracts architectures from the legacy region and
 // flat formats on a single providerConfig version entry. Remove this function
 // (and its call site) once all providers have migrated to capability flavors.
+//
+// Region entries without an explicit architecture default to amd64.
 func archsFromLegacyFormats(v providerConfigMachineImageVersion) []string {
 	archs := make([]string, 0)
 	for _, region := range v.Regions {
+		if region.Architecture == "" {
+			archs = append(archs, "amd64")
+			continue
+		}
 		archs = append(archs, region.Architecture)
 	}
 	if v.Architecture != "" {

--- a/pkg/util/machine_image_test.go
+++ b/pkg/util/machine_image_test.go
@@ -394,6 +394,13 @@ var _ = Describe("machine image version", func() {
 					"3.0.0": {arch_amd64, arch_arm64},
 				}),
 				[]string{"1.0.0", "3.0.0"}, []string{"2.0.0", "3.0.0"}),
+			Entry("region format defaults missing region.architecture to amd64",
+				regionFormatProviderConfig(imageName, map[string][]string{
+					"1.0.0": {""}, // single region, no architecture set
+					"2.0.0": {arch_arm64},
+					"3.0.0": {"", arch_arm64}, // mixed: empty + explicit arm64
+				}),
+				[]string{"1.0.0", "3.0.0"}, []string{"2.0.0", "3.0.0"}),
 			Entry("flat format with duplicate version entries",
 				flatFormatProviderConfig(imageName, map[string][]string{
 					"1.0.0": {arch_amd64},

--- a/pkg/util/machine_image_test.go
+++ b/pkg/util/machine_image_test.go
@@ -1,12 +1,14 @@
 package util
 
 import (
+	"encoding/json"
 	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
 
 	"github.com/gardener/test-infra/pkg/common"
@@ -17,6 +19,82 @@ const (
 	arch_amd64 = "amd64"
 	arch_arm64 = "arm64"
 )
+
+// regionFormatProviderConfig builds a RawExtension in the per-region format,
+// emitting one region entry per architecture per version.
+//
+// Legacy: remove once migration to capability flavors is complete.
+func regionFormatProviderConfig(imageName string, archsByVersion map[string][]string) *runtime.RawExtension {
+	versions := make([]providerConfigMachineImageVersion, 0, len(archsByVersion))
+	for version, archs := range archsByVersion {
+		regions := make([]providerConfigRegion, 0, len(archs))
+		for _, a := range archs {
+			regions = append(regions, providerConfigRegion{Architecture: a})
+		}
+		versions = append(versions, providerConfigMachineImageVersion{
+			Version: version,
+			Regions: regions,
+		})
+	}
+	cfg := providerConfigMachineImages{
+		MachineImages: []providerConfigMachineImage{
+			{Name: imageName, Versions: versions},
+		},
+	}
+	raw, err := json.Marshal(cfg)
+	Expect(err).ToNot(HaveOccurred())
+	return &runtime.RawExtension{Raw: raw}
+}
+
+// flatFormatProviderConfig builds a RawExtension in the flat format,
+// duplicating each version once per architecture.
+//
+// Legacy: remove once migration to capability flavors is complete.
+func flatFormatProviderConfig(imageName string, archsByVersion map[string][]string) *runtime.RawExtension {
+	versions := make([]providerConfigMachineImageVersion, 0)
+	for version, archs := range archsByVersion {
+		for _, a := range archs {
+			versions = append(versions, providerConfigMachineImageVersion{
+				Version:      version,
+				Architecture: a,
+			})
+		}
+	}
+	cfg := providerConfigMachineImages{
+		MachineImages: []providerConfigMachineImage{
+			{Name: imageName, Versions: versions},
+		},
+	}
+	raw, err := json.Marshal(cfg)
+	Expect(err).ToNot(HaveOccurred())
+	return &runtime.RawExtension{Raw: raw}
+}
+
+// capabilityProviderConfigMultiFlavor builds a capability-flavor RawExtension
+// emitting one flavor per architecture per version.
+func capabilityProviderConfigMultiFlavor(imageName string, archsByVersion map[string][]string) *runtime.RawExtension {
+	versions := make([]providerConfigMachineImageVersion, 0, len(archsByVersion))
+	for version, archs := range archsByVersion {
+		flavors := make([]providerConfigCapabilityFlavor, 0, len(archs))
+		for _, a := range archs {
+			flavors = append(flavors, providerConfigCapabilityFlavor{
+				Capabilities: providerConfigCapabilities{Architecture: []string{a}},
+			})
+		}
+		versions = append(versions, providerConfigMachineImageVersion{
+			Version:           version,
+			CapabilityFlavors: flavors,
+		})
+	}
+	cfg := providerConfigMachineImages{
+		MachineImages: []providerConfigMachineImage{
+			{Name: imageName, Versions: versions},
+		},
+	}
+	raw, err := json.Marshal(cfg)
+	Expect(err).ToNot(HaveOccurred())
+	return &runtime.RawExtension{Raw: raw}
+}
 
 var _ = Describe("machine image version", func() {
 	var (
@@ -35,6 +113,12 @@ var _ = Describe("machine image version", func() {
 			futureTime = metav1.NewTime(time.Now().Add(time.Hour * 24))
 			cloudprofile = gardencorev1beta1.CloudProfile{
 				Spec: gardencorev1beta1.CloudProfileSpec{
+					ProviderConfig: BuildCapabilityProviderConfig(ArchsByImage{imageName: {
+						"3.4.5": {arch_amd64, arch_arm64},
+						"2.3.3": {arch_amd64, arch_arm64},
+						"2.3.4": {arch_amd64, arch_arm64},
+						"4.5.6": {arch_amd64, arch_arm64},
+					}}),
 					MachineImages: []gardencorev1beta1.MachineImage{
 						{
 							Name: imageName,
@@ -42,19 +126,19 @@ var _ = Describe("machine image version", func() {
 								{ExpirableVersion: gardencorev1beta1.ExpirableVersion{
 									Version:        "3.4.5",
 									ExpirationDate: &futureTime,
-								}, Architectures: []string{arch_amd64, arch_arm64}, InPlaceUpdates: &gardencorev1beta1.InPlaceUpdates{Supported: true}},
+								}, InPlaceUpdates: &gardencorev1beta1.InPlaceUpdates{Supported: true}},
 								{ExpirableVersion: gardencorev1beta1.ExpirableVersion{
 									Version:        "2.3.3",
 									ExpirationDate: &futureTime,
-								}, Architectures: []string{arch_amd64, arch_arm64}},
+								}},
 								{ExpirableVersion: gardencorev1beta1.ExpirableVersion{
 									Version:        "2.3.4",
 									ExpirationDate: &futureTime,
-								}, Architectures: []string{arch_amd64, arch_arm64}},
+								}},
 								{ExpirableVersion: gardencorev1beta1.ExpirableVersion{
 									Version:        "4.5.6",
 									ExpirationDate: &expiredTime,
-								}, Architectures: []string{arch_amd64, arch_arm64}},
+								}},
 							},
 						},
 					},
@@ -200,6 +284,12 @@ var _ = Describe("machine image version", func() {
 		BeforeEach(func() {
 			cloudprofile = gardencorev1beta1.CloudProfile{
 				Spec: gardencorev1beta1.CloudProfileSpec{
+					ProviderConfig: BuildCapabilityProviderConfig(ArchsByImage{imageName: {
+						"3.4.5": {arch_amd64},
+						"3.4.0": {arch_amd64},
+						"2.3.3": {arch_amd64},
+						"4.5.6": {arch_amd64},
+					}}),
 					MachineImages: []gardencorev1beta1.MachineImage{
 						{
 							Name: imageName,
@@ -207,19 +297,19 @@ var _ = Describe("machine image version", func() {
 								{ExpirableVersion: gardencorev1beta1.ExpirableVersion{
 									Version:        "3.4.5",
 									ExpirationDate: &futureTime,
-								}, Architectures: []string{arch_amd64}, InPlaceUpdates: &gardencorev1beta1.InPlaceUpdates{Supported: true, MinVersionForUpdate: ptr.To("2.3.0")}},
+								}, InPlaceUpdates: &gardencorev1beta1.InPlaceUpdates{Supported: true, MinVersionForUpdate: ptr.To("2.3.0")}},
 								{ExpirableVersion: gardencorev1beta1.ExpirableVersion{
 									Version:        "3.4.0",
 									ExpirationDate: &futureTime,
-								}, Architectures: []string{arch_amd64}, InPlaceUpdates: &gardencorev1beta1.InPlaceUpdates{Supported: true}},
+								}, InPlaceUpdates: &gardencorev1beta1.InPlaceUpdates{Supported: true}},
 								{ExpirableVersion: gardencorev1beta1.ExpirableVersion{
 									Version:        "2.3.3",
 									ExpirationDate: &futureTime,
-								}, Architectures: []string{arch_amd64}, InPlaceUpdates: &gardencorev1beta1.InPlaceUpdates{Supported: true, MinVersionForUpdate: ptr.To("2.3.0")}},
+								}, InPlaceUpdates: &gardencorev1beta1.InPlaceUpdates{Supported: true, MinVersionForUpdate: ptr.To("2.3.0")}},
 								{ExpirableVersion: gardencorev1beta1.ExpirableVersion{
 									Version:        "4.5.6",
 									ExpirationDate: &expiredTime,
-								}, Architectures: []string{arch_amd64}, InPlaceUpdates: &gardencorev1beta1.InPlaceUpdates{Supported: true}},
+								}, InPlaceUpdates: &gardencorev1beta1.InPlaceUpdates{Supported: true}},
 							},
 						},
 					},
@@ -264,7 +354,127 @@ var _ = Describe("machine image version", func() {
 			cloudprofile.Spec.MachineImages[0].Versions = []gardencorev1beta1.MachineImageVersion{}
 			_, err := GetLatestPreviousVersionForInPlaceUpdate(cloudprofile, currentImage, arch)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("no machine image versions found in cloudprofile " + cloudprofile.GetName()))
+			Expect(err.Error()).To(Equal("no machine image versions found in cloudprofile " + cloudprofile.GetName())) //nolint
+		})
+	})
+
+	Describe("#FilterMachineImageVersionsByArch", func() {
+		versions := []gardencorev1beta1.MachineImageVersion{
+			{ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "1.0.0"}},
+			{ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "2.0.0"}},
+			{ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "3.0.0"}},
+		}
+
+		buildCP := func(providerConfig *runtime.RawExtension, capabilityArchs ...string) gardencorev1beta1.CloudProfile {
+			cp := gardencorev1beta1.CloudProfile{
+				Spec: gardencorev1beta1.CloudProfileSpec{ProviderConfig: providerConfig},
+			}
+			if len(capabilityArchs) > 0 {
+				cp.Spec.MachineCapabilities = []gardencorev1beta1.CapabilityDefinition{
+					{Name: "architecture", Values: gardencorev1beta1.CapabilityValues(capabilityArchs)},
+				}
+			}
+			return cp
+		}
+
+		DescribeTable("filters versions by architecture from providerConfig",
+			func(providerConfig *runtime.RawExtension, expectedAMD64, expectedARM64 []string) {
+				cp := buildCP(providerConfig)
+
+				Expect(versionStrings(FilterMachineImageVersionsByArch(cp, imageName, versions, arch_amd64))).
+					To(ConsistOf(expectedAMD64))
+				Expect(versionStrings(FilterMachineImageVersionsByArch(cp, imageName, versions, arch_arm64))).
+					To(ConsistOf(expectedARM64))
+			},
+			// Legacy formats: remove the next two entries once migration to capability flavors is complete.
+			Entry("region format",
+				regionFormatProviderConfig(imageName, map[string][]string{
+					"1.0.0": {arch_amd64},
+					"2.0.0": {arch_arm64},
+					"3.0.0": {arch_amd64, arch_arm64},
+				}),
+				[]string{"1.0.0", "3.0.0"}, []string{"2.0.0", "3.0.0"}),
+			Entry("flat format with duplicate version entries",
+				flatFormatProviderConfig(imageName, map[string][]string{
+					"1.0.0": {arch_amd64},
+					"2.0.0": {arch_amd64, arch_arm64},
+					"3.0.0": {arch_arm64},
+				}),
+				[]string{"1.0.0", "2.0.0"}, []string{"2.0.0", "3.0.0"}),
+			Entry("capability-flavor format (single flavor with arch list)",
+				BuildCapabilityProviderConfig(ArchsByImage{imageName: {
+					"1.0.0": {arch_amd64},
+					"2.0.0": {arch_amd64, arch_arm64},
+					"3.0.0": {arch_arm64},
+				}}),
+				[]string{"1.0.0", "2.0.0"}, []string{"2.0.0", "3.0.0"}),
+			Entry("capability-flavor format (multiple flavors per version)",
+				capabilityProviderConfigMultiFlavor(imageName, map[string][]string{
+					"1.0.0": {arch_amd64},
+					"2.0.0": {arch_amd64, arch_arm64},
+					"3.0.0": {arch_arm64},
+				}),
+				[]string{"1.0.0", "2.0.0"}, []string{"2.0.0", "3.0.0"}),
+		)
+
+		It("returns all versions for the implicit arch when MachineCapabilities[architecture] has a single value", func() {
+			cp := buildCP(nil, arch_amd64)
+
+			Expect(versionStrings(FilterMachineImageVersionsByArch(cp, imageName, versions, arch_amd64))).
+				To(ConsistOf("1.0.0", "2.0.0", "3.0.0"))
+			Expect(FilterMachineImageVersionsByArch(cp, imageName, versions, arch_arm64)).To(BeEmpty())
+		})
+
+		It("ignores providerConfig when MachineCapabilities[architecture] has a single value", func() {
+			// providerConfig declares arm64 on every version, but MachineCapabilities pins amd64.
+			cp := buildCP(
+				BuildCapabilityProviderConfig(ArchsByImage{imageName: {
+					"1.0.0": {arch_arm64},
+					"2.0.0": {arch_arm64},
+					"3.0.0": {arch_arm64},
+				}}),
+				arch_amd64,
+			)
+
+			Expect(versionStrings(FilterMachineImageVersionsByArch(cp, imageName, versions, arch_amd64))).
+				To(ConsistOf("1.0.0", "2.0.0", "3.0.0"))
+			Expect(FilterMachineImageVersionsByArch(cp, imageName, versions, arch_arm64)).To(BeEmpty())
+		})
+
+		It("falls back to providerConfig when MachineCapabilities[architecture] has more than one value", func() {
+			cp := buildCP(
+				BuildCapabilityProviderConfig(ArchsByImage{imageName: {
+					"1.0.0": {arch_amd64},
+					"2.0.0": {arch_arm64},
+					"3.0.0": {arch_amd64, arch_arm64},
+				}}),
+				arch_amd64, arch_arm64,
+			)
+
+			Expect(versionStrings(FilterMachineImageVersionsByArch(cp, imageName, versions, arch_amd64))).
+				To(ConsistOf("1.0.0", "3.0.0"))
+			Expect(versionStrings(FilterMachineImageVersionsByArch(cp, imageName, versions, arch_arm64))).
+				To(ConsistOf("2.0.0", "3.0.0"))
+		})
+
+		It("returns an empty result when the cloudprofile has no provider config", func() {
+			cp := buildCP(nil)
+			Expect(FilterMachineImageVersionsByArch(cp, imageName, versions, arch_amd64)).To(BeEmpty())
+		})
+
+		It("ignores provider-config entries for other image names", func() {
+			cp := buildCP(BuildCapabilityProviderConfig(ArchsByImage{"other-image": {
+				"1.0.0": {arch_amd64},
+			}}))
+			Expect(FilterMachineImageVersionsByArch(cp, imageName, versions, arch_amd64)).To(BeEmpty())
 		})
 	})
 })
+
+func versionStrings(versions []gardencorev1beta1.MachineImageVersion) []string {
+	result := make([]string, 0, len(versions))
+	for _, v := range versions {
+		result = append(result, v.Version)
+	}
+	return result
+}

--- a/pkg/util/machine_image_testing.go
+++ b/pkg/util/machine_image_testing.go
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"encoding/json"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// ArchsByVersion maps a machine-image version to its supported architectures.
+type ArchsByVersion = map[string][]string
+
+// ArchsByImage maps a machine-image name to its per-version architectures.
+type ArchsByImage = map[string]ArchsByVersion
+
+// BuildCapabilityProviderConfig builds a *runtime.RawExtension carrying
+// machine-image architecture data in the capability-flavor format. It is
+// exposed for cross-package tests that need to populate
+// cloudprofile.Spec.ProviderConfig in the schema this package consumes.
+//
+// One capability flavor is emitted per version, listing all archs.
+//
+// This helper is test-only: it asserts via Gomega that JSON marshaling
+// succeeds, so it must be called from within a Ginkgo spec.
+func BuildCapabilityProviderConfig(imagesByName ArchsByImage) *runtime.RawExtension {
+	images := make([]providerConfigMachineImage, 0, len(imagesByName))
+	for imageName, archsByVersion := range imagesByName {
+		versions := make([]providerConfigMachineImageVersion, 0, len(archsByVersion))
+		for version, archs := range archsByVersion {
+			versions = append(versions, providerConfigMachineImageVersion{
+				Version: version,
+				CapabilityFlavors: []providerConfigCapabilityFlavor{
+					{Capabilities: providerConfigCapabilities{Architecture: archs}},
+				},
+			})
+		}
+		images = append(images, providerConfigMachineImage{Name: imageName, Versions: versions})
+	}
+	raw, err := json.Marshal(providerConfigMachineImages{MachineImages: images})
+	Expect(err).ToNot(HaveOccurred())
+	return &runtime.RawExtension{Raw: raw}
+}

--- a/pkg/util/machine_image_testing.go
+++ b/pkg/util/machine_image_testing.go
@@ -7,7 +7,7 @@ package util
 import (
 	"encoding/json"
 
-	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -41,6 +41,6 @@ func BuildCapabilityProviderConfig(imagesByName ArchsByImage) *runtime.RawExtens
 		images = append(images, providerConfigMachineImage{Name: imageName, Versions: versions})
 	}
 	raw, err := json.Marshal(providerConfigMachineImages{MachineImages: images})
-	Expect(err).ToNot(HaveOccurred())
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	return &runtime.RawExtension{Raw: raw}
 }


### PR DESCRIPTION
**How to categorize this PR?**

/area testing
/kind bug

**What this PR does / why we need it**:

The `state` cloudprofile generators stopped populating the legacy `MachineImageVersion.Architectures` field, so `FilterArchSpecificMachineImage` was filtering every version out for any architecture. This rewrites the filter to read architecture data from `cloudprofile.Spec.ProviderConfig` (region, flat, and capability-flavor formats) and to honor a single-valued `Spec.MachineCapabilities[architecture]` as an implicit cloudprofile-wide arch. Region and flat formats are isolated behind a labeled section so they can be removed once provider migration to capability flavors completes.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
`FilterArchSpecificMachineImage` was renamed and resignatured to `FilterMachineImageVersionsByArch(cloudprofile, imageName, versions, architecture)`.

Alternative approach to: https://github.com/gardener/test-infra/pull/984

**Release note**:
```bugfix operator
Machine image architectures are now read from `CloudProfile.spec.providerConfig` (and `spec.machineCapabilities`) instead of the unset legacy `MachineImageVersion.architectures` field, restoring architecture-based version filtering for shoot creation.
```
