### PR TITLE
add shoot url to tm-bot UI

### DIFF
--- a/pkg/apis/config/bot.go
+++ b/pkg/apis/config/bot.go
@@ -48,6 +48,12 @@ type Dashboard struct {
 
 	// Authentication to restrict access to specific parts in the dashboard
 	Authentication DashboardAuthentication `json:"authentication"`
+
+	// GardenerDashboardURLTemplate is the base URL template for the Gardener dashboard.
+	// Use {landscape} as a placeholder for the landscape name.
+	// When set, shoot-related test steps display a link to the shoot in the Gardener dashboard.
+	// +optional
+	GardenerDashboardURLTemplate string `json:"gardenerDashboardURLTemplate,omitempty"`
 }
 
 // DashboardAuthenticationProvider is a enum to specify a dashboard authentication method

--- a/pkg/apis/config/v1beta1/bot.go
+++ b/pkg/apis/config/v1beta1/bot.go
@@ -48,6 +48,12 @@ type Dashboard struct {
 
 	// Authentication to restrict access to specific parts in the dashboard
 	Authentication DashboardAuthentication `json:"authentication"`
+
+	// GardenerDashboardURLTemplate is the base URL template for the Gardener dashboard.
+	// Use {landscape} as a placeholder for the landscape name.
+	// When set, shoot-related test steps display a link to the shoot in the Gardener dashboard.
+	// +optional
+	GardenerDashboardURLTemplate string `json:"gardenerDashboardURLTemplate,omitempty"`
 }
 
 // DashboardAuthenticationProvider is a enum to specify a dashboard authentication method

--- a/pkg/apis/config/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/config/v1beta1/zz_generated.conversion.go
@@ -387,6 +387,7 @@ func autoConvert_v1beta1_Dashboard_To_config_Dashboard(in *Dashboard, out *confi
 	if err := Convert_v1beta1_DashboardAuthentication_To_config_DashboardAuthentication(&in.Authentication, &out.Authentication, s); err != nil {
 		return err
 	}
+	out.GardenerDashboardURLTemplate = in.GardenerDashboardURLTemplate
 	return nil
 }
 
@@ -400,6 +401,7 @@ func autoConvert_config_Dashboard_To_v1beta1_Dashboard(in *config.Dashboard, out
 	if err := Convert_config_DashboardAuthentication_To_v1beta1_DashboardAuthentication(&in.Authentication, &out.Authentication, s); err != nil {
 		return err
 	}
+	out.GardenerDashboardURLTemplate = in.GardenerDashboardURLTemplate
 	return nil
 }
 

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -375,6 +375,13 @@ func schema_test_infra_pkg_apis_config_Dashboard(ref common.ReferenceCallback) c
 							Ref:         ref("github.com/gardener/test-infra/pkg/apis/config.DashboardAuthentication"),
 						},
 					},
+					"gardenerDashboardURLTemplate": {
+						SchemaProps: spec.SchemaProps{
+							Description: "GardenerDashboardURLTemplate is the base URL template for the Gardener dashboard. Use {landscape} as a placeholder for the landscape name. When set, shoot-related test steps display a link to the shoot in the Gardener dashboard.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"UIBasePath", "authentication"},
 			},
@@ -1271,6 +1278,13 @@ func schema_pkg_apis_config_v1beta1_Dashboard(ref common.ReferenceCallback) comm
 							Description: "Authentication to restrict access to specific parts in the dashboard",
 							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/gardener/test-infra/pkg/apis/config/v1beta1.DashboardAuthentication"),
+						},
+					},
+					"gardenerDashboardURLTemplate": {
+						SchemaProps: spec.SchemaProps{
+							Description: "GardenerDashboardURLTemplate is the base URL template for the Gardener dashboard. Use {landscape} as a placeholder for the landscape name. When set, shoot-related test steps display a link to the shoot in the Gardener dashboard.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},

--- a/pkg/testrunner/util.go
+++ b/pkg/testrunner/util.go
@@ -135,6 +135,11 @@ func GetHostURLFromIngressObject(ingress *netv1.Ingress) (string, error) {
 	return hostUrl.String(), nil
 }
 
+// GetGardenerDashboardShootURL returns the Gardener dashboard URL for a specific shoot
+func GetGardenerDashboardShootURL(dashboardBaseURL, projectNamespace, shootName string) string {
+	return fmt.Sprintf("%s/namespace/%s/shoots/%s", dashboardBaseURL, projectNamespace, shootName)
+}
+
 // GetCloudProfilesFromDisk walks through the filesystem and returns all found CloudProfiles
 func GetCloudProfilesFromDisk(cloudProfileSearchPath string) (map[string]gardencorev1beta1.CloudProfile, error) {
 	scheme := runtime.NewScheme()

--- a/pkg/tm-bot/options.go
+++ b/pkg/tm-bot/options.go
@@ -58,7 +58,7 @@ func (o *options) setupDashboard(router *mux.Router, runs *tests.Runs) error {
 		return fmt.Errorf("no authentication provider with name %s", authCfg.Provider)
 	}
 
-	ui.Serve(o.log, runs, o.cfg.Dashboard.UIBasePath, authProvider, router)
+	ui.Serve(o.log, runs, o.cfg.Dashboard.UIBasePath, authProvider, router, o.cfg.Dashboard.GardenerDashboardURLTemplate)
 	return nil
 }
 

--- a/pkg/tm-bot/ui/pages/page.go
+++ b/pkg/tm-bot/ui/pages/page.go
@@ -18,10 +18,11 @@ import (
 )
 
 type Page struct {
-	basePath string
-	log      logr.Logger
-	auth     auth.Provider
-	runs     *tests.Runs
+	basePath                     string
+	log                          logr.Logger
+	auth                         auth.Provider
+	runs                         *tests.Runs
+	gardenerDashboardURLTemplate string
 }
 
 type globalSettings struct {
@@ -41,12 +42,13 @@ type user struct {
 	Name string
 }
 
-func New(logger logr.Logger, runs *tests.Runs, auth auth.Provider, basePath string) *Page {
+func New(logger logr.Logger, runs *tests.Runs, auth auth.Provider, basePath string, gardenerDashboardURLTemplate string) *Page {
 	return &Page{
-		basePath: basePath,
-		log:      logger,
-		auth:     auth,
-		runs:     runs,
+		basePath:                     basePath,
+		log:                          logger,
+		auth:                         auth,
+		runs:                         runs,
+		gardenerDashboardURLTemplate: gardenerDashboardURLTemplate,
 	}
 }
 

--- a/pkg/tm-bot/ui/pages/testrun.go
+++ b/pkg/tm-bot/ui/pages/testrun.go
@@ -42,6 +42,7 @@ type testrunStepStatusItem struct {
 	IsSystem bool
 
 	GrafanaURL string
+	ShootURL   string
 }
 
 func NewTestrunPage(p *Page) http.HandlerFunc {
@@ -62,6 +63,10 @@ func NewTestrunPage(p *Page) http.HandlerFunc {
 
 		argoHostURL, _ := testrunner.GetArgoHost(ctx, p.runs.GetClient())
 		grafanaHostURL, _ := testrunner.GetGrafanaHost(ctx, p.runs.GetClient())
+		shootName := tr.Annotations["shoot.name"]
+		shootProjectNamespace := tr.Annotations["shoot.projectNamespace"]
+		landscape := tr.Annotations[common.AnnotationLandscape]
+		gardenerDashboardURL := strings.ReplaceAll(p.gardenerDashboardURLTemplate, "{landscape}", landscape)
 		metadata := metadata2.FromTestrun(tr)
 		startTime := ""
 		if tr.Status.StartTime != nil {
@@ -130,6 +135,9 @@ func NewTestrunPage(p *Page) http.HandlerFunc {
 			}
 			if grafanaHostURL != "" {
 				item.Steps[i].GrafanaURL = testrunner.GetGrafanaURLFromHostForStep(grafanaHostURL, tr.Status.Workflow, step.TestDefinition.Name)
+			}
+			if gardenerDashboardURL != "" && shootName != "" && shootProjectNamespace != "" {
+				item.Steps[i].ShootURL = testrunner.GetGardenerDashboardShootURL(gardenerDashboardURL, shootProjectNamespace, shootName)
 			}
 		}
 

--- a/pkg/tm-bot/ui/pages/testrun.go
+++ b/pkg/tm-bot/ui/pages/testrun.go
@@ -142,7 +142,7 @@ func NewTestrunPage(p *Page) http.HandlerFunc {
 			if grafanaHostURL != "" {
 				item.Steps[i].GrafanaURL = testrunner.GetGrafanaURLFromHostForStep(grafanaHostURL, tr.Status.Workflow, step.TestDefinition.Name)
 			}
-			if gardenerDashboardURL != "" && shootName != "" && shootProjectNamespace != "" {
+			if gardenerDashboardURL != "" && shootName != "" && shootProjectNamespace != "" && step.TestDefinition.Name == "create-shoot" {
 				item.Steps[i].ShootURL = testrunner.GetGardenerDashboardShootURL(gardenerDashboardURL, shootProjectNamespace, shootName)
 			}
 		}

--- a/pkg/tm-bot/ui/pages/testrun.go
+++ b/pkg/tm-bot/ui/pages/testrun.go
@@ -65,6 +65,12 @@ func NewTestrunPage(p *Page) http.HandlerFunc {
 		grafanaHostURL, _ := testrunner.GetGrafanaHost(ctx, p.runs.GetClient())
 		shootName := tr.Annotations["shoot.name"]
 		shootProjectNamespace := tr.Annotations["shoot.projectNamespace"]
+		if shootName == "" {
+			shootName = getSpecConfigValue(tr.Spec.Config, "SHOOT_NAME")
+		}
+		if shootProjectNamespace == "" {
+			shootProjectNamespace = getSpecConfigValue(tr.Spec.Config, "PROJECT_NAMESPACE")
+		}
 		landscape := tr.Annotations[common.AnnotationLandscape]
 		gardenerDashboardURL := strings.ReplaceAll(p.gardenerDashboardURLTemplate, "{landscape}", landscape)
 		metadata := metadata2.FromTestrun(tr)
@@ -204,4 +210,13 @@ func (l testrunStepStatusItemList) Less(a, b int) bool {
 		return true
 	}
 	return l[a].step.StartTime.Before(l[b].step.StartTime)
+}
+
+func getSpecConfigValue(config []v1beta1.ConfigElement, name string) string {
+	for _, c := range config {
+		if c.Name == name {
+			return c.Value
+		}
+	}
+	return ""
 }

--- a/pkg/tm-bot/ui/templates/testrun.html
+++ b/pkg/tm-bot/ui/templates/testrun.html
@@ -76,7 +76,7 @@
                                 <div class="mdl-tooltip" for="grafana-url-{{$step.Name}}">Show logs</div>
                             {{ end }}
                         </td>
-                        <td class="mdl-data-table__cell--numeric actions">
+                        <td class="mdl-data-table__cell--numeric actions" style="padding-left: 0">
                             {{ if $step.ShootURL }}
                                 <a id="shoot-url-{{$step.Name}}" href="{{ $step.ShootURL }}" target="_blank" class="mdl-button mdl-js-button mdl-button--fab mdl-button--mini-fab"><i class="material-icons" style="color:#4caf50">grass</i></a>
                                 <div class="mdl-tooltip" for="shoot-url-{{$step.Name}}">Open shoot in Gardener</div>

--- a/pkg/tm-bot/ui/templates/testrun.html
+++ b/pkg/tm-bot/ui/templates/testrun.html
@@ -78,7 +78,7 @@
                         </td>
                         <td class="mdl-data-table__cell--numeric actions" style="padding-left: 0">
                             {{ if $step.ShootURL }}
-                                <a id="shoot-url-{{$step.Name}}" href="{{ $step.ShootURL }}" target="_blank" class="mdl-button mdl-js-button mdl-button--fab mdl-button--mini-fab"><i class="material-icons" style="color:#4caf50">grass</i></a>
+                                <a id="shoot-url-{{$step.Name}}" href="{{ $step.ShootURL }}" target="_blank" class="mdl-button mdl-js-button mdl-button--fab mdl-button--mini-fab"><i class="material-icons" style="color:#4caf50">local_florist</i></a>
                                 <div class="mdl-tooltip" for="shoot-url-{{$step.Name}}">Open shoot in Gardener</div>
                             {{ end }}
                         </td>

--- a/pkg/tm-bot/ui/templates/testrun.html
+++ b/pkg/tm-bot/ui/templates/testrun.html
@@ -76,7 +76,7 @@
                                 <div class="mdl-tooltip" for="grafana-url-{{$step.Name}}">Show logs</div>
                             {{ end }}
                             {{ if $step.ShootURL }}
-                                <a id="shoot-url-{{$step.Name}}" href="{{ $step.ShootURL }}" target="_blank" class="mdl-button mdl-js-button mdl-button--fab mdl-button--mini-fab"><i class="material-icons">grass</i></a>
+                                <a id="shoot-url-{{$step.Name}}" href="{{ $step.ShootURL }}" target="_blank" class="mdl-button mdl-js-button mdl-button--fab mdl-button--mini-fab"><i class="material-icons" style="color:#4caf50">grass</i></a>
                                 <div class="mdl-tooltip" for="shoot-url-{{$step.Name}}">Open shoot in Gardener</div>
                             {{ end }}
                         </td>

--- a/pkg/tm-bot/ui/templates/testrun.html
+++ b/pkg/tm-bot/ui/templates/testrun.html
@@ -75,12 +75,13 @@
                                 <a id="grafana-url-{{$step.Name}}" href="{{ $step.GrafanaURL }}" target="_blank" class="mdl-button mdl-js-button mdl-button--fab mdl-button--mini-fab"><i class="material-icons">list</i></a>
                                 <div class="mdl-tooltip" for="grafana-url-{{$step.Name}}">Show logs</div>
                             {{ end }}
+                        </td>
+                        <td class="mdl-data-table__cell--numeric actions">
                             {{ if $step.ShootURL }}
                                 <a id="shoot-url-{{$step.Name}}" href="{{ $step.ShootURL }}" target="_blank" class="mdl-button mdl-js-button mdl-button--fab mdl-button--mini-fab"><i class="material-icons" style="color:#4caf50">grass</i></a>
                                 <div class="mdl-tooltip" for="shoot-url-{{$step.Name}}">Open shoot in Gardener</div>
                             {{ end }}
                         </td>
-                        <td></td>
                     </tr>
                     <div class="mdl-tooltip" for="grafana-url">{{ $step.Phase.Tooltip }}</div>
                 {{ end }}

--- a/pkg/tm-bot/ui/templates/testrun.html
+++ b/pkg/tm-bot/ui/templates/testrun.html
@@ -75,6 +75,10 @@
                                 <a id="grafana-url-{{$step.Name}}" href="{{ $step.GrafanaURL }}" target="_blank" class="mdl-button mdl-js-button mdl-button--fab mdl-button--mini-fab"><i class="material-icons">list</i></a>
                                 <div class="mdl-tooltip" for="grafana-url-{{$step.Name}}">Show logs</div>
                             {{ end }}
+                            {{ if $step.ShootURL }}
+                                <a id="shoot-url-{{$step.Name}}" href="{{ $step.ShootURL }}" target="_blank" class="mdl-button mdl-js-button mdl-button--fab mdl-button--mini-fab"><i class="material-icons">grass</i></a>
+                                <div class="mdl-tooltip" for="shoot-url-{{$step.Name}}">Open shoot in Gardener</div>
+                            {{ end }}
                         </td>
                         <td></td>
                     </tr>

--- a/pkg/tm-bot/ui/ui.go
+++ b/pkg/tm-bot/ui/ui.go
@@ -16,7 +16,7 @@ import (
 	"github.com/gardener/test-infra/pkg/tm-bot/ui/pages"
 )
 
-func Serve(log logr.Logger, runs *tests.Runs, basePath string, a auth.Provider, r *mux.Router) {
+func Serve(log logr.Logger, runs *tests.Runs, basePath string, a auth.Provider, r *mux.Router, gardenerDashboardURLTemplate string) {
 	fs := http.FileServer(http.Dir(filepath.Join(basePath, "static")))
 	r.PathPrefix("/static/").Handler(http.StripPrefix("/static/", fs))
 
@@ -24,7 +24,7 @@ func Serve(log logr.Logger, runs *tests.Runs, basePath string, a auth.Provider, 
 	r.HandleFunc("/login", a.Login)
 	r.HandleFunc("/logout", a.Logout)
 
-	page := pages.New(log, runs, a, basePath)
+	page := pages.New(log, runs, a, basePath, gardenerDashboardURLTemplate)
 
 	r.HandleFunc("/command-help", pages.NewCommandHelpPage(log, a, basePath))
 	r.HandleFunc("/command-help/{plugin}", pages.NewCommandDetailedHelpPage(log, a, basePath))


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

Add a Go-To-Shoot Button in the tm-bot UI

<img width="1836" height="168" alt="Screenshot 2026-07-02 at 17 11 47" src="https://github.com/user-attachments/assets/61046fcc-4938-45f4-a237-f2d770794ea3" />


**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```


