### PR TITLE
remove tm.gardener.cloud usage

### DIFF
--- a/cmd/tm-bot/README.md
+++ b/cmd/tm-bot/README.md
@@ -2,13 +2,45 @@
 
 The Testmachinery GitHub bot is a [GitHub app](https://developer.github.com/apps/about-apps/) that listens on Pull Request events/webhooks and reacts on them.
 
-It also checks if a user is authorized (currently is member of the organization) to perform teh command.
+It also checks if a user is authorized (currently is member of the organization) to perform the command.
 
 The bot is mainly build to run integration tests in PR's and report back the correct status.
 
 ## Plugins
 
-[Command help](https://tm.gardener.cloud/command-help)
+### Available Commands
+
+| Command | Description | Authorization | Example |
+|---------|-------------|---------------|---------|
+| `/test` | Runs a testrun specified by flags or default config. The current repository is injected as a default location. | team | `/test [sub-command] [--flags]` |
+| `/test-single` | Runs a single testrun specified by a path or default config. | team | `/test-single [path to the testrun]` |
+| `/skip` | Clears the TestMachinery GitHub status to skip a failed or pending test. | codeowners | `/skip` |
+| `/resume` | Resumes a paused testrun for the current PR. | team | `/resume` |
+| `/echo` | Prints the provided value as a PR comment. Useful for testing bot connectivity. | team | `/echo "text to echo"` |
+| `/xkcd` | Posts a random (or numbered) xkcd comic as a PR comment. | org | `/xkcd --num 2` |
+
+#### `/test` flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--testrunPath` | `""` | Path to the testrun file to execute |
+| `--set` | `[]` | Additional Helm values (`key=value`) |
+| `--template` | `false` | Run Go templating on the file before execution |
+| `--dry-run` | `false` | Print the rendered testrun without executing |
+
+#### `/test-single` flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--dry-run` | `false` | Print the rendered testrun without executing |
+
+#### `/xkcd` flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--num` | `0` (random) | Specific xkcd comic number to post |
+
+### Plugin configuration
 
 Plugins and their default values can be configured by creating a values file in `.ci/tm-bot` in the default branch of the repository.
 This file will be parsed by the bot and the plugins will automatically be able to access the config for a certain call.

--- a/pkg/tm-bot/plugins/respond.go
+++ b/pkg/tm-bot/plugins/respond.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 )
 
-const AboutThisBotWithoutCommands = "Instructions for interacting with me using PR comments are available <a href=\"https://tm.gardener.cloud/command-help\">here</a>"
+const AboutThisBotWithoutCommands = "Instructions for interacting with me using PR comments are available <a href=\"https://github.com/gardener/test-infra/blob/master/cmd/tm-bot/README.md#available-commands\">here</a>"
 
 // FormatSimpleResponse formats a response that does not warrant additional explanation in the
 // details section.

--- a/pkg/tm-bot/plugins/resume/resume.go
+++ b/pkg/tm-bot/plugins/resume/resume.go
@@ -45,7 +45,7 @@ func (r *resume) Authorization() github.AuthorizationType {
 }
 
 func (r *resume) Description() string {
-	return "Prints the provided value"
+	return "Resumes a paused testrun for the current PR"
 }
 
 func (r *resume) Example() string {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->
remove tm.gardener.cloud mention. Hardcode the commands available to tm-bot in docs.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind task

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
