### PR TITLE
testrunner: surface CloudProfile path errors instead of silently exiting

### DIFF
--- a/cmd/testrunner/cmd/run_template/options.go
+++ b/cmd/testrunner/cmd/run_template/options.go
@@ -6,6 +6,7 @@ package run_template
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"time"
@@ -82,12 +83,10 @@ func (o *options) Complete() error {
 	if o.cloudProfileSearchPath != "" {
 		cloudProfiles, err = testrunner.GetCloudProfilesFromDisk(filepath.Clean(o.cloudProfileSearchPath))
 		if err != nil {
-			logger.Log.Error(err, "unable to find CloudProfiles in files", "root directory", o.cloudProfileSearchPath)
-			os.Exit(1)
+			return fmt.Errorf("unable to find CloudProfiles in files at %s: %w", o.cloudProfileSearchPath, err)
 		}
 		if len(cloudProfiles) == 0 {
-			logger.Log.Error(err, "no CloudProfiles found in files", "root directory", o.cloudProfileSearchPath)
-			os.Exit(1)
+			return fmt.Errorf("no CloudProfiles found in files at %s", o.cloudProfileSearchPath)
 		}
 	} else {
 		gardenK8sClient, err = kutil.NewClientFromFile(o.testrunnerKubeconfigPath, client.Options{


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area testing
/kind bug

**What this PR does / why we need it**:

When `--cloud-profile-search-path` points to a non-existent or empty directory, `Complete()` calls `logger.Log.Error(...)` followed by `os.Exit(1)`. However, `logger.Log` is a zero-value `logr.Logger` (a discard sink since logr v1.0) at that point, so no output is produced and the process exits silently with code 1.

The fix returns errors from `Complete()` instead, which bubble up to the `Run` cobra handler where they are printed via `fmt.Println`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Verified locally:
- Non-existent path: `unable to find CloudProfiles in files at /nonexistent/path: CloudProfile search path /nonexistent/path does not exist: stat /nonexistent/path: no such file or directory`
- Existing but empty directory: `no CloudProfiles found in files at /tmp/empty-cloudprofiles`
- Valid path: `Complete()` succeeds, testrunner proceeds normally

**Release note**:
```bugfix developer
testrunner now prints an error message when --cloud-profile-search-path is invalid or empty, instead of exiting silently with code 1.
```