### PR TITLE
Add helper script for kubeconfig creation out of existing cluster access

### DIFF
--- a/conformance-tests/README.md
+++ b/conformance-tests/README.md
@@ -7,9 +7,11 @@ Run K8s conformance tests using [Hydrophone](https://github.com/kubernetes-sigs/
 ### Run conformance tests via Gardener's test automation
 `cd` into your local `gardener/test-infra` folder and target some cluster.  Adjust values for argument `k8sVersion` to match your new cluster's version.
 
+This requires a "vanilla" `$KUBECONFIG` (i.e. one that doesn't require special credential plugins). If you already have cluster-admin access with some credential plugins and need a kubeconfig without, you can create the resp. service accounts and tokens or use [this helper script](./create-token-kubeconfig.sh).
+
 ```bash
 # first set KUBECONFIG to your cluster
-docker run -ti -e --rm -v $KUBECONFIG:/mye2e/shoot.config -v $PWD:/go/src/github.com/gardener/test-infra -e E2E_EXPORT_PATH=/tmp/export -e KUBECONFIG=/mye2e/shoot.config --network=host --workdir /go/src/github.com/gardener/test-infra  --platform linux/amd64 golang:1.23 bash
+docker run -ti -e --rm -v $KUBECONFIG:/mye2e/shoot.config -v $PWD:/go/src/github.com/gardener/test-infra -e E2E_EXPORT_PATH=/tmp/export -e KUBECONFIG=/mye2e/shoot.config --network=host --workdir /go/src/github.com/gardener/test-infra  --platform linux/amd64 golang:1.26.1 bash
 
 # run the command below within the container to invoke tests in a parallel way and allow tests to flake
 go run ./conformance-tests --k8sVersion=1.30.4 --flakeAttempts=5

--- a/conformance-tests/create-token-kubeconfig.sh
+++ b/conformance-tests/create-token-kubeconfig.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Creates a token-based kubeconfig suitable for the conformance test container,
+# which cannot use credential plugins. Requires cluster-admin access via $KUBECONFIG.
+# outputs a kubeconfig file at the path specified as the first argument, or conformance-kubeconfig.yaml if none is provided.
+
+set -euo pipefail
+
+NAMESPACE="kube-system"
+SA_NAME="conformance-sa"
+CRB_NAME="conformance-sa-admin"
+TOKEN_DURATION="12h"
+OUTPUT_KUBECONFIG="${1:-conformance-kubeconfig.yaml}"
+
+echo "Creating ServiceAccount '$SA_NAME' in namespace '$NAMESPACE'..."
+kubectl create serviceaccount "$SA_NAME" -n "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+
+echo "Binding '$SA_NAME' to cluster-admin..."
+kubectl create clusterrolebinding "$CRB_NAME" \
+  --clusterrole=cluster-admin \
+  --serviceaccount="${NAMESPACE}:${SA_NAME}" --dry-run=client -o yaml | kubectl apply -f -
+
+echo "Requesting token (duration: $TOKEN_DURATION)..."
+TOKEN=$(kubectl create token "$SA_NAME" -n "$NAMESPACE" --duration="$TOKEN_DURATION")
+
+echo "Extracting cluster info from current kubeconfig..."
+CA_TMPFILE=$(mktemp)
+trap 'rm -f "$CA_TMPFILE"' EXIT
+
+kubectl config view --minify --raw \
+  -o jsonpath='{.clusters[0].cluster.certificate-authority-data}' \
+  | base64 -d > "$CA_TMPFILE"
+
+CLUSTER_SERVER=$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}')
+
+echo "Building token-based kubeconfig at '$OUTPUT_KUBECONFIG'..."
+kubectl config set-cluster conformance-cluster \
+  --server="$CLUSTER_SERVER" \
+  --certificate-authority="$CA_TMPFILE" \
+  --embed-certs=true \
+  --kubeconfig="$OUTPUT_KUBECONFIG"
+
+kubectl config set-credentials conformance-user \
+  --token="$TOKEN" \
+  --kubeconfig="$OUTPUT_KUBECONFIG"
+
+kubectl config set-context default \
+  --cluster=conformance-cluster \
+  --user=conformance-user \
+  --kubeconfig="$OUTPUT_KUBECONFIG"
+
+kubectl config use-context default --kubeconfig="$OUTPUT_KUBECONFIG"
+
+echo "Done. Kubeconfig written to: $OUTPUT_KUBECONFIG"
+echo "Token expires in $TOKEN_DURATION. Mount it into the container with:"
+echo "  docker run ... -v \$PWD/$OUTPUT_KUBECONFIG:/mye2e/shoot.config -e KUBECONFIG=/mye2e/shoot.config ..."
+echo ""
+echo "Clean up manually after the tests complete:"
+echo "  kubectl delete clusterrolebinding $CRB_NAME"
+echo "  kubectl delete serviceaccount $SA_NAME -n $NAMESPACE"


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area docs
/kind enhancement

**What this PR does / why we need it**:
Add helper script for kubeconfig creation out of existing cluster access to make running conformance tests from a local container more easy.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
