### PR TITLE
Add more conformance tests -> hydrophone options

### DIFF
--- a/conformance-tests/README.md
+++ b/conformance-tests/README.md
@@ -21,6 +21,12 @@ GINKGO_PARALLEL=false go run ./conformance-tests --k8sVersion=1.30.4
 
 # use the dry-run flag in combination with the hydrophone log level to see what tests to execute
 go run ./conformance-tests --k8sVersion=1.30.4 --dryRun --conformanceLogLevel 4
+
+# run only a single test by name (regex)
+go run ./conformance-tests --k8sVersion=1.30.4 --focusTestCases="should detect duplicates in a CR when preserving unknown fields" 
+
+# run only a single test by name (regex) but multiple times
+go run ./conformance-tests --k8sVersion=1.30.4 --focusTestCases="should detect duplicates in a CR when preserving unknown fields" --extraGinkgoArgs="--repeat=5"
 ```
 
 ### Run conformance tests (or single tests) directly (without Gardener's test automation)
@@ -76,7 +82,10 @@ kind delete cluster
 | -                              | conformanceLogLevel | 2               | Log level passed to hydrophone                                                                                      |
 | GINKGO_PARALLEL                |  | true            | Runs the tests in parallel with 8 ginkgo nodes.                                                                     |
 | -                              | flakeAttempts | 1               | Flake attempts define how many times a failed test should be rerun                                                  |
+| -                              | deleteNamespaceOnFailure | true   | If false, the test namespaces of failed tests are not deleted, which is helpful for debugging                       |
 | SKIP_INDIVIDUAL_TEST_CASES     | skipIndividualTestCases |                 | A list of ginkgo.skip patterns (regex based) to skip individual test cases. Use "\|" as delimiter.                  |
+| FOCUS_TEST_CASES               | focusTestCases |                 | A ginkgo focus pattern (regex) to run only matching test cases.                                                     |
+| -                              | extraGinkgoArgs |                | Additional arguments passed directly to ginkgo (e.g. `--repeat=3` to stress-test a passing test).                  |
 | E2E_EXPORT_PATH                |  | /tmp/e2e/export | Location to store test results                                                                                      |
 | E2E_KUBECONFIG_PATH            | kubeconfig | $KUBECONFIG     | File path of kubeconfig file. Reverts to $KUBECONFIG and fails if nothing is to be found there.                     |
 | PUBLISH_RESULTS_TO_TESTGRID    |  | false           | Publish test results to google cloud storage for testgrid                                                           |

--- a/conformance-tests/config/config.go
+++ b/conformance-tests/config/config.go
@@ -21,8 +21,11 @@ var (
 	HydrophoneVersion        string
 	K8sRelease               string
 	SkipIndividualTestCases  string
+	FocusTestCases           string
+	ExtraGinkgoArgs          string
 	GinkgoParallel           bool
 	FlakeAttempts            int
+	DeleteNamespaceOnFailure bool
 	ExportPath               string
 	PublishResultsToTestgrid bool
 	ShootKubeconfigPath      string
@@ -38,7 +41,10 @@ func init() {
 	flag.StringVar(&HydrophoneVersion, "hydrophoneVersion", "", "Hydrophone version to be used")
 	flag.StringVar(&K8sRelease, "k8sVersion", "", "Kubernetes release version e.g. 1.14.0")
 	flag.StringVar(&SkipIndividualTestCases, "skipIndividualTestCases", "", "A list of ginkgo.skip patterns (regex based) to skip individual test cases, use \"|\" as delimiter.")
+	flag.StringVar(&FocusTestCases, "focusTestCases", "", "A ginkgo focus pattern (regex) to run only matching test cases.")
+	flag.StringVar(&ExtraGinkgoArgs, "extraGinkgoArgs", "", "Additional arguments passed to ginkgo via hydrophone's --extra-ginkgo-args (e.g. \"--repeat=3\").")
 	flag.IntVar(&FlakeAttempts, "flakeAttempts", 1, "Testcase flake attempts. Will run testcase n times, until it is successful")
+	flag.BoolVar(&DeleteNamespaceOnFailure, "deleteNamespaceOnFailure", true, "If false, the test namespaces of failed tests are not deleted, which is helpful for debugging")
 	flag.StringVar(&ShootKubeconfigPath, "kubeconfig", "", "Kubeconfig file path of cluster to test")
 	flag.StringVar(&CloudProvider, "cloudprovider", "", "Cluster cloud provider (aws, gcp, azure, alicloud, openstack)")
 	flag.BoolVar(&DryRun, "dryRun", false, "use in combination with --conformanceLogLevel to output testcases")
@@ -61,6 +67,10 @@ func init() {
 
 	if SkipIndividualTestCases == "" {
 		SkipIndividualTestCases = os.Getenv("SKIP_INDIVIDUAL_TEST_CASES")
+	}
+
+	if FocusTestCases == "" {
+		FocusTestCases = os.Getenv("FOCUS_TEST_CASES")
 	}
 
 	GinkgoParallel = tiutil.GetenvBool("GINKGO_PARALLEL", true)
@@ -109,8 +119,11 @@ func LogConfig(log logr.Logger) {
 		"HydrophoneVersion", HydrophoneVersion,
 		"GinkgoParallel", GinkgoParallel,
 		"FlakeAttempts", FlakeAttempts,
+		"DeleteNamespaceOnFailure", DeleteNamespaceOnFailure,
 		"PublishResultsToTestgrid", PublishResultsToTestgrid,
 		"SkipIndividualTestCases", SkipIndividualTestCases,
+		"FocusTestCases", FocusTestCases,
+		"ExtraGinkgoArgs", ExtraGinkgoArgs,
 	)
 	if PublishResultsToTestgrid {
 		log.Info("Test results will be uploaded to:", "Project", GcsProjectID, "Bucket", GcsBucket)

--- a/conformance-tests/hydrophone/hydrophone.go
+++ b/conformance-tests/hydrophone/hydrophone.go
@@ -40,8 +40,13 @@ func Run(log logr.Logger) error {
 	}
 
 	hydrophoneRunArgs := []string{
-		"--conformance",
 		"--conformance-image", fmt.Sprintf("registry.k8s.io/conformance:v%s", config.K8sRelease),
+	}
+
+	if config.FocusTestCases != "" {
+		hydrophoneRunArgs = append(hydrophoneRunArgs, "--focus", config.FocusTestCases)
+	} else {
+		hydrophoneRunArgs = append(hydrophoneRunArgs, "--conformance")
 	}
 
 	if config.SkipIndividualTestCases != "" {
@@ -58,6 +63,12 @@ func Run(log logr.Logger) error {
 	}
 	if config.FlakeAttempts != 1 {
 		hydrophoneRunArgs = append(hydrophoneRunArgs, "--extra-ginkgo-args", fmt.Sprintf("--flake-attempts=%d", config.FlakeAttempts))
+	}
+	if config.ExtraGinkgoArgs != "" {
+		hydrophoneRunArgs = append(hydrophoneRunArgs, "--extra-ginkgo-args", config.ExtraGinkgoArgs)
+	}
+	if !config.DeleteNamespaceOnFailure {
+		hydrophoneRunArgs = append(hydrophoneRunArgs, "--extra-args", "--delete-namespace-on-failure=false")
 	}
 
 	controllerruntime.SetLogger(log)


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
Adds a few helpful options to the conformance test invocation:
- a generic `--extraGinkgoArgs` to pass ginkgo params (e.g. have a test repeat several times: `--extraGinkgoArgs="--repeat=5"`
- the option to focus a dedicated test with `--focusTestCases="test name"`
- the option to no longer delete test namespaces on failures with `--deleteNamespaceOnFailure=false`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I've based this PR on https://github.com/gardener/test-infra/pull/1019 to avoid merge conflicts.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
New options for better conformance test debugging: `--deleteNamespaceOnFailure=false`, `--focusTestCases="test name"` and `--extraGinkgoArgs="<ginkgo-args>"`.
```
