### PR TITLE
update go image for both conformance testsgrids

### DIFF
--- a/.test-defs/conformanceTestgrid.yaml
+++ b/.test-defs/conformanceTestgrid.yaml
@@ -42,7 +42,7 @@ spec:
     export E2E_EXPORT_PATH=$TM_EXPORT_PATH &&
     export E2E_KUBECONFIG_PATH=$TM_KUBECONFIG_PATH/shoot.config &&
     go run ./conformance-tests
-  image: golang:1.26.1
+  image: golang:1.26.4
   resources:
     requests:
       memory: "500Mi"

--- a/.test-defs/conformanceTestgridParallel.yaml
+++ b/.test-defs/conformanceTestgridParallel.yaml
@@ -26,7 +26,7 @@ spec:
     export E2E_EXPORT_PATH=$TM_EXPORT_PATH &&
     export E2E_KUBECONFIG_PATH=$TM_KUBECONFIG_PATH/shoot.config &&
     go run ./conformance-tests --flakeAttempts=5
-  image: golang:1.26.1
+  image: golang:1.26.4
   resources:
     requests:
       memory: "500Mi"


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->
Use correct go image version in testgrids after update of test-machinery:
- https://github.com/gardener/test-infra/pull/1025

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind task

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```