### PR TITLE
update go image for both conformance testsgrids

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -34,6 +34,13 @@
       ],
       "datasourceTemplate": "docker",
       "versioningTemplate": "docker"
+    },
+    /* Keep golang image in conformance TestDefinitions in sync with go.mod */
+    {
+      "fileMatch": ["^\\.test-defs/conformanceTestgrid(Parallel)?\\.yaml$"],
+      "matchStrings": ["image:\\s*(?<depName>golang):(?<currentValue>[^\\s]+)"],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker"
     }
   ],
 
@@ -95,6 +102,13 @@
         "europe-docker.pkg.dev/gardener-project/releases/3rd/credativ/vali"
       ],
       "groupName": "vali-images"
+    },
+
+    /* Group golang image updates in conformance TestDefinitions */
+    {
+      "matchManagers": ["regex"],
+      "matchPackageNames": ["golang"],
+      "groupName": "golang-testdef-image"
     }
   ]
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->
Keep `conformanceTestgrid` files in sync with go.mod for the golang version updates. 
This would help Maintainers to not forget to update the go-version used in the Testdefinitions 

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement 

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
