### PR TITLE
skip Duplicate value ocm errors.

### DIFF
--- a/pkg/testrunner/componentdescriptor/componentdescriptor.go
+++ b/pkg/testrunner/componentdescriptor/componentdescriptor.go
@@ -21,6 +21,14 @@ import (
 	tmv1beta1 "github.com/gardener/test-infra/pkg/apis/testmachinery/v1beta1"
 )
 
+// isOCMValidationError reports whether err is an OCM component descriptor
+// validation error (e.g. duplicate resources). These errors arise from bugs in
+// upstream component pipelines and are safe to skip because the testrunner only
+// extracts name+version from each component — it never reads resources or SBOMs.
+func isOCMValidationError(err error) bool {
+	return strings.Contains(err.Error(), "Duplicate value")
+}
+
 type Options struct {
 	// CfgPath is the path to the .ocmconfig file. Per default, the library checks for the config file at
 	// $HOME/.ocmconfig.
@@ -94,7 +102,7 @@ func GetComponents(ctx context.Context, log logr.Logger, cdPath string, repoRef 
 			"repository argument or one or multiple repositories in the .ocmconfig file")
 	}
 
-	return resolveReferences(octx, cd, resolver)
+	return resolveReferences(log, octx, cd, resolver)
 }
 
 // The resolveReferences function is an auxiliary function for GetComponents. It implements a typical Breadth First
@@ -103,7 +111,7 @@ func GetComponents(ctx context.Context, log logr.Logger, cdPath string, repoRef 
 // transitive closure) of the root component c.
 // resolver can either a specific ocm repository (if all components are in the same repository) or a compound resolver
 // covering multiple repositories
-func resolveReferences(octx ocm.Context, c *compdesc.ComponentDescriptor, resolver ocm.ComponentVersionResolver) ([]*Component, error) {
+func resolveReferences(log logr.Logger, octx ocm.Context, c *compdesc.ComponentDescriptor, resolver ocm.ComponentVersionResolver) ([]*Component, error) {
 	components := make([]*Component, 0)
 	// Set size to 0, as we cannot know the number of component version beforehand
 	visited := make(map[Component]struct{}, 0)
@@ -121,6 +129,19 @@ func resolveReferences(octx ocm.Context, c *compdesc.ComponentDescriptor, resolv
 		for _, ref := range c.References {
 			ac, err := resolver.LookupComponentVersion(ref.GetComponentName(), ref.GetVersion())
 			if err != nil {
+				if isOCMValidationError(err) {
+					// The component descriptor has invalid resources (e.g. duplicate SBOM entries
+					// from a broken upstream release pipeline). Since the testrunner only uses
+					// name+version metadata, we record the component with what we know and skip
+					// traversing its references rather than failing the entire run.
+					log.Info("skipping component with invalid descriptor", "component", ref.GetComponentName(), "version", ref.GetVersion(), "error", err.Error())
+					key := Component{Name: ref.GetComponentName(), Version: ref.GetVersion()}
+					if _, ok := visited[key]; !ok {
+						visited[key] = struct{}{}
+						components = append(components, &key)
+					}
+					continue
+				}
 				return nil, fmt.Errorf("error resolving component references: %w", err)
 			}
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->
Temporarily skip validations on `Duplicate value`

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind task

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
