### PR TITLE
add skip for specific ocm components

### DIFF
--- a/cmd/testrunner/cmd/run_template/options.go
+++ b/cmd/testrunner/cmd/run_template/options.go
@@ -202,6 +202,7 @@ func (o *options) AddFlags(fs *pflag.FlagSet) error {
 	fs.StringVar(&o.shootParameters.ComponentDescriptorPath, "component-descriptor-path", "", "Path to the component descriptor (BOM) of the current landscape.")
 	fs.StringVar(&o.shootParameters.Repository, "repo", "", "Repository to resolve the component reference of the component described in the file at the component descriptor path")
 	fs.StringVar(&o.shootParameters.OCMConfigPath, "ocm-config-path", "", "Path to the ocm config")
+	fs.StringArrayVar(&o.shootParameters.SkipValidationOnOCMComponents, "skip-validation-on-ocm-component", []string{}, "OCM component name(s) to skip validation during component descriptor resolution")
 
 	fs.StringArrayVar(&o.shootParameters.SetValues, "set", make([]string, 0), "sets additional helm values")
 	fs.StringArrayVarP(&o.shootParameters.FileValues, "values", "f", make([]string, 0), "yaml value files to override template values")

--- a/pkg/testrunner/componentdescriptor/componentdescriptor.go
+++ b/pkg/testrunner/componentdescriptor/componentdescriptor.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -25,6 +26,9 @@ type Options struct {
 	// CfgPath is the path to the .ocmconfig file. Per default, the library checks for the config file at
 	// $HOME/.ocmconfig.
 	CfgPath string
+	// SkipValidationOnComponents is a list of component names to skip during BFS traversal.
+	// Their name+version will still be recorded but their descriptor will not be fetched.
+	SkipValidationOnComponents []string
 }
 
 type Option func(options *Options)
@@ -94,7 +98,7 @@ func GetComponents(ctx context.Context, log logr.Logger, cdPath string, repoRef 
 			"repository argument or one or multiple repositories in the .ocmconfig file")
 	}
 
-	return resolveReferences(octx, cd, resolver)
+	return resolveReferences(octx, cd, resolver, options.SkipValidationOnComponents)
 }
 
 // The resolveReferences function is an auxiliary function for GetComponents. It implements a typical Breadth First
@@ -103,7 +107,7 @@ func GetComponents(ctx context.Context, log logr.Logger, cdPath string, repoRef 
 // transitive closure) of the root component c.
 // resolver can either a specific ocm repository (if all components are in the same repository) or a compound resolver
 // covering multiple repositories
-func resolveReferences(octx ocm.Context, c *compdesc.ComponentDescriptor, resolver ocm.ComponentVersionResolver) ([]*Component, error) {
+func resolveReferences(octx ocm.Context, c *compdesc.ComponentDescriptor, resolver ocm.ComponentVersionResolver, skipValidationOnComponents []string) ([]*Component, error) {
 	components := make([]*Component, 0)
 	// Set size to 0, as we cannot know the number of component version beforehand
 	visited := make(map[Component]struct{}, 0)
@@ -119,6 +123,14 @@ func resolveReferences(octx ocm.Context, c *compdesc.ComponentDescriptor, resolv
 		components = append(components, NewFromVersionedElement(octx, *c))
 
 		for _, ref := range c.References {
+			if slices.Contains(skipValidationOnComponents, ref.GetComponentName()) {
+				key := Component{Name: ref.GetComponentName(), Version: ref.GetVersion()}
+				if _, ok := visited[key]; !ok {
+					visited[key] = struct{}{}
+					components = append(components, &key)
+				}
+				continue
+			}
 			ac, err := resolver.LookupComponentVersion(ref.GetComponentName(), ref.GetVersion())
 			if err != nil {
 				return nil, fmt.Errorf("error resolving component references: %w", err)

--- a/pkg/testrunner/template/template.go
+++ b/pkg/testrunner/template/template.go
@@ -55,6 +55,7 @@ func RenderTestruns(ctx context.Context, log logr.Logger, parameters *Parameters
 func getInternalParametersFunc(ctx context.Context, log logr.Logger, parameters *Parameters) (func(string) *internalParameters, error) {
 	components, err := componentdescriptor.GetComponents(ctx, log, parameters.ComponentDescriptorPath, parameters.Repository, func(opts *componentdescriptor.Options) {
 		opts.CfgPath = parameters.OCMConfigPath
+		opts.SkipValidationOnComponents = parameters.SkipValidationOnOCMComponents
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/testrunner/template/types.go
+++ b/pkg/testrunner/template/types.go
@@ -27,6 +27,9 @@ type Parameters struct {
 
 	SetValues  []string
 	FileValues []string
+
+	// SkipValidationOnOCMComponents is a list of OCM component names to skip during component descriptor resolution.
+	SkipValidationOnOCMComponents []string
 }
 
 type internalParameters struct {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->
add feature to skip specific ocm components from failing ocm validation.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind task

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
add new flag `skip-validation-on-ocm-component` to skip specific ocm components from failing ocm validation.
```
