### PR TITLE
add logging when skipping validation of specific components

### DIFF
--- a/pkg/testrunner/componentdescriptor/componentdescriptor.go
+++ b/pkg/testrunner/componentdescriptor/componentdescriptor.go
@@ -98,7 +98,7 @@ func GetComponents(ctx context.Context, log logr.Logger, cdPath string, repoRef 
 			"repository argument or one or multiple repositories in the .ocmconfig file")
 	}
 
-	return resolveReferences(octx, cd, resolver, options.SkipValidationOnComponents)
+	return resolveReferences(log, octx, cd, resolver, options.SkipValidationOnComponents)
 }
 
 // The resolveReferences function is an auxiliary function for GetComponents. It implements a typical Breadth First
@@ -107,7 +107,7 @@ func GetComponents(ctx context.Context, log logr.Logger, cdPath string, repoRef 
 // transitive closure) of the root component c.
 // resolver can either a specific ocm repository (if all components are in the same repository) or a compound resolver
 // covering multiple repositories
-func resolveReferences(octx ocm.Context, c *compdesc.ComponentDescriptor, resolver ocm.ComponentVersionResolver, skipValidationOnComponents []string) ([]*Component, error) {
+func resolveReferences(log logr.Logger, octx ocm.Context, c *compdesc.ComponentDescriptor, resolver ocm.ComponentVersionResolver, skipValidationOnComponents []string) ([]*Component, error) {
 	components := make([]*Component, 0)
 	// Set size to 0, as we cannot know the number of component version beforehand
 	visited := make(map[Component]struct{}, 0)
@@ -126,6 +126,7 @@ func resolveReferences(octx ocm.Context, c *compdesc.ComponentDescriptor, resolv
 			if slices.Contains(skipValidationOnComponents, ref.GetComponentName()) {
 				key := Component{Name: ref.GetComponentName(), Version: ref.GetVersion()}
 				if _, ok := visited[key]; !ok {
+					log.Info("skipping OCM validation for component", "component", ref.GetComponentName(), "version", ref.GetVersion())
 					visited[key] = struct{}{}
 					components = append(components, &key)
 				}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->
improvement for:
- https://github.com/gardener/test-infra/pull/1029

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind task

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
